### PR TITLE
fix: correlate photo URLs to correct device in concurrent captures

### DIFF
--- a/custom_components/ajax_cobranded/notification.py
+++ b/custom_components/ajax_cobranded/notification.py
@@ -188,11 +188,21 @@ class AjaxNotificationListener:
                         _LOGGER.debug("Rejected photo URL from unexpected domain")
                         continue
                     _LOGGER.debug("Extracted photo URL from push: %s", photo_url[:60])
-                    # Resolve any pending photo futures
-                    for future in list(self._photo_callbacks.values()):
-                        if not future.done():
+                    # Resolve the photo future for the matching device
+                    resolved = False
+                    for device_id, future in list(self._photo_callbacks.items()):
+                        if not future.done() and device_id.upper() in photo_url.upper():
                             future.set_result(photo_url)
-                    self._photo_callbacks.clear()
+                            self._photo_callbacks.pop(device_id, None)
+                            resolved = True
+                            break
+                    if not resolved:
+                        # Fallback: resolve first pending (single-device case)
+                        for device_id, future in list(self._photo_callbacks.items()):
+                            if not future.done():
+                                future.set_result(photo_url)
+                                self._photo_callbacks.pop(device_id, None)
+                                break
                     break
             except Exception:
                 _LOGGER.debug("Failed to parse ENCODED_DATA from push")


### PR DESCRIPTION
## Summary
- Photo URL from push is now matched to the specific device by checking if device_id appears in the URL
- Only resolves the matching future instead of all pending futures
- Falls back to first pending callback for single-device setups

## Related issue
Related to #9

## Test plan
- [ ] Trigger photo capture on two devices simultaneously, verify each gets its own photo
- [ ] Single device capture still works correctly