### PR TITLE
fix: register photo cleanup task for proper unload on reload

### DIFF
--- a/custom_components/ajax_cobranded/__init__.py
+++ b/custom_components/ajax_cobranded/__init__.py
@@ -118,7 +118,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
 
     # Run cleanup on startup and every 24h
     await _photo_cleanup()
-    async_track_time_interval(hass, _photo_cleanup, timedelta(hours=24))
+    unsub_cleanup = async_track_time_interval(hass, _photo_cleanup, timedelta(hours=24))
+    entry.async_on_unload(unsub_cleanup)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 


### PR DESCRIPTION
## Summary
- Save `unsub` callback from `async_track_time_interval` and register via `entry.async_on_unload()`
- Prevents duplicate cleanup tasks accumulating on integration reload

## Related issue
Related to #10

## Test plan
- [ ] Reload integration multiple times, verify no duplicate cleanup tasks in debug logs