### PR TITLE
fix: normalize via_device to use hub_id consistently

### DIFF
--- a/custom_components/ajax_cobranded/light.py
+++ b/custom_components/ajax_cobranded/light.py
@@ -75,7 +75,7 @@ class AjaxLight(CoordinatorEntity[AjaxCobrandedCoordinator], LightEntity):
                 name=device.name,
                 manufacturer=MANUFACTURER,
                 model=device.device_type.replace("_", " ").title(),
-                via_device=(DOMAIN, f"hub_{device.hub_id}"),
+                via_device=(DOMAIN, device.hub_id),
             )
 
     @property

--- a/custom_components/ajax_cobranded/switch.py
+++ b/custom_components/ajax_cobranded/switch.py
@@ -80,7 +80,7 @@ class AjaxSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):
                 name=device.name,
                 manufacturer=MANUFACTURER,
                 model=device.device_type.replace("_", " ").title(),
-                via_device=(DOMAIN, f"hub_{device.hub_id}"),
+                via_device=(DOMAIN, device.hub_id),
             )
 
     @property


### PR DESCRIPTION
## Summary
- `switch.py` and `light.py` used `f"hub_{device.hub_id}"` while other platforms used `device.hub_id`
- Normalized to `device.hub_id` everywhere to prevent orphan devices in the device registry

## Related issue
Related to #12

## Test plan
- [ ] Verify switch/light devices show correct parent hub in device registry