### PR TITLE
feat: add notification URL and label overrides to security event blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-04-25
+
+### Changed
+- Security event notification blueprint exposes two new optional inputs: `notification_url` (path the mobile app opens when the notification is tapped) and `event_labels` (mapping of `event_type` to display label, editable for translations or icon customisation). Existing automations using the blueprint keep working without changes — both inputs default to the previous behaviour.
+
 ## [1.2.0] - 2026-04-25
 
 ### Added

--- a/custom_components/aegis_ajax/blueprints/automation/security_event_notification.yaml
+++ b/custom_components/aegis_ajax/blueprints/automation/security_event_notification.yaml
@@ -3,7 +3,8 @@ blueprint:
   description: >-
     Send a detailed notification on any Ajax security event, using enriched
     event data (device_name, room_name, device_type). Optionally filter by
-    a specific event type.
+    a specific event type, override the per-event-type display labels (for
+    translations) and set a click-through URL.
   domain: automation
   input:
     event_entity:
@@ -28,26 +29,42 @@ blueprint:
       default: ""
       selector:
         text: {}
+    notification_url:
+      name: Notification URL (optional)
+      description: >-
+        Path opened by the mobile app when the notification is tapped
+        (e.g. /lovelace/seguridad). Leave empty to omit.
+      default: ""
+      selector:
+        text: {}
+    event_labels:
+      name: Event labels (optional)
+      description: >-
+        Mapping of event_type to display label. Edit values to translate or
+        customise the title prefix. Unknown event types fall back to a
+        prettified version of the event_type.
+      default:
+        alarm: "🚨 Alarm"
+        arm: "🔒 Armed"
+        arm_night: "🌙 Night mode"
+        disarm: "🔓 Disarmed"
+        disarm_night: "🔓 Night mode off"
+        tamper: "⚠️ Tamper"
+        panic: "🆘 Panic"
+        battery_low: "🪫 Low battery"
+        connection_lost: "📡 Connection lost"
+        malfunction: "⚙️ Malfunction"
+        fire: "🔥 Fire"
+        co_alarm: "☁️ CO alarm"
+        flood: "💧 Flood"
+        glass_break: "💔 Glass break"
+        motion: "🏃 Motion"
+        door_open: "🚪 Door open"
 
 variables:
   event_type_filter: !input event_type_filter
-  event_labels:
-    alarm: "🚨 Alarm"
-    arm: "🔒 Armed"
-    arm_night: "🌙 Night mode"
-    disarm: "🔓 Disarmed"
-    disarm_night: "🔓 Night mode off"
-    tamper: "⚠️ Tamper"
-    panic: "🆘 Panic"
-    battery_low: "🪫 Low battery"
-    connection_lost: "📡 Connection lost"
-    malfunction: "⚙️ Malfunction"
-    fire: "🔥 Fire"
-    co_alarm: "☁️ CO alarm"
-    flood: "💧 Flood"
-    glass_break: "💔 Glass break"
-    motion: "🏃 Motion"
-    door_open: "🚪 Door open"
+  event_labels: !input event_labels
+  notification_url: !input notification_url
 
 triggers:
   - trigger: state
@@ -77,3 +94,4 @@ actions:
         push:
           sound: default
         tag: "ajax-event-{{ trigger.to_state.attributes.event_type }}"
+        url: "{{ notification_url }}"

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.0"
+    "version": "1.2.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.0"
+version = "1.2.1"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Adds two new optional inputs to the bundled \`security_event_notification.yaml\` blueprint:
  - **\`notification_url\`** — forwarded to the notify call's \`data.url\`, so the mobile companion app opens a specific dashboard view when the notification is tapped (e.g. \`/lovelace/seguridad\`).
  - **\`event_labels\`** — dict mapping \`event_type\` to display label, editable from the blueprint UI for translations or icon customisation.
- Defaults preserve the previous behaviour (English labels, no URL), so existing automations consuming the blueprint keep working without changes.

Triggered by an in-the-wild user on v1.2.0 whose hand-edited automation was missing the \`event_labels\` \`variables:\` block — exposing the values as inputs avoids that pitfall and makes localisation possible.

## Test plan
- [x] YAML structure parses correctly (HA-aware loader registers the \`!input\` constructor; 5 inputs, 16 default labels parsed).
- [x] \`make check\` green — 750 tests, lint, format, typecheck, dead-code.
- [ ] Manual smoke test in a HA instance: re-import the blueprint, create an automation, verify URL navigation and translated labels work.

Bumps to 1.2.1.