### PR TITLE
chore: route security reports through GitHub advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,14 +6,14 @@ If you discover a security vulnerability in this integration, please report it r
 
 **Do NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, please email: **basilio.vera@gmail.com**
+Instead, use GitHub's [private vulnerability reporting](https://github.com/bvis/aegis-hass/security/advisories/new) so the report stays confidential while it's investigated.
 
 Include:
 - A description of the vulnerability
 - Steps to reproduce
 - Potential impact
 
-You will receive a response within 48 hours. We will work with you to understand and address the issue before any public disclosure.
+You will receive an initial response within 48 hours. We will work with you to understand and address the issue before any public disclosure.
 
 ## Scope
 


### PR DESCRIPTION
## Summary
Removes the personal email address from \`SECURITY.md\` and replaces the disclosure channel with GitHub's [private vulnerability reporting](https://github.com/bvis/aegis-hass/security/advisories/new) — the same flow already used by \`CODE_OF_CONDUCT.md\` and \`SUPPORT.md\`.

Keeps confidentiality of the disclosure process intact without exposing a personal address.

## Test plan
- [x] No code changes — doc-only.
- [x] Verified the new SECURITY.md no longer contains any email or personal contact reference.