### PR TITLE
fix: update unique_id when email changes during reconfigure

### DIFF
--- a/custom_components/ajax_cobranded/config_flow.py
+++ b/custom_components/ajax_cobranded/config_flow.py
@@ -179,6 +179,10 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                 await client.connect()
                 await asyncio.wait_for(client.login(), timeout=30)
                 await client.close()
+                # Update unique_id if email changed
+                if email != entry.unique_id:
+                    await self.async_set_unique_id(email)
+                    self._abort_if_unique_id_configured(updates={"email": email})
                 return self.async_update_reload_and_abort(
                     entry,
                     data={


### PR DESCRIPTION
## Summary
- During reconfigure, if the email changes, update the config entry `unique_id` to match
- Prevents identity mismatch between persisted unique_id and actual credentials

## Related issue
Related to #11

## Test plan
- [ ] Reconfigure with a different email, verify unique_id updates
- [ ] Reconfigure with same email, verify no change