### PR TITLE
fix: blocking proto import, reconfigure 2FA flow, and session persistence

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -7,6 +7,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -151,6 +151,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
             device_id=entry.data.get("device_id"),
             app_label=entry.data.get("app_label", ""),
         )
+    # Restore session token from stored data to skip re-login (and 2FA) on restart
+    if entry.data.get("session_token") and entry.data.get("user_hex_id"):
+        client.session.set_session(str(entry.data["session_token"]), str(entry.data["user_hex_id"]))
     await client.connect()
     coordinator = AjaxCobrandedCoordinator(
         hass=hass,

--- a/custom_components/aegis_ajax/api/client.py
+++ b/custom_components/aegis_ajax/api/client.py
@@ -28,6 +28,21 @@ from custom_components.aegis_ajax.const import (
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+# Proto imports use C extensions (protobuf). Import at module level so HA's
+# async event loop never triggers a blocking-import violation at runtime.
+# _proto_path is loaded by api/__init__.py before this module.
+# isort: off
+from v3.mobilegwsvc.commonmodels.type import user_role_pb2  # noqa: E402
+from v3.mobilegwsvc.service.login_by_password import (  # noqa: E402
+    endpoint_pb2_grpc as login_password_grpc,
+    request_pb2 as login_password_req,
+)
+from v3.mobilegwsvc.service.login_by_totp import (  # noqa: E402
+    endpoint_pb2_grpc as login_totp_grpc,
+    request_pb2 as login_totp_req,
+)
+# isort: on
+
 _LOGGER = logging.getLogger(__name__)
 
 _TRANSIENT_CODES = {
@@ -152,17 +167,11 @@ class AjaxGrpcClient:
 
     async def login(self) -> None:
         """Authenticate with Ajax servers via gRPC."""
-        from v3.mobilegwsvc.commonmodels.type import user_role_pb2  # noqa: PLC0415
-        from v3.mobilegwsvc.service.login_by_password import (  # noqa: PLC0415
-            endpoint_pb2_grpc,
-            request_pb2,
-        )
-
         channel = self._get_channel()
-        stub = endpoint_pb2_grpc.LoginByPasswordServiceStub(channel)
+        stub = login_password_grpc.LoginByPasswordServiceStub(channel)
         params = self._session.get_login_params()
 
-        request = request_pb2.LoginByPasswordRequest(
+        request = login_password_req.LoginByPasswordRequest(
             email=params["email"],
             password_sha256_hash=params["password_sha256_hash"],
             user_role=user_role_pb2.USER_ROLE_USER,
@@ -192,16 +201,10 @@ class AjaxGrpcClient:
 
     async def login_totp(self, email: str, request_id: str, totp_code: str) -> None:
         """Complete 2FA authentication by submitting the TOTP code."""
-        from v3.mobilegwsvc.commonmodels.type import user_role_pb2  # noqa: PLC0415
-        from v3.mobilegwsvc.service.login_by_totp import (  # noqa: PLC0415
-            endpoint_pb2_grpc,
-            request_pb2,
-        )
-
         channel = self._get_channel()
-        stub = endpoint_pb2_grpc.LoginByTotpServiceStub(channel)
+        stub = login_totp_grpc.LoginByTotpServiceStub(channel)
 
-        request = request_pb2.LoginByTotpRequest(
+        request = login_totp_req.LoginByTotpRequest(
             email=email,
             user_role=user_role_pb2.USER_ROLE_USER,
             totp=totp_code,

--- a/custom_components/aegis_ajax/api/session.py
+++ b/custom_components/aegis_ajax/api/session.py
@@ -61,8 +61,13 @@ class AjaxSession:
 
     @staticmethod
     def hash_password(password: str) -> str:
-        """Return the SHA-256 hex digest of the given password (public API)."""
-        return hashlib.sha256(password.encode("utf-8")).hexdigest()
+        """Return the SHA-256 hex digest of the given password.
+
+        The Ajax API requires ``password_sha256_hash`` in the login request —
+        this is a protocol constraint, not a design choice.  We cannot use a
+        stronger KDF here because the server expects this exact format.
+        """
+        return hashlib.sha256(password.encode("utf-8")).hexdigest()  # noqa: S324
 
     def set_credentials(self, email: str, password: str) -> None:
         self._email = email

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -144,16 +144,18 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if self._client is None:
                 raise RuntimeError("Client not initialized")
-            return self.async_create_entry(
-                title=f"Ajax Security ({self._email})",
-                data={
-                    "email": self._email,
-                    "password_hash": self._password_hash,
-                    "app_label": self._app_label,
-                    "spaces": user_input["spaces"],
-                    "device_id": self._client.session.device_id,
-                },
-            )
+            data: dict[str, Any] = {
+                "email": self._email,
+                "password_hash": self._password_hash,
+                "app_label": self._app_label,
+                "spaces": user_input["spaces"],
+                "device_id": self._client.session.device_id,
+            }
+            # Persist session token to avoid re-login (and 2FA) on restart
+            if self._client.session.session_token:
+                data["session_token"] = self._client.session.session_token
+                data["user_hex_id"] = self._client.session.user_hex_id
+            return self.async_create_entry(title=f"Ajax Security ({self._email})", data=data)
         if self._client:
             spaces_api = SpacesApi(self._client)
             spaces = await spaces_api.list_spaces()
@@ -182,31 +184,24 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            email = user_input["email"]
-            password_hash = AjaxSession.hash_password(user_input["password"])
-            app_label = user_input.get("app_label", entry.data.get("app_label", APPLICATION_LABEL))
+            self._email = user_input["email"]
+            self._password_hash = AjaxSession.hash_password(user_input["password"])
+            self._app_label = user_input.get(
+                "app_label", entry.data.get("app_label", APPLICATION_LABEL)
+            )
             try:
-                client = AjaxGrpcClient(
-                    email=email,
-                    password_hash=password_hash,
-                    app_label=app_label,
+                self._client = AjaxGrpcClient(
+                    email=self._email,
+                    password_hash=self._password_hash,
+                    app_label=self._app_label,
                 )
-                await client.connect()
-                await asyncio.wait_for(client.login(), timeout=30)
-                await client.close()
-                # Update unique_id if email changed
-                if email != entry.unique_id:
-                    await self.async_set_unique_id(email)
-                    self._abort_if_unique_id_configured(updates={"email": email})
-                return self.async_update_reload_and_abort(
-                    entry,
-                    data={
-                        **entry.data,
-                        "email": email,
-                        "password_hash": password_hash,
-                        "app_label": app_label,
-                    },
-                )
+                await self._client.connect()
+                await asyncio.wait_for(self._client.login(), timeout=30)
+                await self._client.close()
+                return await self._async_finish_reconfigure()
+            except TwoFactorRequiredError as e:
+                self._request_id = e.request_id
+                return await self.async_step_reconfigure_2fa()
             except AuthenticationError:
                 errors["base"] = "invalid_auth"
             except (ConnectionError, OSError, TimeoutError):
@@ -235,6 +230,53 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    async def async_step_reconfigure_2fa(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle 2FA during reconfiguration."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                if self._client is None:
+                    raise RuntimeError("Client not initialized")
+                await asyncio.wait_for(
+                    self._client.login_totp(
+                        email=self._email,
+                        request_id=self._request_id,
+                        totp_code=user_input["totp_code"],
+                    ),
+                    timeout=30,
+                )
+                await self._client.close()
+                return await self._async_finish_reconfigure()
+            except AuthenticationError:
+                errors["base"] = "invalid_totp"
+            except TimeoutError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected error during reconfigure 2FA")
+                errors["base"] = "unknown"
+        return self.async_show_form(
+            step_id="reconfigure_2fa", data_schema=TOTP_SCHEMA, errors=errors
+        )
+
+    async def _async_finish_reconfigure(self) -> ConfigFlowResult:
+        """Persist new credentials and session token, then reload."""
+        entry = self._get_reconfigure_entry()
+        if self._email != entry.unique_id:
+            await self.async_set_unique_id(self._email)
+            self._abort_if_unique_id_configured(updates={"email": self._email})
+        new_data: dict[str, Any] = {
+            **entry.data,
+            "email": self._email,
+            "password_hash": self._password_hash,
+            "app_label": self._app_label,
+        }
+        if self._client and self._client.session.session_token:
+            new_data["session_token"] = self._client.session.session_token
+            new_data["user_hex_id"] = self._client.session.user_hex_id
+        return self.async_update_reload_and_abort(entry, data=new_data)
 
     @staticmethod
     @callback

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -28,6 +28,11 @@
                     "password": "Password",
                     "app_label": "App label (co-branded app name)"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Two-Factor Authentication",
+                "description": "Enter the 6-digit code from your authenticator app.",
+                "data": {"totp_code": "TOTP Code"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -28,6 +28,11 @@
                     "password": "Contrasenya",
                     "app_label": "Etiqueta de l'aplicació"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Autenticacio de dos factors",
+                "description": "Introdueix el codi de 6 digits de la teva app d'autenticacio.",
+                "data": {"totp_code": "Codi TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -24,6 +24,11 @@
                 "title": "Překonfigurovat Aegis for Ajax",
                 "description": "Aktualizujte přihlašovací údaje.",
                 "data": {"email": "E-mail", "password": "Heslo", "app_label": "Štítek aplikace"}
+            },
+            "reconfigure_2fa": {
+                "title": "Dvoufaktorové ověření",
+                "description": "Zadejte 6místný kód z vaší ověřovací aplikace.",
+                "data": {"totp_code": "Kód TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -24,6 +24,11 @@
                 "title": "Aegis for Ajax neu konfigurieren",
                 "description": "Aktualisieren Sie Ihre Zugangsdaten.",
                 "data": {"email": "E-Mail", "password": "Passwort", "app_label": "App-Label"}
+            },
+            "reconfigure_2fa": {
+                "title": "Zwei-Faktor-Authentifizierung",
+                "description": "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein.",
+                "data": {"totp_code": "TOTP-Code"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -28,6 +28,11 @@
                     "password": "Password",
                     "app_label": "App label (co-branded app name)"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Two-Factor Authentication",
+                "description": "Enter the 6-digit code from your authenticator app.",
+                "data": {"totp_code": "TOTP Code"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -28,6 +28,11 @@
                     "password": "Contraseña",
                     "app_label": "Etiqueta de la aplicación"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Autenticacion de dos factores",
+                "description": "Introduce el codigo de 6 digitos de tu app de autenticacion.",
+                "data": {"totp_code": "Codigo TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -28,6 +28,11 @@
                     "password": "Mot de passe",
                     "app_label": "Label de l'application"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Authentification à deux facteurs",
+                "description": "Entrez le code à 6 chiffres de votre application d'authentification.",
+                "data": {"totp_code": "Code TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -24,6 +24,11 @@
                 "title": "Riconfigura Aegis for Ajax",
                 "description": "Aggiorna le credenziali dell'account.",
                 "data": {"email": "E-mail", "password": "Password", "app_label": "Etichetta app"}
+            },
+            "reconfigure_2fa": {
+                "title": "Autenticazione a due fattori",
+                "description": "Inserisci il codice a 6 cifre dalla tua app di autenticazione.",
+                "data": {"totp_code": "Codice TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -24,6 +24,11 @@
                 "title": "Aegis for Ajax herconfigureren",
                 "description": "Werk uw accountgegevens bij.",
                 "data": {"email": "E-mail", "password": "Wachtwoord", "app_label": "App-label"}
+            },
+            "reconfigure_2fa": {
+                "title": "Twee-factor-authenticatie",
+                "description": "Voer de 6-cijferige code in van uw authenticator-app.",
+                "data": {"totp_code": "TOTP-code"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -24,6 +24,11 @@
                 "title": "Rekonfiguracja Aegis for Ajax",
                 "description": "Zaktualizuj dane logowania.",
                 "data": {"email": "E-mail", "password": "Hasło", "app_label": "Etykieta aplikacji"}
+            },
+            "reconfigure_2fa": {
+                "title": "Uwierzytelnianie dwuskładnikowe",
+                "description": "Wprowadź 6-cyfrowy kod z aplikacji uwierzytelniającej.",
+                "data": {"totp_code": "Kod TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -28,6 +28,11 @@
                     "password": "Senha",
                     "app_label": "Rótulo do aplicativo"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Autenticação de dois fatores",
+                "description": "Insira o código de 6 dígitos do seu aplicativo autenticador.",
+                "data": {"totp_code": "Código TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -28,6 +28,11 @@
                     "password": "Palavra-passe",
                     "app_label": "Rótulo da aplicação"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Autenticação de dois fatores",
+                "description": "Introduza o código de 6 dígitos da sua aplicação de autenticação.",
+                "data": {"totp_code": "Código TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -28,6 +28,11 @@
                     "password": "Parolă",
                     "app_label": "Etichetă aplicație"
                 }
+            },
+            "reconfigure_2fa": {
+                "title": "Autentificare în doi pași",
+                "description": "Introduceți codul de 6 cifre din aplicația de autentificare.",
+                "data": {"totp_code": "Cod TOTP"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -24,6 +24,11 @@
                 "title": "Aegis for Ajax — Yeniden yapılandır",
                 "description": "Hesap kimlik bilgilerinizi güncelleyin.",
                 "data": {"email": "E-posta", "password": "Şifre", "app_label": "Uygulama etiketi"}
+            },
+            "reconfigure_2fa": {
+                "title": "İki Faktörlü Doğrulama",
+                "description": "Doğrulama uygulamanızdaki 6 haneli kodu girin.",
+                "data": {"totp_code": "TOTP Kodu"}
             }
         },
         "error": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -24,6 +24,11 @@
                 "title": "Переналаштувати Aegis for Ajax",
                 "description": "Оновіть облікові дані.",
                 "data": {"email": "E-mail", "password": "Пароль", "app_label": "Мітка додатку"}
+            },
+            "reconfigure_2fa": {
+                "title": "Двофакторна автентифікація",
+                "description": "Введіть 6-значний код з вашого додатку автентифікації.",
+                "data": {"totp_code": "Код TOTP"}
             }
         },
         "error": {

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -229,9 +229,9 @@ class TestAsyncStepSelectSpaces:
         # Ensure password_hash is stored, not plaintext password
         assert "password_hash" in call_kwargs["data"]
         assert "password" not in call_kwargs["data"]
-        # Ensure session token is NOT stored
-        assert "session_token" not in call_kwargs["data"]
-        assert "user_hex_id" not in call_kwargs["data"]
+        # Session token persisted to survive restarts (avoids re-login / 2FA)
+        assert "session_token" in call_kwargs["data"]
+        assert "user_hex_id" in call_kwargs["data"]
 
     @pytest.mark.asyncio
     async def test_step_select_spaces_with_client_loads_spaces(self) -> None:


### PR DESCRIPTION
## Summary

Addresses the three issues reported in #28 — blocking C extension import on HA 2025+, missing 2FA handling in reconfigure flow, and session token not surviving restarts.

### Blocking proto import (HA 2025+)

HA 2025+ turns blocking C extension imports inside async functions into a hard failure. The proto stubs for `login()` and `login_totp()` in `client.py` were imported lazily inside those async methods, causing a crash on every startup:

```
Detected blocking call to import_module with args ('google._upb._message',)
```

Fix: move these proto imports to module level in `client.py`. Other files keep lazy imports safely — once the C extension is loaded by `client.py` at import time, subsequent lazy imports in `security.py`, `spaces.py`, etc. don't trigger the blocking violation.

### Reconfigure 2FA

`async_step_reconfigure` did not catch `TwoFactorRequiredError` — it fell through to the generic `except Exception` handler showing "unknown error" to users with 2FA enabled.

Fix: add `async_step_reconfigure_2fa` step (parallel to the existing `async_step_2fa` for initial setup), with `_async_finish_reconfigure` helper to persist credentials after successful login. Translations added for all 14 languages.

### Session persistence

After login (including 2FA), the session token was not saved. Every HA restart triggered a full re-login — and for 2FA accounts, that meant entering a TOTP code every time.

Fix: persist `session_token` and `user_hex_id` in `config_entry.data` after successful login (both initial setup and reconfigure). Restore them in `async_setup_entry` so the coordinator skips re-login on restart.

### Relation to #28

This PR implements the same fixes proposed in #28 by @svilendotorg, adapted to the current codebase (which has diverged significantly since #28 was opened). Key differences:
- Proto `sys.path` setup uses the centralized `_proto_path.py` module instead of adding a new copy
- `assert` replaced with explicit `RuntimeError` check (project convention)
- `reconfigure_2fa` translations added for all 14 languages (not just English)
- Lazy proto imports kept in non-critical files (safe once C extension is loaded)

## Test plan
- [x] All 722 unit tests pass
- [x] Coverage ≥80% (80.86%)
- [x] Lint, format, typecheck, dead-code checks pass
- [ ] Test on HA 2025+/2026+ with 2FA account: initial setup, reconfigure, restart
- [ ] Verify session survives restart without re-login prompt