### PR TITLE
Add hub Wi-Fi network sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 
 - **Alarm Control Panel**: Arm away, disarm, night mode, group arming with PIN code support
 - **Force Arm Services**: `ajax_cobranded.force_arm` and `ajax_cobranded.force_arm_night` to arm ignoring open sensors
-- **Binary Sensors**: Door open/close, motion detection, smoke, leak, tamper, CO, heat, glass break, vibration, CRA monitoring, cellular connection, lid tamper, external contacts, anti-masking, interference detection, ethernet link, mains power
-- **Hub Network**: Real-time hub network data — ethernet/wifi/gsm connection status, IP addressing, cellular signal strength and network type, power supply status
-- **Sensors**: Battery level, temperature, humidity, CO2, signal strength, GSM type (2G/3G/4G), Wi-Fi signal level, IMEI, Ethernet IP/gateway/DNS, cellular signal/network, connection type
+- **Binary Sensors**: Door open/close, motion detection, smoke, leak, tamper, CO, heat, glass break, vibration, CRA monitoring, cellular connection, lid tamper, external contacts, anti-masking, interference detection, ethernet link, Wi-Fi link, mains power
+- **Hub Network**: Real-time hub network data — ethernet/wifi/gsm connection status, Wi-Fi SSID and signal strength, IP addressing, cellular signal strength and network type, power supply status
+- **Sensors**: Battery level, temperature, humidity, CO2, signal strength, GSM type (2G/3G/4G), Wi-Fi signal level, Wi-Fi SSID, Wi-Fi IP, IMEI, Ethernet IP/gateway/DNS, cellular signal/network, connection type
 - **Switches**: Relays, wall switches, sockets (multi-channel support)
 - **Lights**: Dimmers with brightness control
 - **Cameras**: MotionCam Photo on Demand — capture photos and view them in HA (PhOD models only)
@@ -124,7 +124,7 @@ You can type any custom label during setup if yours is not listed.
 
 | Type | Devices | Entities |
 |---|---|---|
-| Hub | Hub, Hub Plus, Hub 2, Hub 2 Plus, Hub 2 4G | Alarm panel, battery, GSM type/connected, CRA monitoring, lid tamper, IMEI |
+| Hub | Hub, Hub Plus, Hub 2, Hub 2 Plus, Hub 2 4G | Alarm panel, battery, GSM type/connected, CRA monitoring, lid tamper, IMEI, hub network sensors (Ethernet/Wi-Fi/GSM, IP data, cellular signal/network, mains power) |
 | Door Sensors | DoorProtect, DoorProtect Plus, DoorProtect Fibra, DoorProtect S/G3 | Door open/close, tamper, vibration (Plus), battery, temperature, signal, external contacts |
 | Motion Sensors | MotionProtect, MotionProtect Plus/Outdoor/Curtain | Motion detected (real-time), tamper, battery, temperature, signal |
 | Cameras | MotionCam PhOD, MotionCam Outdoor PhOD | Photo on-demand capture + storage, motion detected, tamper, battery |
@@ -163,9 +163,12 @@ Photos are automatically cleaned up based on your retention settings (configurab
 - **CRA connection** — binary sensor showing if the hub is connected to the monitoring station
 - **Cellular connected** — binary sensor for GSM/4G connection status
 - **GSM type** — sensor showing connection type (2G/3G/4G)
+- **Hub network sensors** — Ethernet/Wi-Fi connectivity, Wi-Fi SSID/signal, Ethernet/Wi-Fi IP addressing, cellular signal/network, and mains power status
 - **Lid opened** — tamper detection for the hub enclosure
 - **Battery** — hub battery level
 - **IMEI** — hub cellular modem identifier
+
+> **Note on hub network sensors**: These entities are backed by the HTS connection. If HTS is unavailable or reconnecting, they may temporarily become unavailable instead of showing stale data.
 
 ### Real-time event sensors
 Door open/close and motion detection are **transient events** — they appear when the event occurs and clear automatically. The integration uses a persistent gRPC stream for instant delivery (typically < 1 second latency).

--- a/custom_components/ajax_cobranded/binary_sensor.py
+++ b/custom_components/ajax_cobranded/binary_sensor.py
@@ -122,6 +122,7 @@ async def async_setup_entry(
             hub_device = coordinator.devices.get(space.hub_id)
             if hub_device:
                 entities.append(AjaxHubEthernetSensor(coordinator, space.hub_id))
+                entities.append(AjaxHubWifiSensor(coordinator, space.hub_id))
                 entities.append(AjaxHubPowerSensor(coordinator, space.hub_id))
     async_add_entities(entities)
 
@@ -279,6 +280,22 @@ class AjaxHubEthernetSensor(_HubNetworkBinarySensor):
     def is_on(self) -> bool:
         state = self.coordinator.hub_network.get(self._hub_id)
         return state.ethernet_connected if state else False
+
+
+class AjaxHubWifiSensor(_HubNetworkBinarySensor):
+    """Hub Wi-Fi link status."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_translation_key = "wifi"
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
+        super().__init__(coordinator, hub_id)
+        self._attr_unique_id = f"ajax_cobranded_{hub_id}_wifi"
+
+    @property
+    def is_on(self) -> bool:
+        state = self.coordinator.hub_network.get(self._hub_id)
+        return state.wifi_connected if state else False
 
 
 class AjaxHubPowerSensor(_HubNetworkBinarySensor):

--- a/custom_components/ajax_cobranded/sensor.py
+++ b/custom_components/ajax_cobranded/sensor.py
@@ -128,6 +128,9 @@ async def async_setup_entry(
     for space in coordinator.spaces.values():
         if space.hub_id and coordinator.devices.get(space.hub_id):
             entities.append(AjaxHubConnectionTypeSensor(coordinator, space.hub_id))
+            entities.append(AjaxHubWifiSsidSensor(coordinator, space.hub_id))
+            entities.append(AjaxHubWifiSignalSensor(coordinator, space.hub_id))
+            entities.append(AjaxHubWifiIpSensor(coordinator, space.hub_id))
             entities.append(AjaxHubEthernetIpSensor(coordinator, space.hub_id))
             entities.append(AjaxHubEthernetGatewaySensor(coordinator, space.hub_id))
             entities.append(AjaxHubEthernetDnsSensor(coordinator, space.hub_id))
@@ -275,6 +278,51 @@ class AjaxHubConnectionTypeSensor(_HubNetworkSensor):
     def native_value(self) -> str | None:
         state = self.coordinator.hub_network.get(self._hub_id)
         return state.primary_connection if state else None
+
+
+class AjaxHubWifiSsidSensor(_HubNetworkSensor):
+    """Hub Wi-Fi SSID."""
+
+    _attr_translation_key = "wifi_ssid"
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
+        super().__init__(coordinator, hub_id)
+        self._attr_unique_id = f"ajax_cobranded_{hub_id}_wifi_ssid"
+
+    @property
+    def native_value(self) -> str | None:
+        state = self.coordinator.hub_network.get(self._hub_id)
+        return state.wifi_ssid if state and state.wifi_ssid else None
+
+
+class AjaxHubWifiSignalSensor(_HubNetworkSensor):
+    """Hub Wi-Fi signal level."""
+
+    _attr_translation_key = "wifi_signal_level"
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
+        super().__init__(coordinator, hub_id)
+        self._attr_unique_id = f"ajax_cobranded_{hub_id}_wifi_signal_level"
+
+    @property
+    def native_value(self) -> str | None:
+        state = self.coordinator.hub_network.get(self._hub_id)
+        return state.wifi_signal_level if state else None
+
+
+class AjaxHubWifiIpSensor(_HubNetworkSensor):
+    """Hub Wi-Fi IP address."""
+
+    _attr_translation_key = "wifi_ip"
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
+        super().__init__(coordinator, hub_id)
+        self._attr_unique_id = f"ajax_cobranded_{hub_id}_wifi_ip"
+
+    @property
+    def native_value(self) -> str | None:
+        state = self.coordinator.hub_network.get(self._hub_id)
+        return state.wifi_ip if state and state.wifi_ip else None
 
 
 class AjaxHubEthernetIpSensor(_HubNetworkSensor):

--- a/custom_components/ajax_cobranded/strings.json
+++ b/custom_components/ajax_cobranded/strings.json
@@ -13,16 +13,12 @@
             "2fa": {
                 "title": "Two-Factor Authentication",
                 "description": "Enter the 6-digit code from your authenticator app.",
-                "data": {
-                    "totp_code": "TOTP Code"
-                }
+                "data": {"totp_code": "TOTP Code"}
             },
             "select_spaces": {
                 "title": "Select Spaces",
                 "description": "Choose which spaces (hubs) to add.",
-                "data": {
-                    "spaces": "Spaces"
-                }
+                "data": {"spaces": "Spaces"}
             },
             "reconfigure": {
                 "title": "Reconfigure Ajax Security",
@@ -76,11 +72,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Capture photo"
-            }
-        },
+        "button": {"capture_photo": {"name": "Capture photo"}},
         "event": {
             "security_event": {
                 "name": "Security event",
@@ -109,103 +101,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "CRA connection"
-            },
-            "gsm": {
-                "name": "Cellular connected"
-            },
-            "lid": {
-                "name": "Lid opened"
-            },
-            "ext_contact": {
-                "name": "External contact broken"
-            },
-            "ext_alert": {
-                "name": "External contact alert"
-            },
-            "drilling": {
-                "name": "Case drilling"
-            },
-            "anti_mask": {
-                "name": "Anti-masking"
-            },
-            "malfunction": {
-                "name": "Malfunction"
-            },
-            "interference": {
-                "name": "Interference"
-            },
-            "relay_stuck": {
-                "name": "Relay stuck"
-            },
-            "always_active": {
-                "name": "Always active"
-            },
-            "glass_break": {
-                "name": "Glass break"
-            },
-            "vibration": {
-                "name": "Vibration"
-            },
-            "tamper": {
-                "name": "Case tamper"
-            },
-            "connectivity": {
-                "name": "Connectivity"
-            },
-            "problem": {
-                "name": "Device problem"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Mains power"
-            }
+            "monitoring": {"name": "CRA connection"},
+            "gsm": {"name": "Cellular connected"},
+            "lid": {"name": "Lid opened"},
+            "ext_contact": {"name": "External contact broken"},
+            "ext_alert": {"name": "External contact alert"},
+            "drilling": {"name": "Case drilling"},
+            "anti_mask": {"name": "Anti-masking"},
+            "malfunction": {"name": "Malfunction"},
+            "interference": {"name": "Interference"},
+            "relay_stuck": {"name": "Relay stuck"},
+            "always_active": {"name": "Always active"},
+            "glass_break": {"name": "Glass break"},
+            "vibration": {"name": "Vibration"},
+            "tamper": {"name": "Case tamper"},
+            "connectivity": {"name": "Connectivity"},
+            "problem": {"name": "Device problem"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Mains power"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Signal strength"
-            },
-            "mobile_network_type": {
-                "name": "Mobile network type"
-            },
-            "wifi_signal_level": {
-                "name": "Wi-Fi signal level"
-            },
-            "sim_status": {
-                "name": "SIM status"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Connection type"
-            },
-            "ethernet_ip": {
-                "name": "Ethernet IP address"
-            },
-            "ethernet_gateway": {
-                "name": "Ethernet gateway"
-            },
-            "ethernet_dns": {
-                "name": "Ethernet DNS"
-            },
-            "cellular_signal": {
-                "name": "Cellular signal"
-            },
-            "cellular_network": {
-                "name": "Cellular network"
-            }
+            "signal_strength": {"name": "Signal strength"},
+            "mobile_network_type": {"name": "Mobile network type"},
+            "wifi_signal_level": {"name": "Wi-Fi signal level"},
+            "sim_status": {"name": "SIM status"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Connection type"},
+            "wifi_ssid": {"name": "Wi-Fi SSID"},
+            "wifi_ip": {"name": "Wi-Fi IP address"},
+            "ethernet_ip": {"name": "Ethernet IP address"},
+            "ethernet_gateway": {"name": "Ethernet gateway"},
+            "ethernet_dns": {"name": "Ethernet DNS"},
+            "cellular_signal": {"name": "Cellular signal"},
+            "cellular_network": {"name": "Cellular network"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Channel 1"
-            },
-            "channel_2": {
-                "name": "Channel 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Channel 1"}, "channel_2": {"name": "Channel 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/ca.json
+++ b/custom_components/ajax_cobranded/translations/ca.json
@@ -13,16 +13,12 @@
             "2fa": {
                 "title": "Autenticacio de dos factors",
                 "description": "Introdueix el codi de 6 digits de la teva app d'autenticacio.",
-                "data": {
-                    "totp_code": "Codi TOTP"
-                }
+                "data": {"totp_code": "Codi TOTP"}
             },
             "select_spaces": {
                 "title": "Seleccionar espais",
                 "description": "Tria quins espais (hubs) afegir.",
-                "data": {
-                    "spaces": "Espais"
-                }
+                "data": {"spaces": "Espais"}
             },
             "reconfigure": {
                 "title": "Reconfigurar Ajax Security",
@@ -76,11 +72,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Capturar foto"
-            }
-        },
+        "button": {"capture_photo": {"name": "Capturar foto"}},
         "event": {
             "security_event": {
                 "name": "Esdeveniment de seguretat",
@@ -109,103 +101,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Connexio CRA"
-            },
-            "gsm": {
-                "name": "Mobil connectat"
-            },
-            "lid": {
-                "name": "Tapa oberta"
-            },
-            "ext_contact": {
-                "name": "Contacte extern trencat"
-            },
-            "ext_alert": {
-                "name": "Alerta contacte extern"
-            },
-            "drilling": {
-                "name": "Perforacio de caixa"
-            },
-            "anti_mask": {
-                "name": "Anti-enmascarament"
-            },
-            "malfunction": {
-                "name": "Avaria"
-            },
-            "interference": {
-                "name": "Interferencia"
-            },
-            "relay_stuck": {
-                "name": "Rele bloquejat"
-            },
-            "always_active": {
-                "name": "Sempre actiu"
-            },
-            "glass_break": {
-                "name": "Trencament de vidre"
-            },
-            "vibration": {
-                "name": "Vibració"
-            },
-            "tamper": {
-                "name": "Manipulació de carcassa"
-            },
-            "connectivity": {
-                "name": "Connectivitat"
-            },
-            "problem": {
-                "name": "Problema del dispositiu"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Alimentació externa"
-            }
+            "monitoring": {"name": "Connexio CRA"},
+            "gsm": {"name": "Mobil connectat"},
+            "lid": {"name": "Tapa oberta"},
+            "ext_contact": {"name": "Contacte extern trencat"},
+            "ext_alert": {"name": "Alerta contacte extern"},
+            "drilling": {"name": "Perforacio de caixa"},
+            "anti_mask": {"name": "Anti-enmascarament"},
+            "malfunction": {"name": "Avaria"},
+            "interference": {"name": "Interferencia"},
+            "relay_stuck": {"name": "Rele bloquejat"},
+            "always_active": {"name": "Sempre actiu"},
+            "glass_break": {"name": "Trencament de vidre"},
+            "vibration": {"name": "Vibració"},
+            "tamper": {"name": "Manipulació de carcassa"},
+            "connectivity": {"name": "Connectivitat"},
+            "problem": {"name": "Problema del dispositiu"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Alimentació externa"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Intensitat de senyal"
-            },
-            "mobile_network_type": {
-                "name": "Tipus de xarxa mòbil"
-            },
-            "wifi_signal_level": {
-                "name": "Nivell de senyal Wi-Fi"
-            },
-            "sim_status": {
-                "name": "Estat SIM"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Tipus de connexió"
-            },
-            "ethernet_ip": {
-                "name": "Adreça IP Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Porta d'enllaç Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Senyal cel·lular"
-            },
-            "cellular_network": {
-                "name": "Xarxa cel·lular"
-            }
+            "signal_strength": {"name": "Intensitat de senyal"},
+            "mobile_network_type": {"name": "Tipus de xarxa mòbil"},
+            "wifi_signal_level": {"name": "Nivell de senyal Wi-Fi"},
+            "sim_status": {"name": "Estat SIM"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Tipus de connexió"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "Adreça IP Wi-Fi"},
+            "ethernet_ip": {"name": "Adreça IP Ethernet"},
+            "ethernet_gateway": {"name": "Porta d'enllaç Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Senyal cel·lular"},
+            "cellular_network": {"name": "Xarxa cel·lular"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Canal 1"
-            },
-            "channel_2": {
-                "name": "Canal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/cs.json
+++ b/custom_components/ajax_cobranded/translations/cs.json
@@ -13,25 +13,17 @@
             "2fa": {
                 "title": "Dvoufaktorové ověření",
                 "description": "Zadejte 6místný kód z vaší ověřovací aplikace.",
-                "data": {
-                    "totp_code": "Kód TOTP"
-                }
+                "data": {"totp_code": "Kód TOTP"}
             },
             "select_spaces": {
                 "title": "Vyberte prostory",
                 "description": "Zvolte, které prostory (huby) chcete přidat.",
-                "data": {
-                    "spaces": "Prostory"
-                }
+                "data": {"spaces": "Prostory"}
             },
             "reconfigure": {
                 "title": "Překonfigurovat Ajax Security",
                 "description": "Aktualizujte přihlašovací údaje.",
-                "data": {
-                    "email": "E-mail",
-                    "password": "Heslo",
-                    "app_label": "Štítek aplikace"
-                }
+                "data": {"email": "E-mail", "password": "Heslo", "app_label": "Štítek aplikace"}
             }
         },
         "error": {
@@ -76,11 +68,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Pořídit fotografii"
-            }
-        },
+        "button": {"capture_photo": {"name": "Pořídit fotografii"}},
         "event": {
             "security_event": {
                 "name": "Bezpečnostní událost",
@@ -109,103 +97,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Připojení k pultu centrální ochrany"
-            },
-            "gsm": {
-                "name": "Mobilní síť připojena"
-            },
-            "lid": {
-                "name": "Kryt otevřen"
-            },
-            "ext_contact": {
-                "name": "Externí kontakt přerušen"
-            },
-            "ext_alert": {
-                "name": "Poplach externího kontaktu"
-            },
-            "drilling": {
-                "name": "Vrtání skříně detekováno"
-            },
-            "anti_mask": {
-                "name": "Ochrana proti maskování"
-            },
-            "malfunction": {
-                "name": "Porucha"
-            },
-            "interference": {
-                "name": "Rušení"
-            },
-            "relay_stuck": {
-                "name": "Relé zaseknuté"
-            },
-            "always_active": {
-                "name": "Vždy aktivní"
-            },
-            "glass_break": {
-                "name": "Rozbití skla"
-            },
-            "vibration": {
-                "name": "Vibrace"
-            },
-            "tamper": {
-                "name": "Sabotáž krytu"
-            },
-            "connectivity": {
-                "name": "Připojení"
-            },
-            "problem": {
-                "name": "Problém zařízení"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Napájení ze sítě"
-            }
+            "monitoring": {"name": "Připojení k pultu centrální ochrany"},
+            "gsm": {"name": "Mobilní síť připojena"},
+            "lid": {"name": "Kryt otevřen"},
+            "ext_contact": {"name": "Externí kontakt přerušen"},
+            "ext_alert": {"name": "Poplach externího kontaktu"},
+            "drilling": {"name": "Vrtání skříně detekováno"},
+            "anti_mask": {"name": "Ochrana proti maskování"},
+            "malfunction": {"name": "Porucha"},
+            "interference": {"name": "Rušení"},
+            "relay_stuck": {"name": "Relé zaseknuté"},
+            "always_active": {"name": "Vždy aktivní"},
+            "glass_break": {"name": "Rozbití skla"},
+            "vibration": {"name": "Vibrace"},
+            "tamper": {"name": "Sabotáž krytu"},
+            "connectivity": {"name": "Připojení"},
+            "problem": {"name": "Problém zařízení"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Napájení ze sítě"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Síla signálu"
-            },
-            "mobile_network_type": {
-                "name": "Typ mobilní sítě"
-            },
-            "wifi_signal_level": {
-                "name": "Úroveň Wi-Fi signálu"
-            },
-            "sim_status": {
-                "name": "Stav SIM karty"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Typ připojení"
-            },
-            "ethernet_ip": {
-                "name": "IP adresa Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Brána Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Signál mobilní sítě"
-            },
-            "cellular_network": {
-                "name": "Mobilní síť"
-            }
+            "signal_strength": {"name": "Síla signálu"},
+            "mobile_network_type": {"name": "Typ mobilní sítě"},
+            "wifi_signal_level": {"name": "Úroveň Wi-Fi signálu"},
+            "sim_status": {"name": "Stav SIM karty"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Typ připojení"},
+            "wifi_ssid": {"name": "Wi-Fi SSID"},
+            "wifi_ip": {"name": "Wi-Fi IP adresa"},
+            "ethernet_ip": {"name": "IP adresa Ethernet"},
+            "ethernet_gateway": {"name": "Brána Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Signál mobilní sítě"},
+            "cellular_network": {"name": "Mobilní síť"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Kanál 1"
-            },
-            "channel_2": {
-                "name": "Kanál 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Kanál 1"}, "channel_2": {"name": "Kanál 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/de.json
+++ b/custom_components/ajax_cobranded/translations/de.json
@@ -13,25 +13,17 @@
             "2fa": {
                 "title": "Zwei-Faktor-Authentifizierung",
                 "description": "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein.",
-                "data": {
-                    "totp_code": "TOTP-Code"
-                }
+                "data": {"totp_code": "TOTP-Code"}
             },
             "select_spaces": {
                 "title": "Bereiche auswählen",
                 "description": "Wählen Sie aus, welche Bereiche (Hubs) hinzugefügt werden sollen.",
-                "data": {
-                    "spaces": "Bereiche"
-                }
+                "data": {"spaces": "Bereiche"}
             },
             "reconfigure": {
                 "title": "Ajax Security neu konfigurieren",
                 "description": "Aktualisieren Sie Ihre Zugangsdaten.",
-                "data": {
-                    "email": "E-Mail",
-                    "password": "Passwort",
-                    "app_label": "App-Label"
-                }
+                "data": {"email": "E-Mail", "password": "Passwort", "app_label": "App-Label"}
             }
         },
         "error": {
@@ -76,11 +68,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Foto aufnehmen"
-            }
-        },
+        "button": {"capture_photo": {"name": "Foto aufnehmen"}},
         "event": {
             "security_event": {
                 "name": "Sicherheitsereignis",
@@ -109,103 +97,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Notruf-Leitstelle verbunden"
-            },
-            "gsm": {
-                "name": "Mobilfunk verbunden"
-            },
-            "lid": {
-                "name": "Gehäusedeckel geöffnet"
-            },
-            "ext_contact": {
-                "name": "Externer Kontakt unterbrochen"
-            },
-            "ext_alert": {
-                "name": "Externer Kontaktalarm"
-            },
-            "drilling": {
-                "name": "Gehäusebohrung erkannt"
-            },
-            "anti_mask": {
-                "name": "Abdeckungsschutz"
-            },
-            "malfunction": {
-                "name": "Fehlfunktion"
-            },
-            "interference": {
-                "name": "Störung"
-            },
-            "relay_stuck": {
-                "name": "Relais blockiert"
-            },
-            "always_active": {
-                "name": "Immer aktiv"
-            },
-            "glass_break": {
-                "name": "Glasbruch"
-            },
-            "vibration": {
-                "name": "Vibration"
-            },
-            "tamper": {
-                "name": "Gehäusemanipulation"
-            },
-            "connectivity": {
-                "name": "Konnektivität"
-            },
-            "problem": {
-                "name": "Geräteproblem"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Netzstrom"
-            }
+            "monitoring": {"name": "Notruf-Leitstelle verbunden"},
+            "gsm": {"name": "Mobilfunk verbunden"},
+            "lid": {"name": "Gehäusedeckel geöffnet"},
+            "ext_contact": {"name": "Externer Kontakt unterbrochen"},
+            "ext_alert": {"name": "Externer Kontaktalarm"},
+            "drilling": {"name": "Gehäusebohrung erkannt"},
+            "anti_mask": {"name": "Abdeckungsschutz"},
+            "malfunction": {"name": "Fehlfunktion"},
+            "interference": {"name": "Störung"},
+            "relay_stuck": {"name": "Relais blockiert"},
+            "always_active": {"name": "Immer aktiv"},
+            "glass_break": {"name": "Glasbruch"},
+            "vibration": {"name": "Vibration"},
+            "tamper": {"name": "Gehäusemanipulation"},
+            "connectivity": {"name": "Konnektivität"},
+            "problem": {"name": "Geräteproblem"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "WLAN"},
+            "mains_power": {"name": "Netzstrom"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Signalstärke"
-            },
-            "mobile_network_type": {
-                "name": "Mobilfunknetztyp"
-            },
-            "wifi_signal_level": {
-                "name": "WLAN-Signalstärke"
-            },
-            "sim_status": {
-                "name": "SIM-Status"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Verbindungstyp"
-            },
-            "ethernet_ip": {
-                "name": "Ethernet IP-Adresse"
-            },
-            "ethernet_gateway": {
-                "name": "Ethernet-Gateway"
-            },
-            "ethernet_dns": {
-                "name": "Ethernet-DNS"
-            },
-            "cellular_signal": {
-                "name": "Mobilfunksignal"
-            },
-            "cellular_network": {
-                "name": "Mobilfunknetz"
-            }
+            "signal_strength": {"name": "Signalstärke"},
+            "mobile_network_type": {"name": "Mobilfunknetztyp"},
+            "wifi_signal_level": {"name": "WLAN-Signalstärke"},
+            "sim_status": {"name": "SIM-Status"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Verbindungstyp"},
+            "wifi_ssid": {"name": "WLAN-SSID"},
+            "wifi_ip": {"name": "WLAN-IP-Adresse"},
+            "ethernet_ip": {"name": "Ethernet IP-Adresse"},
+            "ethernet_gateway": {"name": "Ethernet-Gateway"},
+            "ethernet_dns": {"name": "Ethernet-DNS"},
+            "cellular_signal": {"name": "Mobilfunksignal"},
+            "cellular_network": {"name": "Mobilfunknetz"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Kanal 1"
-            },
-            "channel_2": {
-                "name": "Kanal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Kanal 1"}, "channel_2": {"name": "Kanal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/en.json
+++ b/custom_components/ajax_cobranded/translations/en.json
@@ -13,16 +13,12 @@
             "2fa": {
                 "title": "Two-Factor Authentication",
                 "description": "Enter the 6-digit code from your authenticator app.",
-                "data": {
-                    "totp_code": "TOTP Code"
-                }
+                "data": {"totp_code": "TOTP Code"}
             },
             "select_spaces": {
                 "title": "Select Spaces",
                 "description": "Choose which spaces (hubs) to add.",
-                "data": {
-                    "spaces": "Spaces"
-                }
+                "data": {"spaces": "Spaces"}
             },
             "reconfigure": {
                 "title": "Reconfigure Ajax Security",
@@ -76,11 +72,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Capture photo"
-            }
-        },
+        "button": {"capture_photo": {"name": "Capture photo"}},
         "event": {
             "security_event": {
                 "name": "Security event",
@@ -109,103 +101,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "CRA connection"
-            },
-            "gsm": {
-                "name": "Cellular connected"
-            },
-            "lid": {
-                "name": "Lid opened"
-            },
-            "ext_contact": {
-                "name": "External contact broken"
-            },
-            "ext_alert": {
-                "name": "External contact alert"
-            },
-            "drilling": {
-                "name": "Case drilling"
-            },
-            "anti_mask": {
-                "name": "Anti-masking"
-            },
-            "malfunction": {
-                "name": "Malfunction"
-            },
-            "interference": {
-                "name": "Interference"
-            },
-            "relay_stuck": {
-                "name": "Relay stuck"
-            },
-            "always_active": {
-                "name": "Always active"
-            },
-            "glass_break": {
-                "name": "Glass break"
-            },
-            "vibration": {
-                "name": "Vibration"
-            },
-            "tamper": {
-                "name": "Case tamper"
-            },
-            "connectivity": {
-                "name": "Connectivity"
-            },
-            "problem": {
-                "name": "Device problem"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Mains power"
-            }
+            "monitoring": {"name": "CRA connection"},
+            "gsm": {"name": "Cellular connected"},
+            "lid": {"name": "Lid opened"},
+            "ext_contact": {"name": "External contact broken"},
+            "ext_alert": {"name": "External contact alert"},
+            "drilling": {"name": "Case drilling"},
+            "anti_mask": {"name": "Anti-masking"},
+            "malfunction": {"name": "Malfunction"},
+            "interference": {"name": "Interference"},
+            "relay_stuck": {"name": "Relay stuck"},
+            "always_active": {"name": "Always active"},
+            "glass_break": {"name": "Glass break"},
+            "vibration": {"name": "Vibration"},
+            "tamper": {"name": "Case tamper"},
+            "connectivity": {"name": "Connectivity"},
+            "problem": {"name": "Device problem"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Mains power"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Signal strength"
-            },
-            "mobile_network_type": {
-                "name": "Mobile network type"
-            },
-            "wifi_signal_level": {
-                "name": "Wi-Fi signal level"
-            },
-            "sim_status": {
-                "name": "SIM status"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Connection type"
-            },
-            "ethernet_ip": {
-                "name": "Ethernet IP address"
-            },
-            "ethernet_gateway": {
-                "name": "Ethernet gateway"
-            },
-            "ethernet_dns": {
-                "name": "Ethernet DNS"
-            },
-            "cellular_signal": {
-                "name": "Cellular signal"
-            },
-            "cellular_network": {
-                "name": "Cellular network"
-            }
+            "signal_strength": {"name": "Signal strength"},
+            "mobile_network_type": {"name": "Mobile network type"},
+            "wifi_signal_level": {"name": "Wi-Fi signal level"},
+            "sim_status": {"name": "SIM status"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Connection type"},
+            "wifi_ssid": {"name": "Wi-Fi SSID"},
+            "wifi_ip": {"name": "Wi-Fi IP address"},
+            "ethernet_ip": {"name": "Ethernet IP address"},
+            "ethernet_gateway": {"name": "Ethernet gateway"},
+            "ethernet_dns": {"name": "Ethernet DNS"},
+            "cellular_signal": {"name": "Cellular signal"},
+            "cellular_network": {"name": "Cellular network"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Channel 1"
-            },
-            "channel_2": {
-                "name": "Channel 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Channel 1"}, "channel_2": {"name": "Channel 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/es.json
+++ b/custom_components/ajax_cobranded/translations/es.json
@@ -13,16 +13,12 @@
             "2fa": {
                 "title": "Autenticacion de dos factores",
                 "description": "Introduce el codigo de 6 digitos de tu app de autenticacion.",
-                "data": {
-                    "totp_code": "Codigo TOTP"
-                }
+                "data": {"totp_code": "Codigo TOTP"}
             },
             "select_spaces": {
                 "title": "Seleccionar espacios",
                 "description": "Elige que espacios (hubs) anadir.",
-                "data": {
-                    "spaces": "Espacios"
-                }
+                "data": {"spaces": "Espacios"}
             },
             "reconfigure": {
                 "title": "Reconfigurar Ajax Security",
@@ -76,11 +72,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Capturar foto"
-            }
-        },
+        "button": {"capture_photo": {"name": "Capturar foto"}},
         "event": {
             "security_event": {
                 "name": "Evento de seguridad",
@@ -109,103 +101,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Conexion CRA"
-            },
-            "gsm": {
-                "name": "Celular conectado"
-            },
-            "lid": {
-                "name": "Tapa abierta"
-            },
-            "ext_contact": {
-                "name": "Contacto externo roto"
-            },
-            "ext_alert": {
-                "name": "Alerta contacto externo"
-            },
-            "drilling": {
-                "name": "Taladrado de caja"
-            },
-            "anti_mask": {
-                "name": "Anti-enmascaramiento"
-            },
-            "malfunction": {
-                "name": "Averia"
-            },
-            "interference": {
-                "name": "Interferencia"
-            },
-            "relay_stuck": {
-                "name": "Rele bloqueado"
-            },
-            "always_active": {
-                "name": "Siempre activo"
-            },
-            "glass_break": {
-                "name": "Rotura de cristal"
-            },
-            "vibration": {
-                "name": "Vibración"
-            },
-            "tamper": {
-                "name": "Manipulación de carcasa"
-            },
-            "connectivity": {
-                "name": "Conectividad"
-            },
-            "problem": {
-                "name": "Problema del dispositivo"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Alimentación externa"
-            }
+            "monitoring": {"name": "Conexion CRA"},
+            "gsm": {"name": "Celular conectado"},
+            "lid": {"name": "Tapa abierta"},
+            "ext_contact": {"name": "Contacto externo roto"},
+            "ext_alert": {"name": "Alerta contacto externo"},
+            "drilling": {"name": "Taladrado de caja"},
+            "anti_mask": {"name": "Anti-enmascaramiento"},
+            "malfunction": {"name": "Averia"},
+            "interference": {"name": "Interferencia"},
+            "relay_stuck": {"name": "Rele bloqueado"},
+            "always_active": {"name": "Siempre activo"},
+            "glass_break": {"name": "Rotura de cristal"},
+            "vibration": {"name": "Vibración"},
+            "tamper": {"name": "Manipulación de carcasa"},
+            "connectivity": {"name": "Conectividad"},
+            "problem": {"name": "Problema del dispositivo"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Alimentación externa"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Intensidad de señal"
-            },
-            "mobile_network_type": {
-                "name": "Tipo de red móvil"
-            },
-            "wifi_signal_level": {
-                "name": "Nivel de señal Wi-Fi"
-            },
-            "sim_status": {
-                "name": "Estado SIM"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Tipo de conexión"
-            },
-            "ethernet_ip": {
-                "name": "IP Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Puerta de enlace Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Señal celular"
-            },
-            "cellular_network": {
-                "name": "Red celular"
-            }
+            "signal_strength": {"name": "Intensidad de señal"},
+            "mobile_network_type": {"name": "Tipo de red móvil"},
+            "wifi_signal_level": {"name": "Nivel de señal Wi-Fi"},
+            "sim_status": {"name": "Estado SIM"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Tipo de conexión"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "IP Wi-Fi"},
+            "ethernet_ip": {"name": "IP Ethernet"},
+            "ethernet_gateway": {"name": "Puerta de enlace Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Señal celular"},
+            "cellular_network": {"name": "Red celular"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Canal 1"
-            },
-            "channel_2": {
-                "name": "Canal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/fr.json
+++ b/custom_components/ajax_cobranded/translations/fr.json
@@ -13,16 +13,12 @@
             "2fa": {
                 "title": "Authentification à deux facteurs",
                 "description": "Entrez le code à 6 chiffres de votre application d'authentification.",
-                "data": {
-                    "totp_code": "Code TOTP"
-                }
+                "data": {"totp_code": "Code TOTP"}
             },
             "select_spaces": {
                 "title": "Sélectionner les espaces",
                 "description": "Choisissez les espaces (hubs) à ajouter.",
-                "data": {
-                    "spaces": "Espaces"
-                }
+                "data": {"spaces": "Espaces"}
             },
             "reconfigure": {
                 "title": "Reconfigurer Ajax Security",
@@ -76,11 +72,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Prendre une photo"
-            }
-        },
+        "button": {"capture_photo": {"name": "Prendre une photo"}},
         "event": {
             "security_event": {
                 "name": "Événement de sécurité",
@@ -109,103 +101,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Connexion télésurveillance"
-            },
-            "gsm": {
-                "name": "Réseau cellulaire connecté"
-            },
-            "lid": {
-                "name": "Couvercle ouvert"
-            },
-            "ext_contact": {
-                "name": "Contact externe ouvert"
-            },
-            "ext_alert": {
-                "name": "Alerte contact externe"
-            },
-            "drilling": {
-                "name": "Perçage du boîtier détecté"
-            },
-            "anti_mask": {
-                "name": "Anti-masquage"
-            },
-            "malfunction": {
-                "name": "Dysfonctionnement"
-            },
-            "interference": {
-                "name": "Interférence"
-            },
-            "relay_stuck": {
-                "name": "Relais bloqué"
-            },
-            "always_active": {
-                "name": "Toujours actif"
-            },
-            "glass_break": {
-                "name": "Bris de verre"
-            },
-            "vibration": {
-                "name": "Vibration"
-            },
-            "tamper": {
-                "name": "Sabotage du boîtier"
-            },
-            "connectivity": {
-                "name": "Connectivité"
-            },
-            "problem": {
-                "name": "Problème appareil"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Alimentation secteur"
-            }
+            "monitoring": {"name": "Connexion télésurveillance"},
+            "gsm": {"name": "Réseau cellulaire connecté"},
+            "lid": {"name": "Couvercle ouvert"},
+            "ext_contact": {"name": "Contact externe ouvert"},
+            "ext_alert": {"name": "Alerte contact externe"},
+            "drilling": {"name": "Perçage du boîtier détecté"},
+            "anti_mask": {"name": "Anti-masquage"},
+            "malfunction": {"name": "Dysfonctionnement"},
+            "interference": {"name": "Interférence"},
+            "relay_stuck": {"name": "Relais bloqué"},
+            "always_active": {"name": "Toujours actif"},
+            "glass_break": {"name": "Bris de verre"},
+            "vibration": {"name": "Vibration"},
+            "tamper": {"name": "Sabotage du boîtier"},
+            "connectivity": {"name": "Connectivité"},
+            "problem": {"name": "Problème appareil"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Alimentation secteur"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Intensité du signal"
-            },
-            "mobile_network_type": {
-                "name": "Type de réseau mobile"
-            },
-            "wifi_signal_level": {
-                "name": "Niveau de signal Wi-Fi"
-            },
-            "sim_status": {
-                "name": "État de la carte SIM"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Type de connexion"
-            },
-            "ethernet_ip": {
-                "name": "Adresse IP Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Passerelle Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Signal cellulaire"
-            },
-            "cellular_network": {
-                "name": "Réseau cellulaire"
-            }
+            "signal_strength": {"name": "Intensité du signal"},
+            "mobile_network_type": {"name": "Type de réseau mobile"},
+            "wifi_signal_level": {"name": "Niveau de signal Wi-Fi"},
+            "sim_status": {"name": "État de la carte SIM"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Type de connexion"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "Adresse IP Wi-Fi"},
+            "ethernet_ip": {"name": "Adresse IP Ethernet"},
+            "ethernet_gateway": {"name": "Passerelle Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Signal cellulaire"},
+            "cellular_network": {"name": "Réseau cellulaire"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Canal 1"
-            },
-            "channel_2": {
-                "name": "Canal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/it.json
+++ b/custom_components/ajax_cobranded/translations/it.json
@@ -13,25 +13,17 @@
             "2fa": {
                 "title": "Autenticazione a due fattori",
                 "description": "Inserisci il codice a 6 cifre dalla tua app di autenticazione.",
-                "data": {
-                    "totp_code": "Codice TOTP"
-                }
+                "data": {"totp_code": "Codice TOTP"}
             },
             "select_spaces": {
                 "title": "Seleziona spazi",
                 "description": "Scegli quali spazi (hub) aggiungere.",
-                "data": {
-                    "spaces": "Spazi"
-                }
+                "data": {"spaces": "Spazi"}
             },
             "reconfigure": {
                 "title": "Riconfigura Ajax Security",
                 "description": "Aggiorna le credenziali dell'account.",
-                "data": {
-                    "email": "E-mail",
-                    "password": "Password",
-                    "app_label": "Etichetta app"
-                }
+                "data": {"email": "E-mail", "password": "Password", "app_label": "Etichetta app"}
             }
         },
         "error": {
@@ -76,11 +68,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Scatta foto"
-            }
-        },
+        "button": {"capture_photo": {"name": "Scatta foto"}},
         "event": {
             "security_event": {
                 "name": "Evento di sicurezza",
@@ -109,103 +97,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Connessione istituto di vigilanza"
-            },
-            "gsm": {
-                "name": "Rete cellulare connessa"
-            },
-            "lid": {
-                "name": "Coperchio aperto"
-            },
-            "ext_contact": {
-                "name": "Contatto esterno aperto"
-            },
-            "ext_alert": {
-                "name": "Allarme contatto esterno"
-            },
-            "drilling": {
-                "name": "Perforazione del contenitore"
-            },
-            "anti_mask": {
-                "name": "Anti-mascheramento"
-            },
-            "malfunction": {
-                "name": "Malfunzionamento"
-            },
-            "interference": {
-                "name": "Interferenza"
-            },
-            "relay_stuck": {
-                "name": "Relè bloccato"
-            },
-            "always_active": {
-                "name": "Sempre attivo"
-            },
-            "glass_break": {
-                "name": "Rottura vetro"
-            },
-            "vibration": {
-                "name": "Vibrazione"
-            },
-            "tamper": {
-                "name": "Manomissione involucro"
-            },
-            "connectivity": {
-                "name": "Connettività"
-            },
-            "problem": {
-                "name": "Problema dispositivo"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Alimentazione di rete"
-            }
+            "monitoring": {"name": "Connessione istituto di vigilanza"},
+            "gsm": {"name": "Rete cellulare connessa"},
+            "lid": {"name": "Coperchio aperto"},
+            "ext_contact": {"name": "Contatto esterno aperto"},
+            "ext_alert": {"name": "Allarme contatto esterno"},
+            "drilling": {"name": "Perforazione del contenitore"},
+            "anti_mask": {"name": "Anti-mascheramento"},
+            "malfunction": {"name": "Malfunzionamento"},
+            "interference": {"name": "Interferenza"},
+            "relay_stuck": {"name": "Relè bloccato"},
+            "always_active": {"name": "Sempre attivo"},
+            "glass_break": {"name": "Rottura vetro"},
+            "vibration": {"name": "Vibrazione"},
+            "tamper": {"name": "Manomissione involucro"},
+            "connectivity": {"name": "Connettività"},
+            "problem": {"name": "Problema dispositivo"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Alimentazione di rete"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Intensità del segnale"
-            },
-            "mobile_network_type": {
-                "name": "Tipo di rete mobile"
-            },
-            "wifi_signal_level": {
-                "name": "Livello segnale Wi-Fi"
-            },
-            "sim_status": {
-                "name": "Stato SIM"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Tipo connessione"
-            },
-            "ethernet_ip": {
-                "name": "Indirizzo IP Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Gateway Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Segnale cellulare"
-            },
-            "cellular_network": {
-                "name": "Rete cellulare"
-            }
+            "signal_strength": {"name": "Intensità del segnale"},
+            "mobile_network_type": {"name": "Tipo di rete mobile"},
+            "wifi_signal_level": {"name": "Livello segnale Wi-Fi"},
+            "sim_status": {"name": "Stato SIM"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Tipo connessione"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "Indirizzo IP Wi-Fi"},
+            "ethernet_ip": {"name": "Indirizzo IP Ethernet"},
+            "ethernet_gateway": {"name": "Gateway Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Segnale cellulare"},
+            "cellular_network": {"name": "Rete cellulare"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Canale 1"
-            },
-            "channel_2": {
-                "name": "Canale 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Canale 1"}, "channel_2": {"name": "Canale 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/nl.json
+++ b/custom_components/ajax_cobranded/translations/nl.json
@@ -13,25 +13,17 @@
             "2fa": {
                 "title": "Twee-factor-authenticatie",
                 "description": "Voer de 6-cijferige code in van uw authenticator-app.",
-                "data": {
-                    "totp_code": "TOTP-code"
-                }
+                "data": {"totp_code": "TOTP-code"}
             },
             "select_spaces": {
                 "title": "Selecteer ruimtes",
                 "description": "Kies welke ruimtes (hubs) u wilt toevoegen.",
-                "data": {
-                    "spaces": "Ruimtes"
-                }
+                "data": {"spaces": "Ruimtes"}
             },
             "reconfigure": {
                 "title": "Ajax Security herconfigureren",
                 "description": "Werk uw accountgegevens bij.",
-                "data": {
-                    "email": "E-mail",
-                    "password": "Wachtwoord",
-                    "app_label": "App-label"
-                }
+                "data": {"email": "E-mail", "password": "Wachtwoord", "app_label": "App-label"}
             }
         },
         "error": {
@@ -76,11 +68,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Foto maken"
-            }
-        },
+        "button": {"capture_photo": {"name": "Foto maken"}},
         "event": {
             "security_event": {
                 "name": "Beveiligingsgebeurtenis",
@@ -109,103 +97,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Verbinding meldkamer"
-            },
-            "gsm": {
-                "name": "Mobiel netwerk verbonden"
-            },
-            "lid": {
-                "name": "Deksel geopend"
-            },
-            "ext_contact": {
-                "name": "Extern contact verbroken"
-            },
-            "ext_alert": {
-                "name": "Alarm extern contact"
-            },
-            "drilling": {
-                "name": "Boren in behuizing"
-            },
-            "anti_mask": {
-                "name": "Anti-masking"
-            },
-            "malfunction": {
-                "name": "Storing"
-            },
-            "interference": {
-                "name": "Interferentie"
-            },
-            "relay_stuck": {
-                "name": "Relais geblokkeerd"
-            },
-            "always_active": {
-                "name": "Altijd actief"
-            },
-            "glass_break": {
-                "name": "Glasbreuk"
-            },
-            "vibration": {
-                "name": "Vibratie"
-            },
-            "tamper": {
-                "name": "Behuizing sabotage"
-            },
-            "connectivity": {
-                "name": "Verbinding"
-            },
-            "problem": {
-                "name": "Apparaatprobleem"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Netstroom"
-            }
+            "monitoring": {"name": "Verbinding meldkamer"},
+            "gsm": {"name": "Mobiel netwerk verbonden"},
+            "lid": {"name": "Deksel geopend"},
+            "ext_contact": {"name": "Extern contact verbroken"},
+            "ext_alert": {"name": "Alarm extern contact"},
+            "drilling": {"name": "Boren in behuizing"},
+            "anti_mask": {"name": "Anti-masking"},
+            "malfunction": {"name": "Storing"},
+            "interference": {"name": "Interferentie"},
+            "relay_stuck": {"name": "Relais geblokkeerd"},
+            "always_active": {"name": "Altijd actief"},
+            "glass_break": {"name": "Glasbreuk"},
+            "vibration": {"name": "Vibratie"},
+            "tamper": {"name": "Behuizing sabotage"},
+            "connectivity": {"name": "Verbinding"},
+            "problem": {"name": "Apparaatprobleem"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Netstroom"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Signaalsterkte"
-            },
-            "mobile_network_type": {
-                "name": "Mobiel netwerktype"
-            },
-            "wifi_signal_level": {
-                "name": "Wi-Fi-signaalsterkte"
-            },
-            "sim_status": {
-                "name": "SIM-status"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Verbindingstype"
-            },
-            "ethernet_ip": {
-                "name": "Ethernet IP-adres"
-            },
-            "ethernet_gateway": {
-                "name": "Ethernet-gateway"
-            },
-            "ethernet_dns": {
-                "name": "Ethernet-DNS"
-            },
-            "cellular_signal": {
-                "name": "Mobiel signaal"
-            },
-            "cellular_network": {
-                "name": "Mobiel netwerk"
-            }
+            "signal_strength": {"name": "Signaalsterkte"},
+            "mobile_network_type": {"name": "Mobiel netwerktype"},
+            "wifi_signal_level": {"name": "Wi-Fi-signaalsterkte"},
+            "sim_status": {"name": "SIM-status"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Verbindingstype"},
+            "wifi_ssid": {"name": "Wi-Fi-SSID"},
+            "wifi_ip": {"name": "Wi-Fi-IP-adres"},
+            "ethernet_ip": {"name": "Ethernet IP-adres"},
+            "ethernet_gateway": {"name": "Ethernet-gateway"},
+            "ethernet_dns": {"name": "Ethernet-DNS"},
+            "cellular_signal": {"name": "Mobiel signaal"},
+            "cellular_network": {"name": "Mobiel netwerk"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Kanaal 1"
-            },
-            "channel_2": {
-                "name": "Kanaal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Kanaal 1"}, "channel_2": {"name": "Kanaal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/pl.json
+++ b/custom_components/ajax_cobranded/translations/pl.json
@@ -13,25 +13,17 @@
             "2fa": {
                 "title": "Uwierzytelnianie dwuskładnikowe",
                 "description": "Wprowadź 6-cyfrowy kod z aplikacji uwierzytelniającej.",
-                "data": {
-                    "totp_code": "Kod TOTP"
-                }
+                "data": {"totp_code": "Kod TOTP"}
             },
             "select_spaces": {
                 "title": "Wybierz przestrzenie",
                 "description": "Wybierz przestrzenie (huby) do dodania.",
-                "data": {
-                    "spaces": "Przestrzenie"
-                }
+                "data": {"spaces": "Przestrzenie"}
             },
             "reconfigure": {
                 "title": "Rekonfiguracja Ajax Security",
                 "description": "Zaktualizuj dane logowania.",
-                "data": {
-                    "email": "E-mail",
-                    "password": "Hasło",
-                    "app_label": "Etykieta aplikacji"
-                }
+                "data": {"email": "E-mail", "password": "Hasło", "app_label": "Etykieta aplikacji"}
             }
         },
         "error": {
@@ -76,11 +68,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Zrób zdjęcie"
-            }
-        },
+        "button": {"capture_photo": {"name": "Zrób zdjęcie"}},
         "event": {
             "security_event": {
                 "name": "Zdarzenie bezpieczeństwa",
@@ -109,103 +97,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Połączenie z centrum monitoringu"
-            },
-            "gsm": {
-                "name": "Sieć komórkowa"
-            },
-            "lid": {
-                "name": "Pokrywa otwarta"
-            },
-            "ext_contact": {
-                "name": "Zewnętrzny styk przerwany"
-            },
-            "ext_alert": {
-                "name": "Alarm zewnętrznego styku"
-            },
-            "drilling": {
-                "name": "Wiercenie obudowy"
-            },
-            "anti_mask": {
-                "name": "Antymaskowanie"
-            },
-            "malfunction": {
-                "name": "Usterka"
-            },
-            "interference": {
-                "name": "Zakłócenia"
-            },
-            "relay_stuck": {
-                "name": "Przekaźnik zablokowany"
-            },
-            "always_active": {
-                "name": "Zawsze aktywny"
-            },
-            "glass_break": {
-                "name": "Rozbicie szyby"
-            },
-            "vibration": {
-                "name": "Wibracja"
-            },
-            "tamper": {
-                "name": "Sabotaż obudowy"
-            },
-            "connectivity": {
-                "name": "Łączność"
-            },
-            "problem": {
-                "name": "Problem urządzenia"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Zasilanie sieciowe"
-            }
+            "monitoring": {"name": "Połączenie z centrum monitoringu"},
+            "gsm": {"name": "Sieć komórkowa"},
+            "lid": {"name": "Pokrywa otwarta"},
+            "ext_contact": {"name": "Zewnętrzny styk przerwany"},
+            "ext_alert": {"name": "Alarm zewnętrznego styku"},
+            "drilling": {"name": "Wiercenie obudowy"},
+            "anti_mask": {"name": "Antymaskowanie"},
+            "malfunction": {"name": "Usterka"},
+            "interference": {"name": "Zakłócenia"},
+            "relay_stuck": {"name": "Przekaźnik zablokowany"},
+            "always_active": {"name": "Zawsze aktywny"},
+            "glass_break": {"name": "Rozbicie szyby"},
+            "vibration": {"name": "Wibracja"},
+            "tamper": {"name": "Sabotaż obudowy"},
+            "connectivity": {"name": "Łączność"},
+            "problem": {"name": "Problem urządzenia"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Zasilanie sieciowe"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Siła sygnału"
-            },
-            "mobile_network_type": {
-                "name": "Typ sieci komórkowej"
-            },
-            "wifi_signal_level": {
-                "name": "Poziom sygnału Wi-Fi"
-            },
-            "sim_status": {
-                "name": "Status karty SIM"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Typ połączenia"
-            },
-            "ethernet_ip": {
-                "name": "Adres IP Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Brama Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Sygnał komórkowy"
-            },
-            "cellular_network": {
-                "name": "Sieć komórkowa"
-            }
+            "signal_strength": {"name": "Siła sygnału"},
+            "mobile_network_type": {"name": "Typ sieci komórkowej"},
+            "wifi_signal_level": {"name": "Poziom sygnału Wi-Fi"},
+            "sim_status": {"name": "Status karty SIM"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Typ połączenia"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "Adres IP Wi-Fi"},
+            "ethernet_ip": {"name": "Adres IP Ethernet"},
+            "ethernet_gateway": {"name": "Brama Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Sygnał komórkowy"},
+            "cellular_network": {"name": "Sieć komórkowa"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Kanał 1"
-            },
-            "channel_2": {
-                "name": "Kanał 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Kanał 1"}, "channel_2": {"name": "Kanał 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/pt-BR.json
+++ b/custom_components/ajax_cobranded/translations/pt-BR.json
@@ -13,16 +13,12 @@
             "2fa": {
                 "title": "Autenticação de dois fatores",
                 "description": "Insira o código de 6 dígitos do seu aplicativo autenticador.",
-                "data": {
-                    "totp_code": "Código TOTP"
-                }
+                "data": {"totp_code": "Código TOTP"}
             },
             "select_spaces": {
                 "title": "Selecionar espaços",
                 "description": "Escolha quais espaços (hubs) adicionar.",
-                "data": {
-                    "spaces": "Espaços"
-                }
+                "data": {"spaces": "Espaços"}
             },
             "reconfigure": {
                 "title": "Reconfigurar Ajax Security",
@@ -76,11 +72,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Tirar foto"
-            }
-        },
+        "button": {"capture_photo": {"name": "Tirar foto"}},
         "event": {
             "security_event": {
                 "name": "Evento de segurança",
@@ -109,103 +101,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Conexão com central de monitoramento"
-            },
-            "gsm": {
-                "name": "Rede celular conectada"
-            },
-            "lid": {
-                "name": "Tampa aberta"
-            },
-            "ext_contact": {
-                "name": "Contato externo aberto"
-            },
-            "ext_alert": {
-                "name": "Alerta de contato externo"
-            },
-            "drilling": {
-                "name": "Perfuração da caixa detectada"
-            },
-            "anti_mask": {
-                "name": "Anti-mascaramento"
-            },
-            "malfunction": {
-                "name": "Falha"
-            },
-            "interference": {
-                "name": "Interferência"
-            },
-            "relay_stuck": {
-                "name": "Relé preso"
-            },
-            "always_active": {
-                "name": "Sempre ativo"
-            },
-            "glass_break": {
-                "name": "Quebra de vidro"
-            },
-            "vibration": {
-                "name": "Vibração"
-            },
-            "tamper": {
-                "name": "Violação da caixa"
-            },
-            "connectivity": {
-                "name": "Conectividade"
-            },
-            "problem": {
-                "name": "Problema do dispositivo"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Energia externa"
-            }
+            "monitoring": {"name": "Conexão com central de monitoramento"},
+            "gsm": {"name": "Rede celular conectada"},
+            "lid": {"name": "Tampa aberta"},
+            "ext_contact": {"name": "Contato externo aberto"},
+            "ext_alert": {"name": "Alerta de contato externo"},
+            "drilling": {"name": "Perfuração da caixa detectada"},
+            "anti_mask": {"name": "Anti-mascaramento"},
+            "malfunction": {"name": "Falha"},
+            "interference": {"name": "Interferência"},
+            "relay_stuck": {"name": "Relé preso"},
+            "always_active": {"name": "Sempre ativo"},
+            "glass_break": {"name": "Quebra de vidro"},
+            "vibration": {"name": "Vibração"},
+            "tamper": {"name": "Violação da caixa"},
+            "connectivity": {"name": "Conectividade"},
+            "problem": {"name": "Problema do dispositivo"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Energia externa"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Intensidade do sinal"
-            },
-            "mobile_network_type": {
-                "name": "Tipo de rede móvel"
-            },
-            "wifi_signal_level": {
-                "name": "Nível de sinal Wi-Fi"
-            },
-            "sim_status": {
-                "name": "Status do SIM"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Tipo de conexão"
-            },
-            "ethernet_ip": {
-                "name": "Endereço IP Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Gateway Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Sinal celular"
-            },
-            "cellular_network": {
-                "name": "Rede celular"
-            }
+            "signal_strength": {"name": "Intensidade do sinal"},
+            "mobile_network_type": {"name": "Tipo de rede móvel"},
+            "wifi_signal_level": {"name": "Nível de sinal Wi-Fi"},
+            "sim_status": {"name": "Status do SIM"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Tipo de conexão"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "Endereço IP Wi-Fi"},
+            "ethernet_ip": {"name": "Endereço IP Ethernet"},
+            "ethernet_gateway": {"name": "Gateway Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Sinal celular"},
+            "cellular_network": {"name": "Rede celular"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Canal 1"
-            },
-            "channel_2": {
-                "name": "Canal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/pt.json
+++ b/custom_components/ajax_cobranded/translations/pt.json
@@ -13,16 +13,12 @@
             "2fa": {
                 "title": "Autenticação de dois fatores",
                 "description": "Introduza o código de 6 dígitos da sua aplicação de autenticação.",
-                "data": {
-                    "totp_code": "Código TOTP"
-                }
+                "data": {"totp_code": "Código TOTP"}
             },
             "select_spaces": {
                 "title": "Selecionar espaços",
                 "description": "Escolha quais os espaços (hubs) a adicionar.",
-                "data": {
-                    "spaces": "Espaços"
-                }
+                "data": {"spaces": "Espaços"}
             },
             "reconfigure": {
                 "title": "Reconfigurar Ajax Security",
@@ -76,11 +72,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Tirar foto"
-            }
-        },
+        "button": {"capture_photo": {"name": "Tirar foto"}},
         "event": {
             "security_event": {
                 "name": "Evento de segurança",
@@ -109,103 +101,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Ligação à central de monitorização"
-            },
-            "gsm": {
-                "name": "Rede celular ligada"
-            },
-            "lid": {
-                "name": "Tampa aberta"
-            },
-            "ext_contact": {
-                "name": "Contacto externo interrompido"
-            },
-            "ext_alert": {
-                "name": "Alerta de contacto externo"
-            },
-            "drilling": {
-                "name": "Perfuração da caixa"
-            },
-            "anti_mask": {
-                "name": "Anti-mascaramento"
-            },
-            "malfunction": {
-                "name": "Avaria"
-            },
-            "interference": {
-                "name": "Interferência"
-            },
-            "relay_stuck": {
-                "name": "Relé bloqueado"
-            },
-            "always_active": {
-                "name": "Sempre ativo"
-            },
-            "glass_break": {
-                "name": "Quebra de vidro"
-            },
-            "vibration": {
-                "name": "Vibração"
-            },
-            "tamper": {
-                "name": "Violação da caixa"
-            },
-            "connectivity": {
-                "name": "Conectividade"
-            },
-            "problem": {
-                "name": "Problema do dispositivo"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Alimentação externa"
-            }
+            "monitoring": {"name": "Ligação à central de monitorização"},
+            "gsm": {"name": "Rede celular ligada"},
+            "lid": {"name": "Tampa aberta"},
+            "ext_contact": {"name": "Contacto externo interrompido"},
+            "ext_alert": {"name": "Alerta de contacto externo"},
+            "drilling": {"name": "Perfuração da caixa"},
+            "anti_mask": {"name": "Anti-mascaramento"},
+            "malfunction": {"name": "Avaria"},
+            "interference": {"name": "Interferência"},
+            "relay_stuck": {"name": "Relé bloqueado"},
+            "always_active": {"name": "Sempre ativo"},
+            "glass_break": {"name": "Quebra de vidro"},
+            "vibration": {"name": "Vibração"},
+            "tamper": {"name": "Violação da caixa"},
+            "connectivity": {"name": "Conectividade"},
+            "problem": {"name": "Problema do dispositivo"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Alimentação externa"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Intensidade do sinal"
-            },
-            "mobile_network_type": {
-                "name": "Tipo de rede móvel"
-            },
-            "wifi_signal_level": {
-                "name": "Nível de sinal Wi-Fi"
-            },
-            "sim_status": {
-                "name": "Estado do SIM"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Tipo de ligação"
-            },
-            "ethernet_ip": {
-                "name": "Endereço IP Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Gateway Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Sinal celular"
-            },
-            "cellular_network": {
-                "name": "Rede celular"
-            }
+            "signal_strength": {"name": "Intensidade do sinal"},
+            "mobile_network_type": {"name": "Tipo de rede móvel"},
+            "wifi_signal_level": {"name": "Nível de sinal Wi-Fi"},
+            "sim_status": {"name": "Estado do SIM"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Tipo de ligação"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "Endereço IP Wi-Fi"},
+            "ethernet_ip": {"name": "Endereço IP Ethernet"},
+            "ethernet_gateway": {"name": "Gateway Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Sinal celular"},
+            "cellular_network": {"name": "Rede celular"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Canal 1"
-            },
-            "channel_2": {
-                "name": "Canal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/ro.json
+++ b/custom_components/ajax_cobranded/translations/ro.json
@@ -13,16 +13,12 @@
             "2fa": {
                 "title": "Autentificare în doi pași",
                 "description": "Introduceți codul de 6 cifre din aplicația de autentificare.",
-                "data": {
-                    "totp_code": "Cod TOTP"
-                }
+                "data": {"totp_code": "Cod TOTP"}
             },
             "select_spaces": {
                 "title": "Selectați spațiile",
                 "description": "Alegeți ce spații (hub-uri) să adăugați.",
-                "data": {
-                    "spaces": "Spații"
-                }
+                "data": {"spaces": "Spații"}
             },
             "reconfigure": {
                 "title": "Reconfigurare Ajax Security",
@@ -76,11 +72,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Capturați fotografie"
-            }
-        },
+        "button": {"capture_photo": {"name": "Capturați fotografie"}},
         "event": {
             "security_event": {
                 "name": "Eveniment de securitate",
@@ -109,103 +101,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Conexiune dispecerat"
-            },
-            "gsm": {
-                "name": "Rețea celulară conectată"
-            },
-            "lid": {
-                "name": "Capac deschis"
-            },
-            "ext_contact": {
-                "name": "Contact extern deschis"
-            },
-            "ext_alert": {
-                "name": "Alertă contact extern"
-            },
-            "drilling": {
-                "name": "Găurire carcasă detectată"
-            },
-            "anti_mask": {
-                "name": "Anti-mascare"
-            },
-            "malfunction": {
-                "name": "Defecțiune"
-            },
-            "interference": {
-                "name": "Interferență"
-            },
-            "relay_stuck": {
-                "name": "Releu blocat"
-            },
-            "always_active": {
-                "name": "Întotdeauna activ"
-            },
-            "glass_break": {
-                "name": "Spargere geam"
-            },
-            "vibration": {
-                "name": "Vibrație"
-            },
-            "tamper": {
-                "name": "Sabotaj carcasă"
-            },
-            "connectivity": {
-                "name": "Conectivitate"
-            },
-            "problem": {
-                "name": "Problemă dispozitiv"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Alimentare rețea"
-            }
+            "monitoring": {"name": "Conexiune dispecerat"},
+            "gsm": {"name": "Rețea celulară conectată"},
+            "lid": {"name": "Capac deschis"},
+            "ext_contact": {"name": "Contact extern deschis"},
+            "ext_alert": {"name": "Alertă contact extern"},
+            "drilling": {"name": "Găurire carcasă detectată"},
+            "anti_mask": {"name": "Anti-mascare"},
+            "malfunction": {"name": "Defecțiune"},
+            "interference": {"name": "Interferență"},
+            "relay_stuck": {"name": "Releu blocat"},
+            "always_active": {"name": "Întotdeauna activ"},
+            "glass_break": {"name": "Spargere geam"},
+            "vibration": {"name": "Vibrație"},
+            "tamper": {"name": "Sabotaj carcasă"},
+            "connectivity": {"name": "Conectivitate"},
+            "problem": {"name": "Problemă dispozitiv"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Alimentare rețea"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Puterea semnalului"
-            },
-            "mobile_network_type": {
-                "name": "Tip rețea mobilă"
-            },
-            "wifi_signal_level": {
-                "name": "Nivel semnal Wi-Fi"
-            },
-            "sim_status": {
-                "name": "Status SIM"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Tip conexiune"
-            },
-            "ethernet_ip": {
-                "name": "Adresă IP Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Gateway Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Semnal celular"
-            },
-            "cellular_network": {
-                "name": "Rețea celulară"
-            }
+            "signal_strength": {"name": "Puterea semnalului"},
+            "mobile_network_type": {"name": "Tip rețea mobilă"},
+            "wifi_signal_level": {"name": "Nivel semnal Wi-Fi"},
+            "sim_status": {"name": "Status SIM"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Tip conexiune"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "Adresă IP Wi-Fi"},
+            "ethernet_ip": {"name": "Adresă IP Ethernet"},
+            "ethernet_gateway": {"name": "Gateway Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Semnal celular"},
+            "cellular_network": {"name": "Rețea celulară"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Canal 1"
-            },
-            "channel_2": {
-                "name": "Canal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/tr.json
+++ b/custom_components/ajax_cobranded/translations/tr.json
@@ -13,25 +13,17 @@
             "2fa": {
                 "title": "İki Faktörlü Doğrulama",
                 "description": "Doğrulama uygulamanızdaki 6 haneli kodu girin.",
-                "data": {
-                    "totp_code": "TOTP Kodu"
-                }
+                "data": {"totp_code": "TOTP Kodu"}
             },
             "select_spaces": {
                 "title": "Alan Seçimi",
                 "description": "Eklemek istediğiniz alanları (hub'ları) seçin.",
-                "data": {
-                    "spaces": "Alanlar"
-                }
+                "data": {"spaces": "Alanlar"}
             },
             "reconfigure": {
                 "title": "Ajax Security'yi yeniden yapılandır",
                 "description": "Hesap kimlik bilgilerinizi güncelleyin.",
-                "data": {
-                    "email": "E-posta",
-                    "password": "Şifre",
-                    "app_label": "Uygulama etiketi"
-                }
+                "data": {"email": "E-posta", "password": "Şifre", "app_label": "Uygulama etiketi"}
             }
         },
         "error": {
@@ -76,11 +68,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Fotoğraf çek"
-            }
-        },
+        "button": {"capture_photo": {"name": "Fotoğraf çek"}},
         "event": {
             "security_event": {
                 "name": "Güvenlik olayı",
@@ -109,103 +97,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Güvenlik merkezi bağlantısı"
-            },
-            "gsm": {
-                "name": "Hücresel ağ bağlı"
-            },
-            "lid": {
-                "name": "Kapak açık"
-            },
-            "ext_contact": {
-                "name": "Harici kontak açık"
-            },
-            "ext_alert": {
-                "name": "Harici kontak alarmı"
-            },
-            "drilling": {
-                "name": "Gövde delme algılandı"
-            },
-            "anti_mask": {
-                "name": "Örtme koruması"
-            },
-            "malfunction": {
-                "name": "Arıza"
-            },
-            "interference": {
-                "name": "Parazit"
-            },
-            "relay_stuck": {
-                "name": "Röle takılı"
-            },
-            "always_active": {
-                "name": "Her zaman aktif"
-            },
-            "glass_break": {
-                "name": "Cam kırılması"
-            },
-            "vibration": {
-                "name": "Titreşim"
-            },
-            "tamper": {
-                "name": "Kasa kurcalama"
-            },
-            "connectivity": {
-                "name": "Bağlantı"
-            },
-            "problem": {
-                "name": "Cihaz sorunu"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Şebeke gücü"
-            }
+            "monitoring": {"name": "Güvenlik merkezi bağlantısı"},
+            "gsm": {"name": "Hücresel ağ bağlı"},
+            "lid": {"name": "Kapak açık"},
+            "ext_contact": {"name": "Harici kontak açık"},
+            "ext_alert": {"name": "Harici kontak alarmı"},
+            "drilling": {"name": "Gövde delme algılandı"},
+            "anti_mask": {"name": "Örtme koruması"},
+            "malfunction": {"name": "Arıza"},
+            "interference": {"name": "Parazit"},
+            "relay_stuck": {"name": "Röle takılı"},
+            "always_active": {"name": "Her zaman aktif"},
+            "glass_break": {"name": "Cam kırılması"},
+            "vibration": {"name": "Titreşim"},
+            "tamper": {"name": "Kasa kurcalama"},
+            "connectivity": {"name": "Bağlantı"},
+            "problem": {"name": "Cihaz sorunu"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Şebeke gücü"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Sinyal gücü"
-            },
-            "mobile_network_type": {
-                "name": "Mobil ağ türü"
-            },
-            "wifi_signal_level": {
-                "name": "Wi-Fi sinyal seviyesi"
-            },
-            "sim_status": {
-                "name": "SIM durumu"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Bağlantı türü"
-            },
-            "ethernet_ip": {
-                "name": "Ethernet IP adresi"
-            },
-            "ethernet_gateway": {
-                "name": "Ethernet ağ geçidi"
-            },
-            "ethernet_dns": {
-                "name": "Ethernet DNS"
-            },
-            "cellular_signal": {
-                "name": "Hücresel sinyal"
-            },
-            "cellular_network": {
-                "name": "Hücresel ağ"
-            }
+            "signal_strength": {"name": "Sinyal gücü"},
+            "mobile_network_type": {"name": "Mobil ağ türü"},
+            "wifi_signal_level": {"name": "Wi-Fi sinyal seviyesi"},
+            "sim_status": {"name": "SIM durumu"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Bağlantı türü"},
+            "wifi_ssid": {"name": "Wi-Fi SSID"},
+            "wifi_ip": {"name": "Wi-Fi IP adresi"},
+            "ethernet_ip": {"name": "Ethernet IP adresi"},
+            "ethernet_gateway": {"name": "Ethernet ağ geçidi"},
+            "ethernet_dns": {"name": "Ethernet DNS"},
+            "cellular_signal": {"name": "Hücresel sinyal"},
+            "cellular_network": {"name": "Hücresel ağ"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Kanal 1"
-            },
-            "channel_2": {
-                "name": "Kanal 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Kanal 1"}, "channel_2": {"name": "Kanal 2"}}
     }
 }

--- a/custom_components/ajax_cobranded/translations/uk.json
+++ b/custom_components/ajax_cobranded/translations/uk.json
@@ -13,25 +13,17 @@
             "2fa": {
                 "title": "Двофакторна автентифікація",
                 "description": "Введіть 6-значний код з вашого додатку автентифікації.",
-                "data": {
-                    "totp_code": "Код TOTP"
-                }
+                "data": {"totp_code": "Код TOTP"}
             },
             "select_spaces": {
                 "title": "Вибір просторів",
                 "description": "Виберіть простори (хаби) для додавання.",
-                "data": {
-                    "spaces": "Простори"
-                }
+                "data": {"spaces": "Простори"}
             },
             "reconfigure": {
                 "title": "Переналаштувати Ajax Security",
                 "description": "Оновіть облікові дані.",
-                "data": {
-                    "email": "E-mail",
-                    "password": "Пароль",
-                    "app_label": "Мітка додатку"
-                }
+                "data": {"email": "E-mail", "password": "Пароль", "app_label": "Мітка додатку"}
             }
         },
         "error": {
@@ -76,11 +68,7 @@
         }
     },
     "entity": {
-        "button": {
-            "capture_photo": {
-                "name": "Зробити фото"
-            }
-        },
+        "button": {"capture_photo": {"name": "Зробити фото"}},
         "event": {
             "security_event": {
                 "name": "Подія безпеки",
@@ -109,103 +97,41 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {
-                "name": "Підключення до ЦМО"
-            },
-            "gsm": {
-                "name": "Стільниковий зв'язок"
-            },
-            "lid": {
-                "name": "Кришка відкрита"
-            },
-            "ext_contact": {
-                "name": "Зовнішній контакт розімкнений"
-            },
-            "ext_alert": {
-                "name": "Тривога зовнішнього контакту"
-            },
-            "drilling": {
-                "name": "Свердління корпусу"
-            },
-            "anti_mask": {
-                "name": "Антизамаскування"
-            },
-            "malfunction": {
-                "name": "Несправність"
-            },
-            "interference": {
-                "name": "Перешкоди"
-            },
-            "relay_stuck": {
-                "name": "Реле застрягло"
-            },
-            "always_active": {
-                "name": "Завжди активний"
-            },
-            "glass_break": {
-                "name": "Розбиття скла"
-            },
-            "vibration": {
-                "name": "Вібрація"
-            },
-            "tamper": {
-                "name": "Зламування корпусу"
-            },
-            "connectivity": {
-                "name": "Підключення"
-            },
-            "problem": {
-                "name": "Проблема пристрою"
-            },
-            "ethernet": {
-                "name": "Ethernet"
-            },
-            "mains_power": {
-                "name": "Зовнішнє живлення"
-            }
+            "monitoring": {"name": "Підключення до ЦМО"},
+            "gsm": {"name": "Стільниковий зв'язок"},
+            "lid": {"name": "Кришка відкрита"},
+            "ext_contact": {"name": "Зовнішній контакт розімкнений"},
+            "ext_alert": {"name": "Тривога зовнішнього контакту"},
+            "drilling": {"name": "Свердління корпусу"},
+            "anti_mask": {"name": "Антизамаскування"},
+            "malfunction": {"name": "Несправність"},
+            "interference": {"name": "Перешкоди"},
+            "relay_stuck": {"name": "Реле застрягло"},
+            "always_active": {"name": "Завжди активний"},
+            "glass_break": {"name": "Розбиття скла"},
+            "vibration": {"name": "Вібрація"},
+            "tamper": {"name": "Зламування корпусу"},
+            "connectivity": {"name": "Підключення"},
+            "problem": {"name": "Проблема пристрою"},
+            "ethernet": {"name": "Ethernet"},
+            "wifi": {"name": "Wi-Fi"},
+            "mains_power": {"name": "Зовнішнє живлення"}
         },
         "sensor": {
-            "signal_strength": {
-                "name": "Рівень сигналу"
-            },
-            "mobile_network_type": {
-                "name": "Тип мобільної мережі"
-            },
-            "wifi_signal_level": {
-                "name": "Рівень сигналу Wi-Fi"
-            },
-            "sim_status": {
-                "name": "Стан SIM-карти"
-            },
-            "sim_imei": {
-                "name": "IMEI"
-            },
-            "connection_type": {
-                "name": "Тип з'єднання"
-            },
-            "ethernet_ip": {
-                "name": "IP-адреса Ethernet"
-            },
-            "ethernet_gateway": {
-                "name": "Шлюз Ethernet"
-            },
-            "ethernet_dns": {
-                "name": "DNS Ethernet"
-            },
-            "cellular_signal": {
-                "name": "Сигнал мобільної мережі"
-            },
-            "cellular_network": {
-                "name": "Мобільна мережа"
-            }
+            "signal_strength": {"name": "Рівень сигналу"},
+            "mobile_network_type": {"name": "Тип мобільної мережі"},
+            "wifi_signal_level": {"name": "Рівень сигналу Wi-Fi"},
+            "sim_status": {"name": "Стан SIM-карти"},
+            "sim_imei": {"name": "IMEI"},
+            "connection_type": {"name": "Тип з'єднання"},
+            "wifi_ssid": {"name": "SSID Wi-Fi"},
+            "wifi_ip": {"name": "IP-адреса Wi-Fi"},
+            "ethernet_ip": {"name": "IP-адреса Ethernet"},
+            "ethernet_gateway": {"name": "Шлюз Ethernet"},
+            "ethernet_dns": {"name": "DNS Ethernet"},
+            "cellular_signal": {"name": "Сигнал мобільної мережі"},
+            "cellular_network": {"name": "Мобільна мережа"}
         },
-        "switch": {
-            "channel_1": {
-                "name": "Канал 1"
-            },
-            "channel_2": {
-                "name": "Канал 2"
-            }
-        }
+        "switch": {"channel_1": {"name": "Канал 1"}, "channel_2": {"name": "Канал 2"}}
     }
 }

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -135,9 +135,9 @@ class TestEthernetIP:
         assert state.ethernet_mask == "255.255.255.0"
 
     def test_parse_gateway(self) -> None:
-        gw_bytes = bytes([192, 168, 1, 254])
+        gw_bytes = bytes([10, 0, 0, 254])
         state = parse_hub_params({KEY_ETH_GATE: gw_bytes})
-        assert state.ethernet_gateway == "192.168.1.254"
+        assert state.ethernet_gateway == "10.0.0.254"
 
     def test_parse_dns(self) -> None:
         dns_bytes = bytes([8, 8, 8, 8])

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from custom_components.ajax_cobranded.api.hts.hub_state import HubNetworkState
 from custom_components.ajax_cobranded.api.models import Device
 from custom_components.ajax_cobranded.binary_sensor import (
     _DEVICE_TYPE_SENSORS,
     BINARY_SENSOR_TYPES,
     AjaxBinarySensor,
     AjaxConnectivitySensor,
+    AjaxHubWifiSensor,
     AjaxProblemSensor,
 )
 from custom_components.ajax_cobranded.const import DeviceState
@@ -504,3 +506,40 @@ class TestAjaxProblemSensor:
         sensor = AjaxProblemSensor(coordinator=coordinator, device_id="dev-1")
         assert sensor._attr_device_info is not None
         assert ("ajax_cobranded", "dev-1") in sensor._attr_device_info["identifiers"]
+
+
+class TestAjaxHubWifiSensor:
+    def _make_coordinator(self, wifi_connected: bool = True) -> MagicMock:
+        hub_device = Device(
+            id="hub-1",
+            hub_id="hub-1",
+            name="Hub Two Plus",
+            device_type="hub_two_plus",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": hub_device}
+        coordinator.hub_network = {"hub-1": HubNetworkState(wifi_connected=wifi_connected)}
+        return coordinator
+
+    def test_is_on_when_wifi_connected(self) -> None:
+        sensor = AjaxHubWifiSensor(self._make_coordinator(True), "hub-1")
+        assert sensor.is_on is True
+
+    def test_is_off_when_wifi_not_connected(self) -> None:
+        sensor = AjaxHubWifiSensor(self._make_coordinator(False), "hub-1")
+        assert sensor.is_on is False
+
+    def test_available_when_hub_network_exists(self) -> None:
+        sensor = AjaxHubWifiSensor(self._make_coordinator(True), "hub-1")
+        assert sensor.available is True
+
+    def test_translation_key(self) -> None:
+        sensor = AjaxHubWifiSensor(self._make_coordinator(True), "hub-1")
+        assert sensor._attr_translation_key == "wifi"

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from custom_components.ajax_cobranded.api.hts.hub_state import HubNetworkState
 from custom_components.ajax_cobranded.api.hub_object import SimCardInfo
 from custom_components.ajax_cobranded.api.models import BatteryInfo, Device
 from custom_components.ajax_cobranded.const import DeviceState
 from custom_components.ajax_cobranded.sensor import (
     SENSOR_TYPES,
+    AjaxHubWifiIpSensor,
+    AjaxHubWifiSignalSensor,
+    AjaxHubWifiSsidSensor,
     AjaxSensor,
     AjaxSimImeiSensor,
 )
@@ -297,3 +301,47 @@ class TestAjaxSimImeiSensor:
         coordinator = self._make_coordinator("hub-1", None)
         sensor = AjaxSimImeiSensor(coordinator=coordinator, hub_id="hub-1")
         assert sensor.available is False
+
+
+class TestHubWifiSensors:
+    def _make_coordinator(self, hub_id: str = "hub-1") -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.devices = {hub_id: _make_hub_device(hub_id)}
+        coordinator.hub_network = {
+            hub_id: HubNetworkState(
+                wifi_connected=True,
+                wifi_ssid="TestWiFi",
+                wifi_signal_level="normal",
+                wifi_ip="10.0.0.42",
+            )
+        }
+        return coordinator
+
+    def test_wifi_ssid_sensor_returns_ssid(self) -> None:
+        coordinator = self._make_coordinator()
+        sensor = AjaxHubWifiSsidSensor(coordinator, "hub-1")
+        assert sensor.native_value == "TestWiFi"
+
+    def test_wifi_signal_sensor_returns_signal(self) -> None:
+        coordinator = self._make_coordinator()
+        sensor = AjaxHubWifiSignalSensor(coordinator, "hub-1")
+        assert sensor.native_value == "normal"
+
+    def test_wifi_ip_sensor_returns_ip(self) -> None:
+        coordinator = self._make_coordinator()
+        sensor = AjaxHubWifiIpSensor(coordinator, "hub-1")
+        assert sensor.native_value == "10.0.0.42"
+
+    def test_hub_wifi_sensors_available_with_hts_state(self) -> None:
+        coordinator = self._make_coordinator()
+        assert AjaxHubWifiSsidSensor(coordinator, "hub-1").available is True
+        assert AjaxHubWifiSignalSensor(coordinator, "hub-1").available is True
+        assert AjaxHubWifiIpSensor(coordinator, "hub-1").available is True
+
+    def test_hub_wifi_sensors_return_none_when_no_values(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": _make_hub_device("hub-1")}
+        coordinator.hub_network = {"hub-1": HubNetworkState()}
+        assert AjaxHubWifiSsidSensor(coordinator, "hub-1").native_value is None
+        assert AjaxHubWifiIpSensor(coordinator, "hub-1").native_value is None
+        assert AjaxHubWifiSignalSensor(coordinator, "hub-1").native_value == "unknown"


### PR DESCRIPTION
## Summary

Add hub Wi-Fi network entities backed by HTS hub network state.

This exposes the Wi-Fi information already present in HTS snapshots, including:
- Wi-Fi connected
- Wi-Fi SSID
- Wi-Fi signal level
- Wi-Fi IP address

## What changed

- Added a hub Wi-Fi binary sensor for link status
- Added hub Wi-Fi sensors for SSID, signal level, and IP address
- Updated README documentation for hub network entities
- Added translation keys for all existing languages in the repo
- Added unit tests for the new hub Wi-Fi entities

## Notes

The new entities are exposed when hub HTS network state is available. They are not hardcoded to a specific hub model name, which covers Hub 2 Plus and other hubs that report Wi-Fi data through HTS.

As with the existing hub network entities, these sensors are HTS-backed and may become temporarily unavailable while HTS reconnects.

## Tests

- `pytest tests/unit/test_binary_sensor.py tests/unit/test_sensor.py`