### PR TITLE
chore: project-health files (CoC, PR template, dependabot)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
     attributes:
       label: Integration version
       description: "HACS > Ajax Security > version number"
-      placeholder: "0.6.4"
+      placeholder: "1.2.0"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/bvis/aegis-ajax-hass/blob/main/README.md
+    url: https://github.com/bvis/aegis-hass/blob/main/README.md
     about: Check the README for setup instructions and troubleshooting

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for the contribution! A few minutes spent filling this in helps reviews
+move quickly.
+-->
+
+## Summary
+
+<!--
+What does this PR change and why? One or two paragraphs is enough. Link any
+related issue with `Relates to #N` (avoid `Fixes #N` / `Closes #N` — let the
+maintainer close issues manually after release validation).
+-->
+
+## Test plan
+
+<!--
+Tick what applies, add anything project-specific. CI runs lint, format,
+typecheck, unit tests and dead-code analysis on every push — keep it green.
+-->
+
+- [ ] `make check` passes locally on a freshly built Docker image
+- [ ] New behaviour covered by unit tests in `tests/unit/`
+- [ ] Coverage stays at or above the 80% threshold
+- [ ] User-facing strings updated in `strings.json` and the 14 translation files
+- [ ] `README.md` / `CHANGELOG.md` updated when the change is user-visible
+
+## Notes for the reviewer
+
+<!--
+Anything the reviewer should know: gotchas, areas you want a closer look at,
+follow-ups deliberately deferred, manual validation done on real hardware, etc.
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  # Python dependencies declared in pyproject.toml
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Madrid
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Bundle all minor / patch bumps into one PR per week to reduce noise.
+      python-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the workflows under .github/workflows/
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Madrid
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(actions)"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers privately through GitHub's private
+vulnerability reporting:
+<https://github.com/bvis/aegis-hass/security/advisories/new>.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
## Summary

Filling the standard open-source project-health gaps and fixing two stale references in the existing files. No code changes, repo metadata only.

**New files**

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1. Reports go through GitHub's [private vulnerability reporting](https://github.com/bvis/aegis-hass/security/advisories/new) rather than a personal email.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — Summary / Test plan / Notes-for-the-reviewer scaffold matching the style already used in this repo (no `Fixes #N`, conventional reviews on `make check`, translations + README + CHANGELOG checklist).
- **`.github/dependabot.yml`** — weekly grouped updates for pip and github-actions. Minor/patch grouped to keep noise down, max 5 open PRs per ecosystem.

**Tweaks to existing files**

- `.github/ISSUE_TEMPLATE/config.yml` — broken link pointed at the legacy `aegis-ajax-hass` repo name, now points to `aegis-hass`.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — version placeholder bumped from `0.6.4` to `1.2.0`.

## Test plan

- [x] No code changes — CI is informational only here.
- [x] YAML files valid (dependabot, issue templates).
- [x] Markdown renders cleanly on GitHub.