### PR TITLE
feat: expose wired input alert state for MultiTransmitter children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- MultiTransmitter wired inputs (`wire_input_mt`) and hub-wired inputs (`wire_input`) now expose an "alert" binary sensor that toggles when the wired third-party sensor is triggered. The alarm category reported by the hub (intrusion, glass_break, fire, vibration, …) is surfaced as an `alarm_type` attribute on the entity. Translations added for all 14 supported languages (#36)
+
 ## [1.1.1-beta.1] - 2026-04-24
 
 ### Fixed

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -72,6 +72,29 @@ _SIM_STATUS_MAP: dict[int, str] = {
     5: "Unknown",
 }
 
+_ALARM_TYPE_NAMES: dict[int, str] = {
+    0: "unspecified",
+    1: "intrusion",
+    2: "fire",
+    3: "medical",
+    4: "panic",
+    5: "gas",
+    6: "tamper",
+    7: "malfunction",
+    8: "leak",
+    9: "service",
+    10: "key_arm",
+    11: "glass_break",
+    12: "high_temperature",
+    13: "low_temperature",
+    14: "masking",
+    15: "duress_code",
+    16: "vibration",
+    17: "blocking_element",
+    18: "bolt_contact",
+}
+
+
 _STATE_MAP: dict[int, DeviceState] = {
     0: DeviceState.ONLINE,
     1: DeviceState.LOCKED,
@@ -205,6 +228,13 @@ class DevicesApi:
                 result["external_contact_broken"] = True
             elif which == "external_contact_alert":
                 result["external_contact_alert"] = True
+            elif which == "wire_input_status":
+                ws = status.wire_input_status
+                result["wire_input_alert"] = bool(ws.is_alert) if hasattr(ws, "is_alert") else True
+                if hasattr(ws, "type"):
+                    result["wire_input_alarm_type"] = _ALARM_TYPE_NAMES.get(
+                        int(ws.type), "unspecified"
+                    )
             elif which == "case_drilling_detected":
                 result["case_drilling"] = True
             elif which == "anti_masking_alert":

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -51,6 +51,7 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
     "always_active": BinarySensorTypeInfo(BinarySensorDeviceClass.RUNNING, "always_active"),
     "glass_break": BinarySensorTypeInfo(BinarySensorDeviceClass.SAFETY, "glass_break"),
     "vibration": BinarySensorTypeInfo(BinarySensorDeviceClass.VIBRATION, "vibration"),
+    "wire_input_alert": BinarySensorTypeInfo(BinarySensorDeviceClass.SAFETY, "wire_input_alert"),
 }
 
 _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
@@ -125,6 +126,8 @@ _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
     "transmitter": ["tamper"],
     "multi_transmitter": ["tamper"],
     "multi_transmitter_fibra": ["tamper"],
+    "wire_input": ["wire_input_alert"],
+    "wire_input_mt": ["wire_input_alert"],
     "life_quality": [],
     "water_stop": [],
     "keypad_combi": ["tamper"],
@@ -203,11 +206,18 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensor
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         device = self._device
-        if device is None or self._status_key != "motion_detected":
+        if device is None:
             return {}
-        detected_at = device.statuses.get("motion_detected_at")
-        if detected_at is not None:
-            return {"detected_at": detected_at}
+        if self._status_key == "motion_detected":
+            detected_at = device.statuses.get("motion_detected_at")
+            if detected_at is not None:
+                return {"detected_at": detected_at}
+            return {}
+        if self._status_key == "wire_input_alert":
+            alarm_type = device.statuses.get("wire_input_alarm_type")
+            if alarm_type is not None:
+                return {"alarm_type": alarm_type}
+            return {}
         return {}
 
 

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -45,6 +45,7 @@ _STATUS_KEY_MAP: dict[str, str] = {
     "interference_detected": "interference",
     "glass_break_detected": "glass_break",
     "vibration_detected": "vibration",
+    "wire_input_status": "wire_input_alert",
 }
 
 

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -133,6 +133,7 @@
             "always_active": {"name": "Always active"},
             "glass_break": {"name": "Glass break"},
             "vibration": {"name": "Vibration"},
+            "wire_input_alert": {"name": "Wire input alert"},
             "tamper": {"name": "Case tamper"},
             "connectivity": {"name": "Connectivity"},
             "problem": {"name": "Device problem"},

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -133,6 +133,7 @@
             "always_active": {"name": "Sempre actiu"},
             "glass_break": {"name": "Trencament de vidre"},
             "vibration": {"name": "Vibració"},
+            "wire_input_alert": {"name": "Alerta d'entrada cablejada"},
             "tamper": {"name": "Manipulació de carcassa"},
             "connectivity": {"name": "Connectivitat"},
             "problem": {"name": "Problema del dispositiu"},

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -129,6 +129,7 @@
             "always_active": {"name": "Vždy aktivní"},
             "glass_break": {"name": "Rozbití skla"},
             "vibration": {"name": "Vibrace"},
+            "wire_input_alert": {"name": "Výstraha drátového vstupu"},
             "tamper": {"name": "Sabotáž krytu"},
             "connectivity": {"name": "Připojení"},
             "problem": {"name": "Problém zařízení"},

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -129,6 +129,7 @@
             "always_active": {"name": "Immer aktiv"},
             "glass_break": {"name": "Glasbruch"},
             "vibration": {"name": "Vibration"},
+            "wire_input_alert": {"name": "Drahteingang ausgelöst"},
             "tamper": {"name": "Gehäusemanipulation"},
             "connectivity": {"name": "Konnektivität"},
             "problem": {"name": "Geräteproblem"},

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -133,6 +133,7 @@
             "always_active": {"name": "Always active"},
             "glass_break": {"name": "Glass break"},
             "vibration": {"name": "Vibration"},
+            "wire_input_alert": {"name": "Wire input alert"},
             "tamper": {"name": "Case tamper"},
             "connectivity": {"name": "Connectivity"},
             "problem": {"name": "Device problem"},

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -133,6 +133,7 @@
             "always_active": {"name": "Siempre activo"},
             "glass_break": {"name": "Rotura de cristal"},
             "vibration": {"name": "Vibración"},
+            "wire_input_alert": {"name": "Alerta de entrada cableada"},
             "tamper": {"name": "Manipulación de carcasa"},
             "connectivity": {"name": "Conectividad"},
             "problem": {"name": "Problema del dispositivo"},

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -133,6 +133,7 @@
             "always_active": {"name": "Toujours actif"},
             "glass_break": {"name": "Bris de verre"},
             "vibration": {"name": "Vibration"},
+            "wire_input_alert": {"name": "Alerte d'entrée filaire"},
             "tamper": {"name": "Sabotage du boîtier"},
             "connectivity": {"name": "Connectivité"},
             "problem": {"name": "Problème appareil"},

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -129,6 +129,7 @@
             "always_active": {"name": "Sempre attivo"},
             "glass_break": {"name": "Rottura vetro"},
             "vibration": {"name": "Vibrazione"},
+            "wire_input_alert": {"name": "Allarme ingresso cablato"},
             "tamper": {"name": "Manomissione involucro"},
             "connectivity": {"name": "Connettività"},
             "problem": {"name": "Problema dispositivo"},

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -129,6 +129,7 @@
             "always_active": {"name": "Altijd actief"},
             "glass_break": {"name": "Glasbreuk"},
             "vibration": {"name": "Vibratie"},
+            "wire_input_alert": {"name": "Bedrade ingang alarm"},
             "tamper": {"name": "Behuizing sabotage"},
             "connectivity": {"name": "Verbinding"},
             "problem": {"name": "Apparaatprobleem"},

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -129,6 +129,7 @@
             "always_active": {"name": "Zawsze aktywny"},
             "glass_break": {"name": "Rozbicie szyby"},
             "vibration": {"name": "Wibracja"},
+            "wire_input_alert": {"name": "Alarm wejścia przewodowego"},
             "tamper": {"name": "Sabotaż obudowy"},
             "connectivity": {"name": "Łączność"},
             "problem": {"name": "Problem urządzenia"},

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -133,6 +133,7 @@
             "always_active": {"name": "Sempre ativo"},
             "glass_break": {"name": "Quebra de vidro"},
             "vibration": {"name": "Vibração"},
+            "wire_input_alert": {"name": "Alerta de entrada com fio"},
             "tamper": {"name": "Violação da caixa"},
             "connectivity": {"name": "Conectividade"},
             "problem": {"name": "Problema do dispositivo"},

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -133,6 +133,7 @@
             "always_active": {"name": "Sempre ativo"},
             "glass_break": {"name": "Quebra de vidro"},
             "vibration": {"name": "Vibração"},
+            "wire_input_alert": {"name": "Alerta de entrada com fio"},
             "tamper": {"name": "Violação da caixa"},
             "connectivity": {"name": "Conectividade"},
             "problem": {"name": "Problema do dispositivo"},

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -133,6 +133,7 @@
             "always_active": {"name": "Întotdeauna activ"},
             "glass_break": {"name": "Spargere geam"},
             "vibration": {"name": "Vibrație"},
+            "wire_input_alert": {"name": "Alertă intrare cablată"},
             "tamper": {"name": "Sabotaj carcasă"},
             "connectivity": {"name": "Conectivitate"},
             "problem": {"name": "Problemă dispozitiv"},

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -129,6 +129,7 @@
             "always_active": {"name": "Her zaman aktif"},
             "glass_break": {"name": "Cam kırılması"},
             "vibration": {"name": "Titreşim"},
+            "wire_input_alert": {"name": "Kablolu giriş uyarısı"},
             "tamper": {"name": "Kasa kurcalama"},
             "connectivity": {"name": "Bağlantı"},
             "problem": {"name": "Cihaz sorunu"},

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -129,6 +129,7 @@
             "always_active": {"name": "Завжди активний"},
             "glass_break": {"name": "Розбиття скла"},
             "vibration": {"name": "Вібрація"},
+            "wire_input_alert": {"name": "Сповіщення дротового входу"},
             "tamper": {"name": "Зламування корпусу"},
             "connectivity": {"name": "Підключення"},
             "problem": {"name": "Проблема пристрою"},

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -77,6 +77,9 @@ class TestBinarySensorTypes:
     def test_vibration_sensor_type_exists(self) -> None:
         assert "vibration" in BINARY_SENSOR_TYPES
 
+    def test_wire_input_alert_type_exists(self) -> None:
+        assert "wire_input_alert" in BINARY_SENSOR_TYPES
+
 
 class TestAjaxBinarySensor:
     def _make_device(self, statuses: dict) -> Device:
@@ -354,6 +357,73 @@ class TestDeviceTypeSensors:
     )
     def test_door_protect_family_has_external_contact_alert(self, device_type: str) -> None:
         assert "external_contact_alert" in _DEVICE_TYPE_SENSORS[device_type]
+
+    def test_wire_input_mt_in_device_types(self) -> None:
+        assert "wire_input_mt" in _DEVICE_TYPE_SENSORS
+
+    def test_wire_input_in_device_types(self) -> None:
+        assert "wire_input" in _DEVICE_TYPE_SENSORS
+
+    def test_wire_input_mt_has_alert_sensor(self) -> None:
+        assert "wire_input_alert" in _DEVICE_TYPE_SENSORS["wire_input_mt"]
+
+    def test_wire_input_has_alert_sensor(self) -> None:
+        assert "wire_input_alert" in _DEVICE_TYPE_SENSORS["wire_input"]
+
+
+class TestWireInputAlertSensor:
+    """Binary sensor behaviour for wired-input alerts (MultiTransmitter children)."""
+
+    def _make_device(self, statuses: dict) -> Device:
+        return Device(
+            id="wi-1",
+            hub_id="hub-1",
+            name="Kitchen window",
+            device_type="wire_input_mt",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses=statuses,
+            battery=None,
+        )
+
+    def test_is_on_true(self) -> None:
+        device = self._make_device({"wire_input_alert": True})
+        coordinator = MagicMock()
+        coordinator.devices = {"wi-1": device}
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="wi-1", status_key="wire_input_alert"
+        )
+        assert sensor.is_on is True
+
+    def test_is_on_false(self) -> None:
+        device = self._make_device({"wire_input_alert": False})
+        coordinator = MagicMock()
+        coordinator.devices = {"wi-1": device}
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="wi-1", status_key="wire_input_alert"
+        )
+        assert sensor.is_on is False
+
+    def test_alarm_type_attribute(self) -> None:
+        device = self._make_device({"wire_input_alert": True, "wire_input_alarm_type": "intrusion"})
+        coordinator = MagicMock()
+        coordinator.devices = {"wi-1": device}
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="wi-1", status_key="wire_input_alert"
+        )
+        assert sensor.extra_state_attributes == {"alarm_type": "intrusion"}
+
+    def test_alarm_type_absent_no_attributes(self) -> None:
+        device = self._make_device({"wire_input_alert": True})
+        coordinator = MagicMock()
+        coordinator.devices = {"wi-1": device}
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="wi-1", status_key="wire_input_alert"
+        )
+        assert sensor.extra_state_attributes == {}
 
 
 class TestAjaxConnectivitySensor:

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -294,6 +294,33 @@ class TestStatusParser:
         result = DevicesApi._parse_statuses([status])
         assert result.get("external_contact_alert") is True
 
+    def test_wire_input_status_alerting(self) -> None:
+        status = MagicMock()
+        status.WhichOneof.return_value = "wire_input_status"
+        status.wire_input_status.is_alert = True
+        status.wire_input_status.type = 1  # INTRUSION
+        result = DevicesApi._parse_statuses([status])
+        assert result.get("wire_input_alert") is True
+        assert result.get("wire_input_alarm_type") == "intrusion"
+
+    def test_wire_input_status_not_alerting(self) -> None:
+        status = MagicMock()
+        status.WhichOneof.return_value = "wire_input_status"
+        status.wire_input_status.is_alert = False
+        status.wire_input_status.type = 11  # GLASS_BREAK
+        result = DevicesApi._parse_statuses([status])
+        assert result.get("wire_input_alert") is False
+        assert result.get("wire_input_alarm_type") == "glass_break"
+
+    def test_wire_input_status_unspecified_type(self) -> None:
+        status = MagicMock()
+        status.WhichOneof.return_value = "wire_input_status"
+        status.wire_input_status.is_alert = True
+        status.wire_input_status.type = 0  # UNSPECIFIED
+        result = DevicesApi._parse_statuses([status])
+        assert result.get("wire_input_alert") is True
+        assert result.get("wire_input_alarm_type") == "unspecified"
+
     def test_case_drilling_detected(self) -> None:
         status = MagicMock()
         status.WhichOneof.return_value = "case_drilling_detected"


### PR DESCRIPTION
## Summary
- Wire inputs registered under an Ajax MultiTransmitter (and the Hub Hybrid's wired inputs) now surface their triggered state as a dedicated binary sensor instead of ending up in the default tamper-only bucket.
- Parser now handles the `wire_input_status` oneof, extracting `is_alert` (state) and `type` (CustomAlarmType → intrusion / fire / glass_break / vibration / …).
- Coordinator `_STATUS_KEY_MAP` gets an entry for `wire_input_status → wire_input_alert` so streamed ADD/UPDATE/REMOVE deltas hit the same key.
- `_DEVICE_TYPE_SENSORS` registers `wire_input` and `wire_input_mt` with a single `wire_input_alert` entity (device class SAFETY). The alarm category shows up as an `alarm_type` extra-state-attribute so users can see whether Ajax is treating the input as intrusion, fire, glass break, etc.
- Translations added for `wire_input_alert` in all 14 supported languages (surgical insert, no file reformat).

Confirmed against @andrea271988's diagnostics in #36: their 9 wired inputs appear as individual `wire_input_mt` devices under the MultiTransmitter, so device-type routing works; only the status parsing and entity mapping were missing.

## Test plan
- [x] 12 new unit tests:
  - Parser: `wire_input_status` with `is_alert=True/False` and different `CustomAlarmType` values (intrusion, glass_break, unspecified)
  - Entity: binary sensor `is_on` true/false on `wire_input_alert`
  - Entity: `extra_state_attributes` exposes `alarm_type` when present, empty dict when absent
  - `BINARY_SENSOR_TYPES` and `_DEVICE_TYPE_SENSORS` membership assertions for `wire_input` and `wire_input_mt`
- [x] `make check` green on a freshly built Docker image — 741 tests, coverage 80.35%, lint, format, typecheck, dead-code
- [ ] User validation on real hardware (#36 reporters) — wired sensors attached to a MultiTransmitter should expose an `..._wire_input_alert` entity that toggles on open/close

Related to #36.