### PR TITLE
fix: add translations/en.json for entity name resolution

### DIFF
--- a/custom_components/ajax_cobranded/translations/en.json
+++ b/custom_components/ajax_cobranded/translations/en.json
@@ -1,0 +1,211 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Ajax Security Login",
+                "description": "Enter your Ajax Security account credentials.",
+                "data": {
+                    "email": "Email",
+                    "password": "Password",
+                    "app_label": "App label (co-branded app name)"
+                }
+            },
+            "2fa": {
+                "title": "Two-Factor Authentication",
+                "description": "Enter the 6-digit code from your authenticator app.",
+                "data": {
+                    "totp_code": "TOTP Code"
+                }
+            },
+            "select_spaces": {
+                "title": "Select Spaces",
+                "description": "Choose which spaces (hubs) to add.",
+                "data": {
+                    "spaces": "Spaces"
+                }
+            },
+            "reconfigure": {
+                "title": "Reconfigure Ajax Security",
+                "description": "Update your account credentials.",
+                "data": {
+                    "email": "Email",
+                    "password": "Password",
+                    "app_label": "App label (co-branded app name)"
+                }
+            }
+        },
+        "error": {
+            "invalid_auth": "Invalid email or password.",
+            "invalid_totp": "Invalid TOTP code. Please try again.",
+            "cannot_connect": "Cannot connect to Ajax servers.",
+            "unknown": "An unexpected error occurred."
+        },
+        "abort": {
+            "already_configured": "This account is already configured.",
+            "already_in_progress": "Configuration is already in progress. Please complete or cancel the existing flow.",
+            "account_locked": "Account is locked. Please try again later.",
+            "reauth_successful": "Re-authentication successful.",
+            "reconfigure_successful": "Credentials updated successfully."
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Ajax Security Options",
+                "data": {
+                    "poll_interval": "Fallback poll interval (seconds)",
+                    "use_pin_code": "Require PIN code for arm/disarm",
+                    "fcm_project_id": "FCM Project ID (for push notifications)",
+                    "fcm_app_id": "FCM App ID",
+                    "fcm_api_key": "FCM API Key",
+                    "fcm_sender_id": "FCM Sender ID",
+                    "photo_retention_days": "Photo retention (days)",
+                    "photo_max_per_device": "Max photos per device (0 = unlimited)"
+                }
+            }
+        }
+    },
+    "services": {
+        "force_arm": {
+            "name": "Force arm",
+            "description": "Arm the system ignoring open sensors and active alarms."
+        },
+        "force_arm_night": {
+            "name": "Force arm night mode",
+            "description": "Arm night mode ignoring open sensors and active alarms."
+        }
+    },
+    "entity": {
+        "button": {
+            "capture_photo": {
+                "name": "Capture photo"
+            }
+        },
+        "event": {
+            "security_event": {
+                "name": "Security event",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "alarm": "Alarm",
+                            "arm": "Armed",
+                            "arm_night": "Armed night",
+                            "battery_low": "Battery low",
+                            "co_alarm": "CO alarm",
+                            "connection_lost": "Connection lost",
+                            "disarm": "Disarmed",
+                            "disarm_night": "Disarmed night",
+                            "door_open": "Door opened",
+                            "fire": "Fire",
+                            "flood": "Flood",
+                            "glass_break": "Glass break",
+                            "malfunction": "Malfunction",
+                            "motion": "Motion",
+                            "panic": "Panic",
+                            "tamper": "Tamper"
+                        }
+                    }
+                }
+            }
+        },
+        "binary_sensor": {
+            "monitoring": {
+                "name": "CRA connection"
+            },
+            "gsm": {
+                "name": "Cellular connected"
+            },
+            "lid": {
+                "name": "Lid opened"
+            },
+            "ext_contact": {
+                "name": "External contact broken"
+            },
+            "ext_alert": {
+                "name": "External contact alert"
+            },
+            "drilling": {
+                "name": "Case drilling"
+            },
+            "anti_mask": {
+                "name": "Anti-masking"
+            },
+            "malfunction": {
+                "name": "Malfunction"
+            },
+            "interference": {
+                "name": "Interference"
+            },
+            "relay_stuck": {
+                "name": "Relay stuck"
+            },
+            "always_active": {
+                "name": "Always active"
+            },
+            "glass_break": {
+                "name": "Glass break"
+            },
+            "vibration": {
+                "name": "Vibration"
+            },
+            "tamper": {
+                "name": "Case tamper"
+            },
+            "connectivity": {
+                "name": "Connectivity"
+            },
+            "problem": {
+                "name": "Device problem"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "mains_power": {
+                "name": "Mains power"
+            }
+        },
+        "sensor": {
+            "signal_strength": {
+                "name": "Signal strength"
+            },
+            "mobile_network_type": {
+                "name": "Mobile network type"
+            },
+            "wifi_signal_level": {
+                "name": "Wi-Fi signal level"
+            },
+            "sim_status": {
+                "name": "SIM status"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Connection type"
+            },
+            "ethernet_ip": {
+                "name": "Ethernet IP address"
+            },
+            "ethernet_gateway": {
+                "name": "Ethernet gateway"
+            },
+            "ethernet_dns": {
+                "name": "Ethernet DNS"
+            },
+            "cellular_signal": {
+                "name": "Cellular signal"
+            },
+            "cellular_network": {
+                "name": "Cellular network"
+            }
+        },
+        "switch": {
+            "channel_1": {
+                "name": "Channel 1"
+            },
+            "channel_2": {
+                "name": "Channel 2"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `translations/en.json` so HA resolves `translation_key` at runtime
- Custom integrations require this file — `strings.json` is only used during HA core builds

## Related issue
Related to #13

## Test plan
- [ ] Install on HA, verify sensors show semantic names (e.g. 'Ethernet IP address') instead of device name with numeric suffixes