### PR TITLE
Fix stale hub Ethernet state after incremental HTS updates

### DIFF
--- a/custom_components/ajax_cobranded/api/hts/client.py
+++ b/custom_components/ajax_cobranded/api/hts/client.py
@@ -16,6 +16,11 @@ from custom_components.ajax_cobranded.api.hts.auth import (
 )
 from custom_components.ajax_cobranded.api.hts.crypto import decrypt, encrypt
 from custom_components.ajax_cobranded.api.hts.hub_state import (
+    KEY_ACTIVE_CHANNELS,
+    KEY_ETH_ENABLED,
+    KEY_GPRS_ENABLED,
+    KEY_HUB_POWERED,
+    KEY_WIFI_ENABLED,
     HubNetworkState,
     parse_hub_params,
 )
@@ -91,6 +96,7 @@ class HtsClient:
         self._ping_task: asyncio.Task[None] | None = None
         self._hub_states: dict[str, HubNetworkState] = {}
         self._on_state_update: Callable[[str, HubNetworkState], None] | None = None
+        self._refresh_tasks: dict[str, asyncio.Task[None]] = {}
 
     # ------------------------------------------------------------------
     # Properties
@@ -490,7 +496,7 @@ class HtsClient:
                     len(msg.payload),
                 )
                 if msg.msg_type == MsgType.UPDATES:
-                    self._handle_update(msg)
+                    await self._handle_update(msg)
                 elif msg.msg_type == MsgType.ACK:
                     pass  # expected
                 else:
@@ -502,18 +508,18 @@ class HtsClient:
     # Update handler
     # ------------------------------------------------------------------
 
-    def _handle_update(self, msg: HtsMessage) -> None:
+    async def _handle_update(self, msg: HtsMessage) -> None:
         """Parse an UPDATES message and update hub state."""
         params = tlv_decode(msg.payload)
         if not params:
             return
 
         sub_key = params[0][0] if params[0] else 0
+        hub_id = self._hub_id_from_message(msg)
 
         # SETTINGS_BODY (5) and STATUS_BODY (9) contain data for all devices.
         # Hub data is preceded by the hub_id (4 bytes) as a marker param.
         if sub_key in (5, 9):
-            hub_id = self._hubs[0].hub_id if self._hubs else None
             if not hub_id:
                 return
             hub_id_bytes = bytes.fromhex(hub_id)
@@ -530,6 +536,83 @@ class HtsClient:
                 self._hub_states[hub_id] = new_state
                 if self._on_state_update:
                     self._on_state_update(hub_id, new_state)
+            return
+
+        if not hub_id:
+            return
+
+        kv = self._extract_direct_kv(params[1:])
+        if kv and self._is_network_state_delta(kv):
+            _LOGGER.debug(
+                "Hub %s: parsed %d keys from delta sub-key %d",
+                hub_id,
+                len(kv),
+                sub_key,
+            )
+            existing = self._hub_states.get(hub_id)
+            new_state = parse_hub_params(kv, existing)
+            self._hub_states[hub_id] = new_state
+            if self._on_state_update:
+                self._on_state_update(hub_id, new_state)
+            return
+
+        self._schedule_hub_refresh(hub_id, f"unknown update sub-key {sub_key}")
+
+    def _hub_id_from_message(self, msg: HtsMessage) -> str | None:
+        """Return the hub id when the message is clearly associated with one hub."""
+        known_hubs = {hub.hub_id for hub in self._hubs}
+        for endpoint in (msg.sender, msg.receiver):
+            hub_id = f"{endpoint:08X}"
+            if hub_id in known_hubs:
+                return hub_id
+        if len(self._hubs) == 1:
+            return self._hubs[0].hub_id
+        return None
+
+    @staticmethod
+    def _extract_direct_kv(params: list[bytes]) -> dict[int, bytes]:
+        """Extract alternating 1-byte key/value pairs from a direct delta payload."""
+        kv: dict[int, bytes] = {}
+        i = 0
+        while i + 1 < len(params):
+            key_p = params[i]
+            val_p = params[i + 1]
+            if len(key_p) == 1:
+                kv[key_p[0]] = val_p
+            i += 2
+        return kv
+
+    @staticmethod
+    def _is_network_state_delta(kv: dict[int, bytes]) -> bool:
+        """Return True when the parsed delta contains HTS hub-network keys."""
+        return any(
+            key in kv
+            for key in (
+                KEY_ACTIVE_CHANNELS,
+                KEY_ETH_ENABLED,
+                KEY_WIFI_ENABLED,
+                KEY_GPRS_ENABLED,
+                KEY_HUB_POWERED,
+            )
+        )
+
+    def _schedule_hub_refresh(self, hub_id: str, reason: str) -> None:
+        """Refresh one hub state once when an unparsed hub update arrives."""
+        existing = self._refresh_tasks.get(hub_id)
+        if existing and not existing.done():
+            return
+
+        async def _refresh() -> None:
+            try:
+                _LOGGER.debug("Hub %s: requesting fresh HTS snapshot after %s", hub_id, reason)
+                await self.request_hub_data(hub_id)
+            except Exception:
+                _LOGGER.debug("Hub %s: HTS snapshot refresh failed", hub_id, exc_info=True)
+            finally:
+                self._refresh_tasks.pop(hub_id, None)
+
+        task = asyncio.create_task(_refresh())
+        self._refresh_tasks[hub_id] = task
 
     @staticmethod
     def _extract_device_kv(
@@ -584,6 +667,12 @@ class HtsClient:
     async def close(self) -> None:
         """Disconnect cleanly."""
         self._connected = False
+        refresh_tasks = list(self._refresh_tasks.values())
+        self._refresh_tasks.clear()
+        for task in refresh_tasks:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
         if self._ping_task is not None:
             self._ping_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/custom_components/ajax_cobranded/coordinator.py
+++ b/custom_components/ajax_cobranded/coordinator.py
@@ -150,6 +150,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     all_devices[device.id] = device
             self.devices = all_devices
 
+            if self._hts_task and self._hts_task.done():
+                self._handle_hts_disconnect()
+            if self._hts_client is None:
+                await self._start_hts()
+
             return {"spaces": self.spaces, "devices": self.devices}
         except Exception as err:
             raise UpdateFailed("Error fetching Ajax data") from err
@@ -173,14 +178,32 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._hts_task = asyncio.create_task(
                 self._hts_client.listen(on_state_update=self._on_hts_update)
             )
+            self._hts_task.add_done_callback(self._handle_hts_task_done)
         except (HtsConnectionError, Exception):
             _LOGGER.debug("HTS connection failed (network sensors unavailable)", exc_info=True)
+            self._handle_hts_disconnect()
             self._hts_client = None
 
     def _on_hts_update(self, hub_id: str, state: HubNetworkState) -> None:
         """Handle hub network state update from HTS."""
         self.hub_network[hub_id] = state
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
+    def _handle_hts_task_done(self, task: asyncio.Task[None]) -> None:
+        """Clear stale HTS state when the listen task exits."""
+        if task.cancelled():
+            return
+        with contextlib.suppress(Exception):
+            task.result()
+        self._handle_hts_disconnect()
+
+    def _handle_hts_disconnect(self) -> None:
+        """Drop stale HTS state so hub network entities become unavailable."""
+        self._hts_task = None
+        self._hts_client = None
+        if self.hub_network:
+            self.hub_network.clear()
+            self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     async def _start_device_streams(self) -> None:
         """Start persistent device streams for all spaces."""

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -11,6 +12,8 @@ from custom_components.ajax_cobranded.api.hts.client import (
     HTS_PORT,
     HtsClient,
 )
+from custom_components.ajax_cobranded.api.hts.hub_state import HubNetworkState
+from custom_components.ajax_cobranded.api.hts.messages import HtsMessage, MsgType, tlv_encode
 from custom_components.ajax_cobranded.api.hts.protocol import ETX, STX
 
 # ---------------------------------------------------------------------------
@@ -211,3 +214,97 @@ class TestSendMessage:
 
         assert len(captured) == 1
         assert isinstance(captured[0], bytes)
+
+
+class TestHandleUpdate:
+    @pytest.mark.asyncio
+    async def test_status_body_updates_hub_state(self) -> None:
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        client._on_state_update = MagicMock()
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x09",
+                    bytes.fromhex("12345678"),
+                    b"\x48",
+                    b"\x02",
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        state = client.hub_states["12345678"]
+        assert state.wifi_connected is True
+        assert state.primary_connection == "wifi"
+        client._on_state_update.assert_called_once_with("12345678", state)
+
+    @pytest.mark.asyncio
+    async def test_direct_delta_update_clears_ethernet_and_keeps_wifi(self) -> None:
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        client._hub_states["12345678"] = HubNetworkState(
+            ethernet_connected=True,
+            wifi_connected=True,
+        )
+        client._on_state_update = MagicMock()
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x0a",
+                    b"\x48",
+                    b"\x02",
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        state = client.hub_states["12345678"]
+        assert state.ethernet_connected is False
+        assert state.wifi_connected is True
+        assert state.primary_connection == "wifi"
+        client._on_state_update.assert_called_once_with("12345678", state)
+
+    @pytest.mark.asyncio
+    async def test_unknown_hub_update_requests_refresh_once(self) -> None:
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+
+        async def _refresh(_: str) -> None:
+            await asyncio.sleep(0)
+
+        client.request_hub_data = AsyncMock(side_effect=_refresh)
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x22",
+                    b"\x99",
+                    b"\x01",
+                ]
+            ),
+        )
+
+        await asyncio.gather(client._handle_update(msg), client._handle_update(msg))
+        await asyncio.sleep(0)
+
+        client.request_hub_data.assert_awaited_once_with("12345678")

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.ajax_cobranded.api.hts.hub_state import HubNetworkState
 from custom_components.ajax_cobranded.api.models import Device, Space
 from custom_components.ajax_cobranded.const import ConnectionStatus, DeviceState, SecurityState
 
@@ -73,6 +74,10 @@ class TestCoordinatorInit:
     def test_devices_api_property(self) -> None:
         coordinator = _make_coordinator()
         assert coordinator.devices_api is coordinator._devices_api
+
+    def test_hub_network_initially_empty(self) -> None:
+        coordinator = _make_coordinator()
+        assert coordinator.hub_network == {}
 
 
 class TestAsyncUpdateData:
@@ -148,6 +153,30 @@ class TestAsyncUpdateData:
 
         await coordinator.async_shutdown()
         coordinator._client.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_restarts_hts_when_previous_task_finished(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator.hub_network = {"hub-1": HubNetworkState(ethernet_connected=True)}
+        coordinator._hts_task = MagicMock()
+        coordinator._hts_task.done.return_value = True
+        coordinator._start_hts = AsyncMock()
+
+        space = _make_space("s1")
+        device = _make_device("d1")
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[space])
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[device])
+        coordinator.async_set_updated_data = MagicMock()
+
+        await coordinator._async_update_data()
+
+        assert coordinator.hub_network == {}
+        coordinator._start_hts.assert_awaited_once()
+        coordinator.async_set_updated_data.assert_called_once()
 
 
 class TestStreamHandlers:
@@ -258,6 +287,27 @@ class TestStreamHandlers:
         # No devices in coordinator
         coordinator._handle_status_update("nonexistent", "door_opened", {"op": 1})
         coordinator.async_set_updated_data.assert_not_called()
+
+    def test_handle_hts_disconnect_clears_stale_network_state(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.hub_network["hub-1"] = HubNetworkState(ethernet_connected=True)
+
+        coordinator._handle_hts_disconnect()
+
+        assert coordinator.hub_network == {}
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_handle_hts_task_done_clears_state(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.hub_network["hub-1"] = HubNetworkState(ethernet_connected=True)
+        task = MagicMock(spec=asyncio.Task)
+        task.cancelled.return_value = False
+        task.result.return_value = None
+
+        coordinator._handle_hts_task_done(task)
+
+        assert coordinator.hub_network == {}
+        coordinator.async_set_updated_data.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_shutdown_cancels_stream_tasks(self) -> None:


### PR DESCRIPTION
  ## Summary

  Fix stale HTS-backed hub network sensors when Ajax sends incremental hub updates after link changes.

  This addresses the case where unplugging the hub Ethernet cable was reflected in the official Ajax app, but Home Assistant kept reporting:
  - `binary_sensor.<hub>_ethernet = on`
  - `sensor.<hub>_connection_type = ethernet`

  ## What changed

  - Handle direct HTS delta updates for hub network state instead of relying only on full `SETTINGS_BODY` and `STATUS_BODY` payloads.
  - Add a defensive fallback: when an unknown hub-related HTS update is received, request a fresh full HTS snapshot for that hub.
  - Clear stale HTS-backed hub network state when the HTS listener exits so entities become unavailable instead of keeping the last known value
  forever.
  - Retry HTS startup from the coordinator on later refresh cycles if the previous HTS task has died.

  ## Validation

  Local runtime validation with `scripts/test_hts_connection.py` confirmed the real link-change flow:
  - Ajax emits incremental `UPDATES` with `sub-key 11`
  - after Ethernet unplug, the integration eventually receives a delta that clears Ethernet from `activeChannels`
  - resulting state changes to:
    - `Ethernet: connected=False`
    - `Primary connection: wifi`

  Observed behavior matches the official Ajax app timing, which also updates with a delay of about 1-2 minutes.

  ## Tests

  Added regression coverage for:
  - full HTS status-body parsing
  - incremental delta updates that remove Ethernet while Wi-Fi remains active
  - defensive refresh on unknown hub-related HTS updates
  - coordinator invalidation/recovery of stale HTS state