### PR TITLE
fix: blocking proto import, reconfigure 2FA flow, and session persistence

### DIFF
--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -151,6 +151,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
             device_id=entry.data.get("device_id"),
             app_label=entry.data.get("app_label", ""),
         )
+    # Restore session token from stored data to skip re-login (and 2FA) on restart
+    if entry.data.get("session_token") and entry.data.get("user_hex_id"):
+        client.session.set_session(entry.data["session_token"], entry.data["user_hex_id"])
     await client.connect()
     coordinator = AjaxCobrandedCoordinator(
         hass=hass,

--- a/custom_components/aegis_ajax/api/client.py
+++ b/custom_components/aegis_ajax/api/client.py
@@ -10,6 +10,22 @@ from typing import TYPE_CHECKING, Any
 
 import grpc
 
+# Proto imports use C extensions (protobuf). Import at module level so HA's
+# async event loop never triggers a blocking-import violation at runtime.
+_PROTO_PATH = str(Path(__file__).parent.parent / "proto")
+if _PROTO_PATH not in sys.path:
+    sys.path.append(_PROTO_PATH)
+
+from v3.mobilegwsvc.commonmodels.type import user_role_pb2  # noqa: E402, PLC0415
+from v3.mobilegwsvc.service.login_by_password import (  # noqa: E402, PLC0415
+    endpoint_pb2_grpc as login_password_grpc,
+    request_pb2 as login_password_req,
+)
+from v3.mobilegwsvc.service.login_by_totp import (  # noqa: E402, PLC0415
+    endpoint_pb2_grpc as login_totp_grpc,
+    request_pb2 as login_totp_req,
+)
+
 from custom_components.aegis_ajax.api.session import (
     AjaxSession,
     AuthenticationError,
@@ -152,17 +168,11 @@ class AjaxGrpcClient:
 
     async def login(self) -> None:
         """Authenticate with Ajax servers via gRPC."""
-        from v3.mobilegwsvc.commonmodels.type import user_role_pb2  # noqa: PLC0415
-        from v3.mobilegwsvc.service.login_by_password import (  # noqa: PLC0415
-            endpoint_pb2_grpc,
-            request_pb2,
-        )
-
         channel = self._get_channel()
-        stub = endpoint_pb2_grpc.LoginByPasswordServiceStub(channel)
+        stub = login_password_grpc.LoginByPasswordServiceStub(channel)
         params = self._session.get_login_params()
 
-        request = request_pb2.LoginByPasswordRequest(
+        request = login_password_req.LoginByPasswordRequest(
             email=params["email"],
             password_sha256_hash=params["password_sha256_hash"],
             user_role=user_role_pb2.USER_ROLE_USER,
@@ -192,16 +202,10 @@ class AjaxGrpcClient:
 
     async def login_totp(self, email: str, request_id: str, totp_code: str) -> None:
         """Complete 2FA authentication by submitting the TOTP code."""
-        from v3.mobilegwsvc.commonmodels.type import user_role_pb2  # noqa: PLC0415
-        from v3.mobilegwsvc.service.login_by_totp import (  # noqa: PLC0415
-            endpoint_pb2_grpc,
-            request_pb2,
-        )
-
         channel = self._get_channel()
-        stub = endpoint_pb2_grpc.LoginByTotpServiceStub(channel)
+        stub = login_totp_grpc.LoginByTotpServiceStub(channel)
 
-        request = request_pb2.LoginByTotpRequest(
+        request = login_totp_req.LoginByTotpRequest(
             email=email,
             user_role=user_role_pb2.USER_ROLE_USER,
             totp=totp_code,

--- a/custom_components/aegis_ajax/api/client.py
+++ b/custom_components/aegis_ajax/api/client.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import sys
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import grpc

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -144,16 +144,17 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if self._client is None:
                 raise RuntimeError("Client not initialized")
-            return self.async_create_entry(
-                title=f"Ajax Security ({self._email})",
-                data={
-                    "email": self._email,
-                    "password_hash": self._password_hash,
-                    "app_label": self._app_label,
-                    "spaces": user_input["spaces"],
-                    "device_id": self._client.session.device_id,
-                },
-            )
+            data: dict[str, Any] = {
+                "email": self._email,
+                "password_hash": self._password_hash,
+                "app_label": self._app_label,
+                "spaces": user_input["spaces"],
+                "device_id": self._client.session.device_id,
+            }
+            if self._client.session.session_token:
+                data["session_token"] = self._client.session.session_token
+                data["user_hex_id"] = self._client.session.user_hex_id
+            return self.async_create_entry(title=f"Ajax Security ({self._email})", data=data)
         if self._client:
             spaces_api = SpacesApi(self._client)
             spaces = await spaces_api.list_spaces()
@@ -182,31 +183,22 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            email = user_input["email"]
-            password_hash = AjaxSession.hash_password(user_input["password"])
-            app_label = user_input.get("app_label", entry.data.get("app_label", APPLICATION_LABEL))
+            self._email = user_input["email"]
+            self._password_hash = AjaxSession.hash_password(user_input["password"])
+            self._app_label = user_input.get("app_label", entry.data.get("app_label", APPLICATION_LABEL))
             try:
-                client = AjaxGrpcClient(
-                    email=email,
-                    password_hash=password_hash,
-                    app_label=app_label,
+                self._client = AjaxGrpcClient(
+                    email=self._email,
+                    password_hash=self._password_hash,
+                    app_label=self._app_label,
                 )
-                await client.connect()
-                await asyncio.wait_for(client.login(), timeout=30)
-                await client.close()
-                # Update unique_id if email changed
-                if email != entry.unique_id:
-                    await self.async_set_unique_id(email)
-                    self._abort_if_unique_id_configured(updates={"email": email})
-                return self.async_update_reload_and_abort(
-                    entry,
-                    data={
-                        **entry.data,
-                        "email": email,
-                        "password_hash": password_hash,
-                        "app_label": app_label,
-                    },
-                )
+                await self._client.connect()
+                await asyncio.wait_for(self._client.login(), timeout=30)
+                await self._client.close()
+                return await self._async_finish_reconfigure()
+            except TwoFactorRequiredError as e:
+                self._request_id = e.request_id
+                return await self.async_step_reconfigure_2fa()
             except AuthenticationError:
                 errors["base"] = "invalid_auth"
             except (ConnectionError, OSError, TimeoutError):
@@ -235,6 +227,50 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    async def async_step_reconfigure_2fa(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle 2FA during reconfiguration."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                assert self._client is not None
+                await asyncio.wait_for(
+                    self._client.login_totp(
+                        email=self._email,
+                        request_id=self._request_id,
+                        totp_code=user_input["totp_code"],
+                    ),
+                    timeout=30,
+                )
+                await self._client.close()
+                return await self._async_finish_reconfigure()
+            except AuthenticationError:
+                errors["base"] = "invalid_totp"
+            except TimeoutError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected error during reconfigure 2FA")
+                errors["base"] = "unknown"
+        return self.async_show_form(step_id="reconfigure_2fa", data_schema=TOTP_SCHEMA, errors=errors)
+
+    async def _async_finish_reconfigure(self) -> ConfigFlowResult:
+        """Persist new credentials and reload the entry."""
+        entry = self._get_reconfigure_entry()
+        if self._email != entry.unique_id:
+            await self.async_set_unique_id(self._email)
+            self._abort_if_unique_id_configured(updates={"email": self._email})
+        data: dict[str, Any] = {
+            **entry.data,
+            "email": self._email,
+            "password_hash": self._password_hash,
+            "app_label": self._app_label,
+        }
+        if self._client is not None and self._client.session.session_token:
+            data["session_token"] = self._client.session.session_token
+            data["user_hex_id"] = self._client.session.user_hex_id
+        return self.async_update_reload_and_abort(entry, data=data)
 
     @staticmethod
     @callback

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -28,6 +28,11 @@
                     "password": "Password",
                     "app_label": "App label (co-branded app name)"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Two-Factor Authentication",
+                "description": "Enter the 6-digit code from your authenticator app.",
+                "data": {"totp_code": "TOTP Code"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -28,6 +28,11 @@
                     "password": "Password",
                     "app_label": "App label (co-branded app name)"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Two-Factor Authentication",
+                "description": "Enter the 6-digit code from your authenticator app.",
+                "data": {"totp_code": "TOTP Code"}
             }
         },
         "error": {


### PR DESCRIPTION
## Problem

Three related issues discovered on **HA 2026.4.3** with a **2FA-enabled Ajax account**.

### 1. Blocking C extension import (HA 2026.x regression)

`client.py` imported proto modules lazily inside `async def login()` and `async def login_totp()`. These modules load a protobuf C extension (`google._upb._message`).

HA 2024.11 started *warning* about blocking calls in the async event loop. HA 2025+/2026+ turned this into a **hard failure**, crashing the coordinator on every startup with:

```
Detected blocking call to import_module with args ('google._upb._message',) inside the event loop
```

This only affects users on HA 2025+/2026+. Earlier versions warned but continued.

### 2. `TwoFactorRequiredError` not handled in `async_step_reconfigure`

The initial config flow (`async_step_user`) correctly catches `TwoFactorRequiredError` and routes to `async_step_2fa`. The reconfigure flow did not — it fell through to the bare `except Exception` handler, showing "unknown error" to the user.

Added `async_step_reconfigure_2fa` (parallel to `async_step_2fa`) with matching translation strings.

### 3. Session token not persisted across HA restarts

After a successful login (including 2FA), the session token was discarded. On every HA restart the coordinator called `login()` again — triggering 2FA every time for accounts that have it enabled.

Fix: save `session_token` + `user_hex_id` in the config entry after successful login (both initial setup and reconfigure), and restore them in `async_setup_entry` so `client.session.is_authenticated` is `True` on startup — skipping re-login entirely.

## Changes

| File | Change |
|------|--------|
| `api/client.py` | Move proto imports to module level (fixes blocking call) |
| `config_flow.py` | Add `async_step_reconfigure_2fa`; save session token after login |
| `__init__.py` | Restore session token from entry data on startup |
| `strings.json` | Add `reconfigure_2fa` step strings |
| `translations/en.json` | Add `reconfigure_2fa` step strings |

## Why it worked for others

- **Issue 1**: Only affects HA 2025+/2026+ where blocking imports became fatal
- **Issue 2**: Only affects users who (a) have 2FA and (b) use the reconfigure flow — uncommon since setup is usually done once
- **Issue 3**: Masked by issue 1 — if startup crashes before the coordinator runs, the missing session persistence is never noticed

## Tested on

- HA 2026.4.3, Alpine Linux 3.23.3, Python 3.14
- Ajax account with TOTP 2FA enabled
- Initial setup, reconfigure, and HA restart all verified working