### PR TITLE
fix: OR-reduce wire-input alert across hub firmwares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0-beta.3] - 2026-04-24
+
+### Fixed
+- MultiTransmitter wire input alert now works across hub firmwares that signal state through `external_contact_broken` or `external_contact_alert` oneofs instead of `wire_input_status`. The single `wire_input_alert` entity on `wire_input_mt`/`wire_input` devices now OR-reduces all three sources, so it toggles correctly regardless of which channel the hub uses (#36)
+
 ## [1.2.0-beta.2] - 2026-04-24
 
 ### Fixed

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -54,6 +54,16 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
     "wire_input_alert": BinarySensorTypeInfo(BinarySensorDeviceClass.SAFETY, "wire_input_alert"),
 }
 
+# Devices whose single "alert" entity should OR-reduce several hub status
+# oneofs into one state, because Ajax hub firmwares disagree on which oneof
+# carries the open/closed transition for wired inputs.
+_WIRE_INPUT_DEVICE_TYPES: frozenset[str] = frozenset({"wire_input", "wire_input_mt"})
+_WIRE_INPUT_ALERT_SOURCES: tuple[str, ...] = (
+    "wire_input_alert",
+    "external_contact_broken",
+    "external_contact_alert",
+)
+
 _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
     "door_protect": ["door_opened", "tamper", "external_contact_broken", "external_contact_alert"],
     "door_protect_plus": [
@@ -201,6 +211,15 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensor
         device = self._device
         if device is None:
             return False
+        if (
+            self._status_key == "wire_input_alert"
+            and device.device_type in _WIRE_INPUT_DEVICE_TYPES
+        ):
+            # Different hub firmwares signal the wired-input trigger through
+            # different oneofs. Treat any of them as "alert active".
+            return any(
+                bool(device.statuses.get(source, False)) for source in _WIRE_INPUT_ALERT_SOURCES
+            )
         return bool(device.statuses.get(self._status_key, False))
 
     @property

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.0-beta.2"
+    "version": "1.2.0-beta.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.0-beta.2"
+version = "1.2.0-beta.3"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -434,6 +434,62 @@ class TestWireInputAlertSensor:
         )
         assert sensor.extra_state_attributes == {}
 
+    def test_is_on_via_external_contact_broken(self) -> None:
+        # Some hub firmwares emit state changes through external_contact_broken
+        # rather than wire_input_status. The wire_input_alert entity on a
+        # wire_input_mt device must reflect it.
+        device = self._make_device({"external_contact_broken": True})
+        coordinator = MagicMock()
+        coordinator.devices = {"wi-1": device}
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="wi-1", status_key="wire_input_alert"
+        )
+        assert sensor.is_on is True
+
+    def test_is_on_via_external_contact_alert(self) -> None:
+        device = self._make_device({"external_contact_alert": True})
+        coordinator = MagicMock()
+        coordinator.devices = {"wi-1": device}
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="wi-1", status_key="wire_input_alert"
+        )
+        assert sensor.is_on is True
+
+    def test_is_on_false_when_all_sources_clear(self) -> None:
+        device = self._make_device({})
+        coordinator = MagicMock()
+        coordinator.devices = {"wi-1": device}
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="wi-1", status_key="wire_input_alert"
+        )
+        assert sensor.is_on is False
+
+    def test_door_protect_external_contact_broken_not_routed_as_alert(self) -> None:
+        # Sanity check: the composite OR must apply ONLY to wire_input devices,
+        # not to DoorProtect (where external_contact_broken is a distinct fault
+        # indicator and is exposed as its own entity with PROBLEM class).
+        device = Device(
+            id="dp-1",
+            hub_id="hub-1",
+            name="Front door",
+            device_type="door_protect",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={"external_contact_broken": True},
+            battery=None,
+        )
+        coordinator = MagicMock()
+        coordinator.devices = {"dp-1": device}
+        # A wire_input_alert entity should not exist on door_protect, but if it
+        # somehow did, external_contact_broken must not be OR'd into it.
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="dp-1", status_key="wire_input_alert"
+        )
+        assert sensor.is_on is False
+
 
 class TestAjaxConnectivitySensor:
     def _make_device(self, state: DeviceState = DeviceState.ONLINE) -> Device:


### PR DESCRIPTION
## Summary
Issue #36 validation from @andrea271988 showed that different Ajax hub firmwares disagree on which gRPC status oneof signals a wire-input trigger:

- @Hansontech190's hub: `wire_input_status` with `is_alert=True/False` on open/close — worked in 1.2.0-beta.2.
- @andrea271988's hub: state lives in `external_contact_broken` (op=2/3), and `wire_input_status` is emitted only as spurious op=3 "keep-alives" that cleared our entity immediately — stuck at "Safe" forever.

Rather than duplicate entities per source, expose a single `wire_input_alert` binary sensor per wire input and compute `is_on` as the OR of all three candidate sources (`wire_input_alert`, `external_contact_broken`, `external_contact_alert`) *when the device is `wire_input` / `wire_input_mt`*. DoorProtect and other device types are unaffected — the OR is scoped by device type.

No coordinator or parser changes needed: each oneof already flows into its own internal status key, the entity just reads them all.

## Test plan
- [x] 4 new unit tests:
  - `is_on` True when only `external_contact_broken` is set on a `wire_input_mt` device
  - `is_on` True when only `external_contact_alert` is set
  - `is_on` False when all three sources are absent
  - DoorProtect regression guard: `external_contact_broken` on a `door_protect` device does NOT bleed into a (hypothetical) `wire_input_alert` entity
- [x] `make check` green on fresh Docker image — 750 tests, 80.30% coverage, lint, format, typecheck, dead-code
- [ ] User validation on real hardware — @andrea271988's `wire_input_mt` entities should now toggle Safe ↔ Unsafe on open/close

Version bumped to `1.2.0-beta.3`.