### PR TITLE
fix: expose external contact alert state for DoorProtect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- DoorProtect external wired contact state now exposed via `external_contact_alert` binary sensor — the previous `external_contact_broken` entity only reflected cable-fault events, so the window open/closed state wired through the sensor's external input never changed (#25)
+
 ## [1.1.0] - 2026-04-23
 
 ### Added

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -54,13 +54,46 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
 }
 
 _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
-    "door_protect": ["door_opened", "tamper", "external_contact_broken"],
-    "door_protect_plus": ["door_opened", "tamper", "vibration", "external_contact_broken"],
-    "door_protect_fibra": ["door_opened", "tamper", "external_contact_broken"],
-    "door_protect_s": ["door_opened", "tamper", "external_contact_broken"],
-    "door_protect_s_plus": ["door_opened", "tamper", "vibration", "external_contact_broken"],
-    "door_protect_plus_fibra": ["door_opened", "tamper", "vibration", "external_contact_broken"],
-    "door_protect_g3": ["door_opened", "tamper", "external_contact_broken"],
+    "door_protect": ["door_opened", "tamper", "external_contact_broken", "external_contact_alert"],
+    "door_protect_plus": [
+        "door_opened",
+        "tamper",
+        "vibration",
+        "external_contact_broken",
+        "external_contact_alert",
+    ],
+    "door_protect_fibra": [
+        "door_opened",
+        "tamper",
+        "external_contact_broken",
+        "external_contact_alert",
+    ],
+    "door_protect_s": [
+        "door_opened",
+        "tamper",
+        "external_contact_broken",
+        "external_contact_alert",
+    ],
+    "door_protect_s_plus": [
+        "door_opened",
+        "tamper",
+        "vibration",
+        "external_contact_broken",
+        "external_contact_alert",
+    ],
+    "door_protect_plus_fibra": [
+        "door_opened",
+        "tamper",
+        "vibration",
+        "external_contact_broken",
+        "external_contact_alert",
+    ],
+    "door_protect_g3": [
+        "door_opened",
+        "tamper",
+        "external_contact_broken",
+        "external_contact_alert",
+    ],
     "motion_protect": ["motion_detected", "tamper"],
     "motion_protect_plus": ["motion_detected", "tamper"],
     "motion_protect_fibra": ["motion_detected", "tamper"],

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
 from custom_components.aegis_ajax.api.models import Device
 from custom_components.aegis_ajax.binary_sensor import (
@@ -337,6 +339,21 @@ class TestDeviceTypeSensors:
 
     def test_door_protect_s_plus_has_vibration(self) -> None:
         assert "vibration" in _DEVICE_TYPE_SENSORS["door_protect_s_plus"]
+
+    @pytest.mark.parametrize(
+        "device_type",
+        [
+            "door_protect",
+            "door_protect_plus",
+            "door_protect_fibra",
+            "door_protect_s",
+            "door_protect_s_plus",
+            "door_protect_plus_fibra",
+            "door_protect_g3",
+        ],
+    )
+    def test_door_protect_family_has_external_contact_alert(self, device_type: str) -> None:
+        assert "external_contact_alert" in _DEVICE_TYPE_SENSORS[device_type]
 
 
 class TestAjaxConnectivitySensor:


### PR DESCRIPTION
## Summary
- Adds `external_contact_alert` to all DoorProtect variants in `_DEVICE_TYPE_SENSORS`.
- The `external_contact_broken` sensor introduced in v1.0.4 only signals cable-fault events, so the actual open/closed state of a wired reed switch attached to the DoorProtect's external contact input was never reflected in Home Assistant (both entities were missing it, and the wrong one got added).
- Both statuses are now exposed:
  - `external_contact_broken` → `PROBLEM` device class (wiring fault)
  - `external_contact_alert` → `SAFETY` device class (contact triggered / open)

Relates to #25 — user's diagnostics confirmed the hub emits `external_contact_alert` for this use case, not `external_contact_broken`.

## Test plan
- [x] New parametrised unit test asserts all 7 DoorProtect device types include `external_contact_alert` in their sensor list
- [x] Existing parser tests for both `external_contact_alert` and `external_contact_broken` still pass
- [x] `make check` green in a freshly built Docker image (lint, format, typecheck, 729 unit tests, 80.30% coverage, dead-code)
- [ ] User validation on real hardware (#25 reporter) — window open/close should now toggle the new `external_contact_alert` entity