### PR TITLE
fix: persist refreshed session token + auto-recover on auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Reloading the integration no longer accumulates new active sessions in the user's Ajax account. Three related gaps closed: (a) the latest session token is now persisted back to the config entry after every successful login (it used to be saved only on the initial config flow), (b) the coordinator detects `UNAUTHENTICATED` errors from the gRPC API, forces a fresh login, persists it and retries the failed call once instead of falling out as `UpdateFailed`, and (c) when the user permanently removes the integration, `LogoutService.execute` is now called server-side via the new `async_remove_entry` hook so the dangling session disappears from the Ajax account too. Reload paths still leave the session alive on purpose so the next setup can reuse the token. (#53)
+
 ## [1.2.1-beta.3] - 2026-04-26
 
 ### Fixed

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -197,13 +197,41 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
         )
     # Restore session token from stored data to skip re-login (and 2FA) on restart
     if entry.data.get("session_token") and entry.data.get("user_hex_id"):
+        _LOGGER.debug(
+            "Restoring stored Ajax session for entry %s (user=%s)",
+            entry.entry_id,
+            entry.data["user_hex_id"],
+        )
         client.session.set_session(str(entry.data["session_token"]), str(entry.data["user_hex_id"]))
+    else:
+        _LOGGER.debug(
+            "No stored Ajax session for entry %s — coordinator will log in on first refresh",
+            entry.entry_id,
+        )
     await client.connect()
+
+    def _persist_session(token: str, user_hex_id: str) -> None:
+        """Write the latest session token back to the config entry.
+
+        Called by the coordinator after every successful login so that a
+        restart can reuse the freshest token instead of forcing another
+        login (which would create yet another active session in Ajax).
+        """
+        if (
+            entry.data.get("session_token") == token
+            and entry.data.get("user_hex_id") == user_hex_id
+        ):
+            return
+        new_data = {**entry.data, "session_token": token, "user_hex_id": user_hex_id}
+        hass.config_entries.async_update_entry(entry, data=new_data)
+        _LOGGER.debug("Persisted refreshed Ajax session for entry %s", entry.entry_id)
+
     coordinator = AjaxCobrandedCoordinator(
         hass=hass,
         client=client,
         space_ids=entry.data.get("spaces", []),
         poll_interval=entry.options.get("poll_interval", DEFAULT_POLL_INTERVAL),
+        on_session_persist=_persist_session,
     )
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
@@ -380,3 +408,41 @@ async def async_unload_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntr
         coordinator: AjaxCobrandedCoordinator = entry.runtime_data
         await coordinator.async_shutdown()
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry) -> None:
+    """Invalidate the Ajax session server-side when the user removes the integration.
+
+    Called only on permanent removal, not on reload — reloads route
+    through async_unload_entry which deliberately keeps the session
+    alive so the next setup can reuse the token. Without this hook the
+    Ajax account would keep accumulating "Aegis" devices in its active
+    sessions list every time someone uninstalls and reinstalls.
+    """
+    if "session_token" not in entry.data or "user_hex_id" not in entry.data:
+        return
+
+    common_kwargs = {
+        "email": entry.data["email"],
+        "device_id": entry.data.get("device_id"),
+        "app_label": entry.data.get("app_label", ""),
+    }
+    try:
+        if entry.data.get("password_hash"):
+            client = AjaxGrpcClient(password_hash=entry.data["password_hash"], **common_kwargs)
+        elif entry.data.get("password"):
+            client = AjaxGrpcClient(password=entry.data["password"], **common_kwargs)
+        else:
+            return
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Logout skipped — could not rebuild client", exc_info=True)
+        return
+
+    client.session.set_session(str(entry.data["session_token"]), str(entry.data["user_hex_id"]))
+    try:
+        await client.connect()
+        await client.logout()
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Logout call failed during removal (best-effort)", exc_info=True)
+    finally:
+        await client.close()

--- a/custom_components/aegis_ajax/api/client.py
+++ b/custom_components/aegis_ajax/api/client.py
@@ -102,6 +102,32 @@ class AjaxGrpcClient:
         self._session.clear_session()
         _LOGGER.debug("gRPC channel closed")
 
+    async def logout(self) -> None:
+        """Invalidate the current Ajax session server-side via LogoutService.
+
+        Called only when the user permanently removes the integration —
+        not on every reload. Reload paths must keep the session alive so
+        the next restart can reuse the token instead of opening another
+        active session in the Ajax account.
+        """
+        if self._channel is None or not self._session.is_authenticated:
+            return
+        from v3.mobilegwsvc.service.logout import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        try:
+            stub = endpoint_pb2_grpc.LogoutServiceStub(self._channel)
+            request = request_pb2.LogoutRequest()
+            metadata = self._session.get_call_metadata()
+            await stub.execute(request, metadata=metadata, timeout=10)
+            _LOGGER.debug("Ajax session logged out (server-side invalidated)")
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Logout call failed (best-effort)", exc_info=True)
+        finally:
+            self._session.clear_session()
+
     def _get_channel(self) -> grpc.aio.Channel:
         if self._channel is None:
             raise ConnectionError("gRPC channel not connected. Call connect() first.")

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -26,6 +26,8 @@ from custom_components.aegis_ajax.const import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from homeassistant.core import HomeAssistant
 
     from custom_components.aegis_ajax.api.client import AjaxGrpcClient
@@ -56,6 +58,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         client: AjaxGrpcClient,
         space_ids: list[str],
         poll_interval: int = DEFAULT_POLL_INTERVAL,
+        on_session_persist: Callable[[str, str], None] | None = None,
     ) -> None:
         poll_interval = max(MIN_POLL_INTERVAL, min(MAX_POLL_INTERVAL, poll_interval))
         super().__init__(
@@ -63,6 +66,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self._poll_interval = poll_interval
         self._client = client
+        self._on_session_persist = on_session_persist
         self._space_ids = space_ids
         self._spaces_api = SpacesApi(client)
         self._security_api = SecurityApi(client)
@@ -110,12 +114,46 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def notification_listener(self) -> AjaxNotificationListener | None:
         return self._notification_listener
 
+    async def _login_and_persist(self) -> None:
+        """Login fresh and notify the on_session_persist callback.
+
+        Wrapping the bare client.login() call so every login site goes
+        through the persistence path. Without it the in-memory token is
+        the only copy and a restart re-logins (creating yet another
+        active session in Ajax) instead of reusing the latest one.
+        """
+        _LOGGER.debug("Logging in to Ajax (fresh session)")
+        await self._client.login()
+        token = self._client.session.session_token
+        user_hex_id = self._client.session.user_hex_id
+        if self._on_session_persist and token and user_hex_id:
+            try:
+                self._on_session_persist(token, user_hex_id)
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Failed to persist refreshed session", exc_info=True)
+
+    @staticmethod
+    def _is_unauthenticated_error(exc: Exception) -> bool:
+        """True when a gRPC error indicates the saved token is no longer valid."""
+        # grpc.StatusCode.UNAUTHENTICATED == 16; gRPC raises grpc.aio.AioRpcError
+        code = getattr(exc, "code", None)
+        if callable(code):
+            try:
+                value = code()
+            except Exception:  # noqa: BLE001
+                return False
+            return (
+                getattr(value, "value", (None,))[0] == 16
+                or getattr(value, "name", "") == "UNAUTHENTICATED"
+            )
+        return False
+
     async def _async_update_data(self) -> dict[str, Any]:
         try:
             # Login if not authenticated
             if not self._client.session.is_authenticated:
                 try:
-                    await self._client.login()
+                    await self._login_and_persist()
                     # Restore normal interval after successful re-auth
                     configured = max(MIN_POLL_INTERVAL, min(MAX_POLL_INTERVAL, self._poll_interval))
                     self.update_interval = timedelta(seconds=configured)
@@ -129,8 +167,23 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     )
                     raise UpdateFailed(f"Authentication failed: {err}") from err
 
-            # Refresh spaces
-            all_spaces = await self._spaces_api.list_spaces()
+            # Refresh spaces — if the saved token is stale Ajax replies with
+            # UNAUTHENTICATED; force a fresh login (and persist the new token)
+            # then retry once. Without this recovery the integration would
+            # raise UpdateFailed and the next restart would re-login again,
+            # piling up active sessions in the user's Ajax account.
+            try:
+                all_spaces = await self._spaces_api.list_spaces()
+            except Exception as exc:  # noqa: BLE001
+                if not self._is_unauthenticated_error(exc):
+                    raise
+                _LOGGER.warning(
+                    "Stored Ajax session was rejected (UNAUTHENTICATED). "
+                    "Forcing a fresh login and retrying."
+                )
+                self._client.session.clear_session()
+                await self._login_and_persist()
+                all_spaces = await self._spaces_api.list_spaces()
             now = asyncio.get_running_loop().time()
             new_spaces: dict[str, Space] = {}
             for s in all_spaces:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -162,6 +162,60 @@ class TestAsyncUpdateData:
             await coordinator._async_update_data()
 
     @pytest.mark.asyncio
+    async def test_login_persists_session_via_callback(self) -> None:
+        """A successful login pushes the new token through on_session_persist."""
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = False
+        coordinator._client.session.session_token = "tok-new"
+        coordinator._client.session.user_hex_id = "hex-1"
+        coordinator._client.login = AsyncMock()
+        callback = MagicMock()
+        coordinator._on_session_persist = callback
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[])
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        coordinator._client.login.assert_awaited_once()
+        callback.assert_called_once_with("tok-new", "hex-1")
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_error_triggers_relogin_and_retry(self) -> None:
+        """Stale token rejected by Ajax → force fresh login, persist, retry."""
+        import grpc
+
+        class _UnauthenticatedError(Exception):
+            def code(self) -> grpc.StatusCode:
+                return grpc.StatusCode.UNAUTHENTICATED
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+
+        # First list_spaces raises UNAUTHENTICATED, second call returns []
+        unauth_error = _UnauthenticatedError("session rejected")
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(side_effect=[unauth_error, []])
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+        coordinator._client.session.clear_session = MagicMock()
+        coordinator._client.login = AsyncMock()
+        coordinator._client.session.session_token = "tok-fresh"
+        coordinator._client.session.user_hex_id = "hex-1"
+        callback = MagicMock()
+        coordinator._on_session_persist = callback
+
+        await coordinator._async_update_data()
+
+        coordinator._client.session.clear_session.assert_called_once()
+        coordinator._client.login.assert_awaited_once()
+        callback.assert_called_once_with("tok-fresh", "hex-1")
+        # list_spaces called twice (initial fail + retry)
+        assert coordinator._spaces_api.list_spaces.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_async_shutdown_calls_client_close(self) -> None:
         coordinator = _make_coordinator(space_ids=[])
         coordinator._client.close = AsyncMock()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -486,3 +486,151 @@ class TestAsyncUnloadEntry:
 
         assert result is False
         mock_coordinator.async_shutdown.assert_not_called()
+
+
+class TestSessionPersistence:
+    """Verify the session-token write-back path between coordinator and entry.data."""
+
+    @pytest.mark.asyncio
+    async def test_setup_passes_persist_callback_to_coordinator(self) -> None:
+        from custom_components.aegis_ajax import async_setup_entry
+
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.data = {
+            "email": "user@example.com",
+            "password_hash": "hash",
+            "spaces": ["s1"],
+            "session_token": "tok-old",
+            "user_hex_id": "hex-1",
+        }
+        entry.options = {}
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.session = MagicMock()
+
+        captured: dict[str, object] = {}
+
+        def _record(*args: object, **kwargs: object) -> MagicMock:
+            captured["kwargs"] = kwargs
+            cm = MagicMock()
+            cm.async_config_entry_first_refresh = AsyncMock()
+            cm.async_start_push_notifications = AsyncMock()
+            return cm
+
+        with (
+            patch("custom_components.aegis_ajax.AjaxGrpcClient", return_value=mock_client),
+            patch(
+                "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
+                side_effect=_record,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        # Coordinator received an on_session_persist callback
+        assert "on_session_persist" in captured["kwargs"]
+        callback = captured["kwargs"]["on_session_persist"]
+        assert callable(callback)
+
+        # Calling the callback writes the new credentials back to the entry
+        callback("tok-new", "hex-1")
+        hass.config_entries.async_update_entry.assert_called_once()
+        new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert new_data["session_token"] == "tok-new"
+        assert new_data["user_hex_id"] == "hex-1"
+
+    @pytest.mark.asyncio
+    async def test_persist_callback_skips_when_unchanged(self) -> None:
+        from custom_components.aegis_ajax import async_setup_entry
+
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.data = {
+            "email": "user@example.com",
+            "password_hash": "hash",
+            "spaces": ["s1"],
+            "session_token": "tok-current",
+            "user_hex_id": "hex-1",
+        }
+        entry.options = {}
+
+        captured: dict[str, object] = {}
+
+        def _record(*args: object, **kwargs: object) -> MagicMock:
+            captured["kwargs"] = kwargs
+            cm = MagicMock()
+            cm.async_config_entry_first_refresh = AsyncMock()
+            cm.async_start_push_notifications = AsyncMock()
+            return cm
+
+        with (
+            patch(
+                "custom_components.aegis_ajax.AjaxGrpcClient",
+                return_value=MagicMock(connect=AsyncMock(), session=MagicMock()),
+            ),
+            patch(
+                "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
+                side_effect=_record,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        callback = captured["kwargs"]["on_session_persist"]
+        # Same token as already stored — must not write
+        callback("tok-current", "hex-1")
+        hass.config_entries.async_update_entry.assert_not_called()
+
+
+class TestAsyncRemoveEntry:
+    """Verify the LogoutService call path on permanent removal."""
+
+    @pytest.mark.asyncio
+    async def test_remove_entry_with_session_calls_logout(self) -> None:
+        from custom_components.aegis_ajax import async_remove_entry
+
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            "email": "user@example.com",
+            "password_hash": "hash",
+            "session_token": "tok",
+            "user_hex_id": "hex",
+        }
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.logout = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.session = MagicMock()
+
+        with patch("custom_components.aegis_ajax.AjaxGrpcClient", return_value=mock_client):
+            await async_remove_entry(hass, entry)
+
+        mock_client.connect.assert_awaited_once()
+        mock_client.logout.assert_awaited_once()
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_remove_entry_without_session_skips_logout(self) -> None:
+        from custom_components.aegis_ajax import async_remove_entry
+
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {"email": "user@example.com", "password_hash": "hash"}
+
+        mock_client = MagicMock()
+        mock_client.logout = AsyncMock()
+
+        with patch("custom_components.aegis_ajax.AjaxGrpcClient", return_value=mock_client):
+            await async_remove_entry(hass, entry)
+
+        mock_client.logout.assert_not_called()


### PR DESCRIPTION
## Summary

Targets #53 — every reload of the integration was spawning a fresh active session in the user's Ajax account. Code review surfaced three related gaps in the session lifecycle that I'm fixing in one PR:

### Gap 1 — Persist on every login, not only on initial setup

Until now `entry.data["session_token"]` was only written by the config flow's `select_spaces` step. Any subsequent login (server-side expiry, reauth flow, the new UNAUTHENTICATED retry path below) refreshed the in-memory token but never wrote it back. So the next restart re-logged-in with the stale value and Ajax happily created another active session.

Added an `on_session_persist` callback on the coordinator. `async_setup_entry` wires it to a helper that calls `hass.config_entries.async_update_entry` only when the token actually changed. The coordinator calls it after every `client.login()` (existing path on first refresh + the new retry path).

### Gap 2 — Auto-relogin on UNAUTHENTICATED

`_async_update_data` was treating any exception from `list_spaces` as an `UpdateFailed`, including the gRPC `UNAUTHENTICATED` that signals "your saved token is no longer valid". The coordinator now detects that case, calls `clear_session()` + `_login_and_persist()` and retries the failed call once. After the retry the integration runs as normal and the new token is saved, so the next restart picks it up cleanly.

### Gap 3 — Logout on permanent removal

Added `async_remove_entry` that calls `LogoutService.execute` (v3 mobile gateway) so the dangling session disappears from the Ajax account when the user uninstalls the integration. **Reload paths deliberately do not call logout** — that would invalidate the token and force another login on the very next setup, which is exactly the bug we're trying to avoid.

`AjaxGrpcClient.logout()` is best-effort and falls through to `clear_session()` on failure, so a flaky network at uninstall time still leaves a clean local state.

## Test plan

- [x] 4 new unit tests in `tests/unit/test_init.py` covering the persist callback, the no-op when the token is unchanged, and the logout call on `async_remove_entry` (with and without a stored session).
- [x] 2 new unit tests in `tests/unit/test_coordinator.py` covering `_login_and_persist` and the UNAUTHENTICATED → relogin → persist → retry path.
- [x] `make check` green on a freshly built Docker image — 838 tests total, lint, format, typecheck, dead-code; coverage 80.16%.
- [ ] Validation by #53 reporter once a beta is cut. Logs are still useful — if the issue persists after this fix, they'll tell us which third path we missed.

Relates to #53.