### PR TITLE
feat: option to disable auto-creation of Aegis labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After setup, configure these in **Settings > Devices & Services > Aegis for Ajax
 | FCM credentials | — | Firebase credentials for push notifications (optional) |
 | Photo retention (days) | 30 | How many days to keep captured photos (1-365) |
 | Max photos per device | 100 | Maximum photos stored per camera (0 = unlimited) |
+| Auto-create labels | enabled | Create and assign `aegis_*` labels (camera, hub, door, motion, …) to your entities for easy grouping in dashboards/automations. Disable if you prefer to manage labels manually — with the option enabled the integration re-creates the labels on every restart. |
 
 ### Known App Labels
 

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -9,7 +9,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 
 from custom_components.aegis_ajax.api.client import AjaxGrpcClient
-from custom_components.aegis_ajax.const import DEFAULT_POLL_INTERVAL, DOMAIN, LABELS
+from custom_components.aegis_ajax.const import (
+    CONF_AUTO_CREATE_LABELS,
+    DEFAULT_AUTO_CREATE_LABELS,
+    DEFAULT_POLL_INTERVAL,
+    DOMAIN,
+    LABELS,
+)
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 
 if TYPE_CHECKING:
@@ -197,11 +203,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Auto-label entities for easy grouping in automations
-    try:
-        await _async_apply_labels(hass, entry)
-    except Exception:
-        _LOGGER.debug("Auto-labeling skipped (labels API not available)")
+    # Auto-label entities for easy grouping in automations.
+    # Users can disable this from the OptionsFlow when they prefer to manage
+    # labels manually (the label registry is otherwise authoritative and
+    # re-creates removed labels on every restart).
+    if entry.options.get(CONF_AUTO_CREATE_LABELS, DEFAULT_AUTO_CREATE_LABELS):
+        try:
+            await _async_apply_labels(hass, entry)
+        except Exception:
+            _LOGGER.debug("Auto-labeling skipped (labels API not available)")
 
     async def _force_arm_handler(call: ServiceCall) -> None:
         await _async_handle_force_arm(hass, call)

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -28,9 +28,11 @@ from custom_components.aegis_ajax.api.session import (
 from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import (
     APPLICATION_LABEL,
+    CONF_AUTO_CREATE_LABELS,
     CONF_FORCE_ARM,
     CONF_PHOTO_MAX_PER_DEVICE,
     CONF_PHOTO_RETENTION_DAYS,
+    DEFAULT_AUTO_CREATE_LABELS,
     DEFAULT_PHOTO_MAX_PER_DEVICE,
     DEFAULT_PHOTO_RETENTION_DAYS,
     DEFAULT_POLL_INTERVAL,
@@ -364,6 +366,12 @@ class AjaxCobrandedOptionsFlow(OptionsFlow):
                             CONF_PHOTO_MAX_PER_DEVICE, DEFAULT_PHOTO_MAX_PER_DEVICE
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=0, max=10000)),
+                    vol.Optional(
+                        CONF_AUTO_CREATE_LABELS,
+                        default=self._entry.options.get(
+                            CONF_AUTO_CREATE_LABELS, DEFAULT_AUTO_CREATE_LABELS
+                        ),
+                    ): bool,
                 }
             ),
         )

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -160,8 +160,10 @@ class DeviceState(StrEnum):
 CONF_FORCE_ARM = "force_arm"
 CONF_PHOTO_RETENTION_DAYS = "photo_retention_days"
 CONF_PHOTO_MAX_PER_DEVICE = "photo_max_per_device"
+CONF_AUTO_CREATE_LABELS = "auto_create_labels"
 DEFAULT_PHOTO_RETENTION_DAYS = 30
 DEFAULT_PHOTO_MAX_PER_DEVICE = 100
+DEFAULT_AUTO_CREATE_LABELS = True
 
 EVENT_DOMAIN = f"{DOMAIN}_event"
 

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -63,7 +63,8 @@
                     "fcm_api_key": "FCM API Key",
                     "fcm_sender_id": "FCM Sender ID",
                     "photo_retention_days": "Photo retention (days)",
-                    "photo_max_per_device": "Max photos per device (0 = unlimited)"
+                    "photo_max_per_device": "Max photos per device (0 = unlimited)",
+                    "auto_create_labels": "Auto-create and assign Aegis labels to entities"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -63,7 +63,8 @@
                     "fcm_api_key": "Clau d'API FCM",
                     "fcm_sender_id": "ID de remitent FCM",
                     "photo_retention_days": "Retenció de fotos (dies)",
-                    "photo_max_per_device": "Màxim de fotos per dispositiu (0 = il·limitat)"
+                    "photo_max_per_device": "Màxim de fotos per dispositiu (0 = il·limitat)",
+                    "auto_create_labels": "Crear i assignar automàticament etiquetes Aegis a les entitats"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -59,7 +59,8 @@
                     "fcm_api_key": "API klíč FCM",
                     "fcm_sender_id": "ID odesílatele FCM",
                     "photo_retention_days": "Uchovávání fotografií (dny)",
-                    "photo_max_per_device": "Max fotografií na zařízení (0 = neomezeno)"
+                    "photo_max_per_device": "Max fotografií na zařízení (0 = neomezeno)",
+                    "auto_create_labels": "Automaticky vytvářet a přiřazovat štítky Aegis entitám"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -59,7 +59,8 @@
                     "fcm_api_key": "FCM-API-Schlüssel",
                     "fcm_sender_id": "FCM-Absender-ID",
                     "photo_retention_days": "Foto-Aufbewahrung (Tage)",
-                    "photo_max_per_device": "Max. Fotos pro Gerät (0 = unbegrenzt)"
+                    "photo_max_per_device": "Max. Fotos pro Gerät (0 = unbegrenzt)",
+                    "auto_create_labels": "Aegis-Labels automatisch erstellen und Entitäten zuweisen"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -63,7 +63,8 @@
                     "fcm_api_key": "FCM API Key",
                     "fcm_sender_id": "FCM Sender ID",
                     "photo_retention_days": "Photo retention (days)",
-                    "photo_max_per_device": "Max photos per device (0 = unlimited)"
+                    "photo_max_per_device": "Max photos per device (0 = unlimited)",
+                    "auto_create_labels": "Auto-create and assign Aegis labels to entities"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -63,7 +63,8 @@
                     "fcm_api_key": "Clave de API FCM",
                     "fcm_sender_id": "ID de remitente FCM",
                     "photo_retention_days": "Retención de fotos (días)",
-                    "photo_max_per_device": "Máximo de fotos por dispositivo (0 = ilimitado)"
+                    "photo_max_per_device": "Máximo de fotos por dispositivo (0 = ilimitado)",
+                    "auto_create_labels": "Crear y asignar automáticamente etiquetas Aegis a las entidades"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -63,7 +63,8 @@
                     "fcm_api_key": "Clé API FCM",
                     "fcm_sender_id": "ID d'expéditeur FCM",
                     "photo_retention_days": "Rétention des photos (jours)",
-                    "photo_max_per_device": "Max photos par appareil (0 = illimité)"
+                    "photo_max_per_device": "Max photos par appareil (0 = illimité)",
+                    "auto_create_labels": "Créer et attribuer automatiquement des étiquettes Aegis aux entités"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -59,7 +59,8 @@
                     "fcm_api_key": "Chiave API FCM",
                     "fcm_sender_id": "ID mittente FCM",
                     "photo_retention_days": "Conservazione foto (giorni)",
-                    "photo_max_per_device": "Max foto per dispositivo (0 = illimitato)"
+                    "photo_max_per_device": "Max foto per dispositivo (0 = illimitato)",
+                    "auto_create_labels": "Crea e assegna automaticamente etichette Aegis alle entità"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -59,7 +59,8 @@
                     "fcm_api_key": "FCM-API-sleutel",
                     "fcm_sender_id": "FCM-afzender-ID",
                     "photo_retention_days": "Foto bewaarperiode (dagen)",
-                    "photo_max_per_device": "Max foto's per apparaat (0 = onbeperkt)"
+                    "photo_max_per_device": "Max foto's per apparaat (0 = onbeperkt)",
+                    "auto_create_labels": "Aegis-labels automatisch aanmaken en aan entiteiten toewijzen"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -59,7 +59,8 @@
                     "fcm_api_key": "Klucz API FCM",
                     "fcm_sender_id": "ID nadawcy FCM",
                     "photo_retention_days": "Przechowywanie zdjęć (dni)",
-                    "photo_max_per_device": "Maks. zdjęć na urządzenie (0 = bez limitu)"
+                    "photo_max_per_device": "Maks. zdjęć na urządzenie (0 = bez limitu)",
+                    "auto_create_labels": "Automatycznie twórz i przypisuj etykiety Aegis do encji"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -63,7 +63,8 @@
                     "fcm_api_key": "Chave de API FCM",
                     "fcm_sender_id": "ID do remetente FCM",
                     "photo_retention_days": "Retenção de fotos (dias)",
-                    "photo_max_per_device": "Máx. fotos por dispositivo (0 = ilimitado)"
+                    "photo_max_per_device": "Máx. fotos por dispositivo (0 = ilimitado)",
+                    "auto_create_labels": "Criar e atribuir automaticamente etiquetas Aegis às entidades"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -63,7 +63,8 @@
                     "fcm_api_key": "Chave de API FCM",
                     "fcm_sender_id": "ID do remetente FCM",
                     "photo_retention_days": "Retenção de fotos (dias)",
-                    "photo_max_per_device": "Máx. fotos por dispositivo (0 = ilimitado)"
+                    "photo_max_per_device": "Máx. fotos por dispositivo (0 = ilimitado)",
+                    "auto_create_labels": "Criar e atribuir automaticamente etiquetas Aegis às entidades"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -63,7 +63,8 @@
                     "fcm_api_key": "Cheie API FCM",
                     "fcm_sender_id": "ID expeditor FCM",
                     "photo_retention_days": "Reținere fotografii (zile)",
-                    "photo_max_per_device": "Max fotografii per dispozitiv (0 = nelimitat)"
+                    "photo_max_per_device": "Max fotografii per dispozitiv (0 = nelimitat)",
+                    "auto_create_labels": "Creează și atribuie automat etichete Aegis entităților"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -59,7 +59,8 @@
                     "fcm_api_key": "FCM API Anahtarı",
                     "fcm_sender_id": "FCM Gönderici Kimliği",
                     "photo_retention_days": "Fotoğraf saklama süresi (gün)",
-                    "photo_max_per_device": "Cihaz başına maks. fotoğraf (0 = sınırsız)"
+                    "photo_max_per_device": "Cihaz başına maks. fotoğraf (0 = sınırsız)",
+                    "auto_create_labels": "Aegis etiketlerini otomatik olarak oluştur ve varlıklara ata"
                 }
             }
         }

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -59,7 +59,8 @@
                     "fcm_api_key": "Ключ API FCM",
                     "fcm_sender_id": "ID відправника FCM",
                     "photo_retention_days": "Зберігання фото (днів)",
-                    "photo_max_per_device": "Макс. фото на пристрій (0 = необмежено)"
+                    "photo_max_per_device": "Макс. фото на пристрій (0 = необмежено)",
+                    "auto_create_labels": "Автоматично створювати та призначати мітки Aegis сутностям"
                 }
             }
         }

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -324,6 +324,66 @@ class TestAutoLabeling:
         assert "aegis_hub" in call_kwargs["labels"]
 
 
+class TestAutoCreateLabelsOption:
+    """Verify the `auto_create_labels` OptionsFlow toggle gates label creation."""
+
+    def _make_entry(self, options: dict) -> MagicMock:
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.data = {
+            "email": "test@example.com",
+            "password_hash": "abc123hash",
+            "spaces": ["s1"],
+        }
+        entry.options = options
+        return entry
+
+    async def _run_setup(self, entry: MagicMock) -> MagicMock:
+        from custom_components.aegis_ajax import async_setup_entry
+
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.session = MagicMock()
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_start_push_notifications = AsyncMock()
+
+        apply_labels_mock = AsyncMock()
+        with (
+            patch("custom_components.aegis_ajax.AjaxGrpcClient", return_value=mock_client),
+            patch(
+                "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch("custom_components.aegis_ajax._async_apply_labels", apply_labels_mock),
+        ):
+            await async_setup_entry(hass, entry)
+        return apply_labels_mock
+
+    @pytest.mark.asyncio
+    async def test_auto_create_labels_default_calls_apply(self) -> None:
+        entry = self._make_entry(options={})
+        apply_mock = await self._run_setup(entry)
+        apply_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_create_labels_explicit_true_calls_apply(self) -> None:
+        entry = self._make_entry(options={"auto_create_labels": True})
+        apply_mock = await self._run_setup(entry)
+        apply_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_create_labels_false_skips_apply(self) -> None:
+        entry = self._make_entry(options={"auto_create_labels": False})
+        apply_mock = await self._run_setup(entry)
+        apply_mock.assert_not_awaited()
+
+
 class TestAsyncUnloadEntry:
     @pytest.mark.asyncio
     async def test_unload_entry_success(self) -> None:


### PR DESCRIPTION
## Summary

Adds an OptionsFlow toggle so users who prefer to manage HA labels manually can stop the integration from re-creating and re-assigning the \`aegis_*\` labels on every startup.

- New option \`auto_create_labels\` (default \`True\` — preserves existing behaviour for everyone already on the integration).
- When turned off, \`async_setup_entry\` skips the \`_async_apply_labels\` call entirely, leaving the label registry untouched.
- Available in **Settings → Devices & services → Aegis for Ajax → Configure**, below the photo retention options.
- Translations for the new option label in all 14 supported languages.
- README documents the new option.

Triggered by #47 — user removes \`aegis\`-prefixed labels manually and they get re-created on the next HA restart.

## Test plan

- [x] 3 new unit tests in \`TestAutoCreateLabelsOption\` covering default / explicit-true / explicit-false branches via \`async_setup_entry\` with the \`_async_apply_labels\` patched out.
- [x] \`make check\` green on a freshly built Docker image — 753 tests, lint, format, typecheck, dead-code, **coverage 80.32%**.
- [ ] Manual smoke test: enable/disable the toggle in HA's UI, restart, confirm label registry behaviour matches expectation.

Relates to #47.