### PR TITLE
fix: disable diagnostic entities by default to reduce noise

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -185,6 +185,7 @@ class AjaxConnectivitySensor(CoordinatorEntity[AjaxCobrandedCoordinator], Binary
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_translation_key = "connectivity"
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
         super().__init__(coordinator)
@@ -214,6 +215,7 @@ class AjaxProblemSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySenso
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_translation_key = "problem"
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
         super().__init__(coordinator)
@@ -252,6 +254,7 @@ class _HubNetworkBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], Binar
 
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
         super().__init__(coordinator)

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -81,7 +81,7 @@ SENSOR_TYPES: dict[str, SensorTypeInfo] = {
         "status",
         EntityCategory.DIAGNOSTIC,
         translation_key="mobile_network_type",
-        entity_registry_enabled_default=True,
+        entity_registry_enabled_default=False,
     ),
     "wifi_signal_level": SensorTypeInfo(
         None,
@@ -246,6 +246,7 @@ class _HubNetworkSensor(CoordinatorEntity[AjaxCobrandedCoordinator], SensorEntit
 
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
         super().__init__(coordinator)
@@ -268,6 +269,7 @@ class AjaxHubConnectionTypeSensor(_HubNetworkSensor):
     """Primary connection type: ethernet, wifi, gsm, or none."""
 
     _attr_translation_key = "connection_type"
+    _attr_entity_registry_enabled_default = True  # useful summary, keep enabled
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
         super().__init__(coordinator, hub_id)


### PR DESCRIPTION
## Summary

Most diagnostic and network entities were enabled by default, creating a noisy device page with 22+ entities for just the hub. Following HA best practices, diagnostic entities are now disabled by default — users enable them individually if needed.

### Disabled by default

**Sensors (HTS network):** Wi-Fi SSID, Wi-Fi signal, Wi-Fi IP, Ethernet IP, Ethernet gateway, Ethernet DNS, cellular signal, cellular network, mobile network type

**Binary sensors:** per-device connectivity, per-device problem, hub Ethernet link, hub Wi-Fi link, hub mains power

**Already was disabled:** IMEI, signal strength, Wi-Fi signal level

### Still enabled by default

Alarm panel, security events, battery, temperature, humidity, CO2, connection type, door/motion/smoke/leak/tamper/CO/heat sensors, CRA monitoring, GSM connected, lid opened

## Test plan
- [x] 722 tests pass, coverage ≥80%
- [x] Lint, format, typecheck, dead-code clean
- [ ] Verify on real HA that device page shows fewer entities
- [ ] Verify disabled entities can be enabled from entity settings