### PR TITLE
feat: expose Ajax device serial and suggested_area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-beta.5] - 2026-04-27
+
+### Added
+- Each Ajax device entry in Home Assistant now exposes its hardware identifier as the device `serial_number`, so users can locate sensors physically without walking around triggering each one. Combined with the new `suggested_area` (mapped from the device's Ajax room), HA can auto-assign devices to matching areas the first time the integration is set up. (#55)
+
 ## [1.2.1-beta.4] - 2026-04-26
 
 ### Fixed

--- a/custom_components/aegis_ajax/alarm_control_panel.py
+++ b/custom_components/aegis_ajax/alarm_control_panel.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.const import CONF_FORCE_ARM, DOMAIN, MANUFACTURER, SecurityState
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -237,12 +238,15 @@ class AjaxAlarmControlPanel(CoordinatorEntity[AjaxCobrandedCoordinator], AlarmCo
         space = coordinator.spaces.get(space_id)
         hub_id = space.hub_id if space else space_id
         hub_device = coordinator.devices.get(hub_id)
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, hub_id)},
-            name=space.name if space else "Ajax Hub",
-            manufacturer=MANUFACTURER,
-            model=hub_device.device_type.replace("_", " ").title() if hub_device else "Hub",
-        )
+        if hub_device:
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, hub_id)},
+                name=space.name if space else "Ajax Hub",
+                manufacturer=MANUFACTURER,
+                model="Hub",
+            )
 
     def _get_options(self) -> dict[str, Any]:
         """Return config entry options, or empty dict if entry is unavailable."""

--- a/custom_components/aegis_ajax/api/models.py
+++ b/custom_components/aegis_ajax/api/models.py
@@ -37,6 +37,15 @@ class Space:
 
 
 @dataclass(frozen=True)
+class Room:
+    """Represents an Ajax room within a space."""
+
+    id: str
+    name: str
+    space_id: str
+
+
+@dataclass(frozen=True)
 class BatteryInfo:
     """Battery status for a device."""
 

--- a/custom_components/aegis_ajax/api/spaces.py
+++ b/custom_components/aegis_ajax/api/spaces.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from custom_components.aegis_ajax.api.models import Space
+from custom_components.aegis_ajax.api.models import Room, Space
 from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
 
 if TYPE_CHECKING:
@@ -54,6 +54,49 @@ class SpacesApi:
             return []
 
         return [self.parse_space(s) for s in response.success.spaces]
+
+    async def list_rooms(self, space_id: str) -> list[Room]:
+        """Return the rooms defined in the given space.
+
+        Reads the snapshot message from `SpaceService/stream` and closes
+        the stream — rooms rarely change so we don't keep it open.
+        """
+        from systems.ajax.api.mobile.v2.common.space import (  # noqa: PLC0415
+            space_locator_pb2,
+        )
+        from systems.ajax.api.mobile.v2.space import (  # noqa: PLC0415
+            space_endpoints_pb2_grpc,
+            stream_space_updates_request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = space_endpoints_pb2_grpc.SpaceServiceStub(channel)
+
+        request = stream_space_updates_request_pb2.StreamSpaceUpdatesRequest(
+            space_locator=space_locator_pb2.SpaceLocator(space_id=space_id),
+        )
+        stream = stub.stream(request, metadata=metadata, timeout=15)
+
+        rooms: list[Room] = []
+        try:
+            async for msg in stream:
+                if msg.HasField("failure"):
+                    _LOGGER.debug("Failed to stream space %s for rooms snapshot", space_id)
+                    break
+                if not msg.HasField("success"):
+                    continue
+                if msg.success.WhichOneof("success") != "snapshot":
+                    continue
+                for proto_room in msg.success.snapshot.rooms:
+                    rooms.append(Room(id=proto_room.id, name=proto_room.name, space_id=space_id))
+                break
+        finally:
+            cancel = getattr(stream, "cancel", None)
+            if callable(cancel):
+                cancel()
+
+        return rooms
 
     async def press_panic_button(
         self,

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -8,11 +8,10 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.const import EntityCategory
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -299,14 +298,7 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensor
         self._attr_translation_key = self._type_info.translation_key
         device = coordinator.devices.get(device_id)
         if device:
-            is_hub = device.device_type.startswith("hub")
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, device.id)},
-                name=device.name,
-                manufacturer=MANUFACTURER,
-                model=device.device_type.replace("_", " ").title(),
-                **({} if is_hub else {"via_device": (DOMAIN, device.hub_id)}),
-            )
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     @property
     def _device(self) -> Device | None:
@@ -366,14 +358,7 @@ class AjaxConnectivitySensor(CoordinatorEntity[AjaxCobrandedCoordinator], Binary
         self._attr_unique_id = f"aegis_ajax_{device_id}_connectivity"
         device = coordinator.devices.get(device_id)
         if device:
-            is_hub = device.device_type.startswith("hub")
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, device.id)},
-                name=device.name,
-                manufacturer=MANUFACTURER,
-                model=device.device_type.replace("_", " ").title(),
-                **({} if is_hub else {"via_device": (DOMAIN, device.hub_id)}),
-            )
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     @property
     def is_on(self) -> bool:
@@ -396,14 +381,7 @@ class AjaxProblemSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySenso
         self._attr_unique_id = f"aegis_ajax_{device_id}_problem"
         device = coordinator.devices.get(device_id)
         if device:
-            is_hub = device.device_type.startswith("hub")
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, device.id)},
-                name=device.name,
-                manufacturer=MANUFACTURER,
-                model=device.device_type.replace("_", " ").title(),
-                **({} if is_hub else {"via_device": (DOMAIN, device.hub_id)}),
-            )
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     @property
     def available(self) -> bool:
@@ -434,12 +412,7 @@ class _HubNetworkBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], Binar
         self._hub_id = hub_id
         hub_device = coordinator.devices.get(hub_id)
         if hub_device:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, hub_id)},
-                name=hub_device.name,
-                manufacturer=MANUFACTURER,
-                model=hub_device.device_type.replace("_", " ").title(),
-            )
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
 
     @property
     def available(self) -> bool:

--- a/custom_components/aegis_ajax/button.py
+++ b/custom_components/aegis_ajax/button.py
@@ -6,12 +6,11 @@ import logging
 from typing import TYPE_CHECKING
 
 from homeassistant.components.button import ButtonEntity
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.camera import PHOD_DEVICE_TYPES
-from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -58,13 +57,7 @@ class AjaxCapturePhotoButton(CoordinatorEntity[AjaxCobrandedCoordinator], Button
         self._attr_unique_id = f"aegis_ajax_{device_id}_capture_photo"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, device.id)},
-                name=device.name,
-                manufacturer=MANUFACTURER,
-                model=device.device_type.replace("_", " ").title(),
-                via_device=(DOMAIN, device.hub_id),
-            )
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     async def async_press(self) -> None:
         """Trigger photo capture and retrieve the photo URL."""

--- a/custom_components/aegis_ajax/camera.py
+++ b/custom_components/aegis_ajax/camera.py
@@ -7,11 +7,10 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components.camera import Camera
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -73,13 +72,7 @@ class AjaxCamera(CoordinatorEntity[AjaxCobrandedCoordinator], Camera):
         self._last_image: bytes | None = None
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, device.id)},
-                name=device.name,
-                manufacturer=MANUFACTURER,
-                model=device.device_type.replace("_", " ").title(),
-                via_device=(DOMAIN, device.hub_id),
-            )
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     @property
     def _device(self) -> Device | None:

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
     from custom_components.aegis_ajax.api.client import AjaxGrpcClient
     from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
-    from custom_components.aegis_ajax.api.models import Device, Space
+    from custom_components.aegis_ajax.api.models import Device, Room, Space
     from custom_components.aegis_ajax.notification import AjaxNotificationListener
 
 _LOGGER = logging.getLogger(__name__)
@@ -75,6 +75,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._media_api = MediaApi(client)
         self.spaces: dict[str, Space] = {}
         self.devices: dict[str, Device] = {}
+        self.rooms: dict[str, Room] = {}
         self.sim_info: dict[str, SimCardInfo] = {}
         self._notification_listener: AjaxNotificationListener | None = None
         self._stream_tasks: list[asyncio.Task[None]] = []
@@ -85,6 +86,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._optimistic_space_states: dict[str, tuple[float, Any]] = {}
         # SIM info is mostly static — cache and refresh once per hour
         self._sim_info_last_fetch: float = 0.0
+        # Rooms rarely change — cache and refresh once per hour. None means
+        # never fetched yet so the first poll always populates rooms.
+        self._rooms_last_fetch: float | None = None
         # HTS client for hub network data (ethernet, wifi, gsm, power)
         self._hts_client: HtsClient | None = None
         self._hts_task: asyncio.Task[None] | None = None
@@ -209,6 +213,26 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         if sim:
                             self.sim_info[space.hub_id] = sim
                 self._sim_info_last_fetch = now
+
+            # Fetch rooms for each space (cached, refresh once per hour). Used
+            # to set `suggested_area` on device entries so HA can auto-assign
+            # devices to areas matching their Ajax rooms.
+            rooms_refresh_interval = 3600.0
+            if (
+                self._rooms_last_fetch is None
+                or now - self._rooms_last_fetch > rooms_refresh_interval
+            ):
+                refreshed_rooms: dict[str, Room] = {}
+                for space_id in self.spaces:
+                    try:
+                        space_rooms = await self._spaces_api.list_rooms(space_id)
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.debug("Failed to fetch rooms for space %s", space_id, exc_info=True)
+                        continue
+                    for room in space_rooms:
+                        refreshed_rooms[room.id] = room
+                self.rooms = refreshed_rooms
+                self._rooms_last_fetch = now
 
             # Start persistent device streams on first update (once only)
             if not self._streams_started:

--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -1,0 +1,41 @@
+"""Shared entity helpers for the Aegis Ajax integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from custom_components.aegis_ajax.api.models import Device, Room
+
+
+def build_device_info(
+    device: Device,
+    rooms: Mapping[str, Room] | None = None,
+) -> DeviceInfo:
+    """Build a HA DeviceInfo for an Ajax device.
+
+    Sets `serial_number` from the Ajax device id (the hex hardware identifier
+    shown in the Ajax app) and `suggested_area` from the device's Ajax room
+    when available, so HA can auto-assign devices to matching areas.
+    """
+    is_hub = device.device_type.startswith("hub")
+    info = DeviceInfo(
+        identifiers={(DOMAIN, device.id)},
+        name=device.name,
+        manufacturer=MANUFACTURER,
+        model=device.device_type.replace("_", " ").title(),
+        serial_number=device.id,
+    )
+    if not is_hub:
+        info["via_device"] = (DOMAIN, device.hub_id)
+    if rooms and device.room_id:
+        room = rooms.get(device.room_id) if isinstance(rooms, dict) else None
+        if room is not None:
+            info["suggested_area"] = room.name
+    return info

--- a/custom_components/aegis_ajax/event.py
+++ b/custom_components/aegis_ajax/event.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.const import ALL_EVENT_TYPES, DOMAIN, MANUFACTURER
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -44,12 +45,16 @@ class AjaxSecurityEvent(CoordinatorEntity[AjaxCobrandedCoordinator], EventEntity
         hub_id = space.hub_id if space else space_id
         self._attr_unique_id = f"aegis_ajax_{hub_id}_event"
         self._attr_event_types = ALL_EVENT_TYPES
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, hub_id)},
-            name=space.name if space else "Ajax Hub",
-            manufacturer=MANUFACTURER,
-            model="Hub",
-        )
+        hub_device = coordinator.devices.get(hub_id)
+        if hub_device:
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, hub_id)},
+                name=space.name if space else "Ajax Hub",
+                manufacturer=MANUFACTURER,
+                model="Hub",
+            )
 
     @property
     def event_types(self) -> list[str]:

--- a/custom_components/aegis_ajax/light.py
+++ b/custom_components/aegis_ajax/light.py
@@ -10,12 +10,11 @@ from homeassistant.components.light import (  # type: ignore[attr-defined]
     ColorMode,
     LightEntity,
 )
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
-from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -70,13 +69,7 @@ class AjaxLight(CoordinatorEntity[AjaxCobrandedCoordinator], LightEntity):
         self._attr_unique_id = f"aegis_ajax_{device_id}_light_{channel}"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, device.id)},
-                name=device.name,
-                manufacturer=MANUFACTURER,
-                model=device.device_type.replace("_", " ").title(),
-                via_device=(DOMAIN, device.hub_id),
-            )
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     @property
     def _device(self) -> Device | None:

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.1-beta.4"
+    "version": "1.2.1-beta.5"
 }

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -8,11 +8,10 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -159,14 +158,7 @@ class AjaxSensor(CoordinatorEntity[AjaxCobrandedCoordinator], SensorEntity):
         self._attr_entity_registry_enabled_default = self._type_info.entity_registry_enabled_default
         device = coordinator.devices.get(device_id)
         if device:
-            is_hub = device.device_type.startswith("hub")
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, device.id)},
-                name=device.name,
-                manufacturer=MANUFACTURER,
-                model=device.device_type.replace("_", " ").title(),
-                **({} if is_hub else {"via_device": (DOMAIN, device.hub_id)}),
-            )
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     @property
     def _device(self) -> Device | None:
@@ -204,12 +196,7 @@ class AjaxSimBaseSensor(CoordinatorEntity[AjaxCobrandedCoordinator], SensorEntit
         # Find hub device to populate device_info
         hub_device = coordinator.devices.get(hub_id)
         if hub_device:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, hub_id)},
-                name=hub_device.name,
-                manufacturer=MANUFACTURER,
-                model=hub_device.device_type.replace("_", " ").title(),
-            )
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
 
     @property
     def _sim_info(self) -> SimCardInfo | None:
@@ -253,12 +240,7 @@ class _HubNetworkSensor(CoordinatorEntity[AjaxCobrandedCoordinator], SensorEntit
         self._hub_id = hub_id
         hub_device = coordinator.devices.get(hub_id)
         if hub_device:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, hub_id)},
-                name=hub_device.name,
-                manufacturer=MANUFACTURER,
-                model=hub_device.device_type.replace("_", " ").title(),
-            )
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
 
     @property
     def available(self) -> bool:

--- a/custom_components/aegis_ajax/switch.py
+++ b/custom_components/aegis_ajax/switch.py
@@ -6,12 +6,11 @@ import logging
 from typing import TYPE_CHECKING
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
-from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -88,13 +87,7 @@ class AjaxSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):
             self._attr_name = None
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, device.id)},
-                name=device.name,
-                manufacturer=MANUFACTURER,
-                model=device.device_type.replace("_", " ").title(),
-                via_device=(DOMAIN, device.hub_id),
-            )
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     @property
     def _device(self) -> Device | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.1-beta.4"
+version = "1.2.1-beta.5"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_alarm_control_panel.py
+++ b/tests/unit/test_alarm_control_panel.py
@@ -149,6 +149,7 @@ class TestAlarmControlPanel:
     def test_device_info_with_space(self) -> None:
         coordinator = MagicMock()
         coordinator.spaces = {"s1": self._make_space()}
+        coordinator.devices = {}
         panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
         assert panel._attr_device_info is not None
         assert (
@@ -159,6 +160,7 @@ class TestAlarmControlPanel:
     def test_device_info_without_space(self) -> None:
         coordinator = MagicMock()
         coordinator.spaces = {}
+        coordinator.devices = {}
         panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
         assert panel._attr_device_info is not None
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -94,6 +94,48 @@ class TestCoordinatorInit:
         coordinator = _make_coordinator()
         assert coordinator.hub_network == {}
 
+    def test_rooms_initially_empty(self) -> None:
+        coordinator = _make_coordinator()
+        assert coordinator.rooms == {}
+
+
+class TestRoomsRefresh:
+    @pytest.mark.asyncio
+    async def test_rooms_populated_from_spaces_api(self) -> None:
+        from custom_components.aegis_ajax.api.models import Room
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.list_rooms = AsyncMock(
+            return_value=[Room(id="r1", name="Kitchen", space_id="s1")]
+        )
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        assert coordinator.rooms == {"r1": Room(id="r1", name="Kitchen", space_id="s1")}
+
+    @pytest.mark.asyncio
+    async def test_rooms_failure_swallowed(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.list_rooms = AsyncMock(side_effect=RuntimeError("oops"))
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        # Should not raise — failure is downgraded to debug log
+        await coordinator._async_update_data()
+        assert coordinator.rooms == {}
+
 
 class TestAsyncUpdateData:
     @pytest.mark.asyncio

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -1,0 +1,70 @@
+"""Tests for the shared entity helpers (build_device_info)."""
+
+from __future__ import annotations
+
+from custom_components.aegis_ajax.api.models import Device, Room
+from custom_components.aegis_ajax.const import DOMAIN, DeviceState
+from custom_components.aegis_ajax.entity import build_device_info
+
+
+def _make_device(
+    *,
+    device_type: str = "door_protect",
+    room_id: str | None = None,
+    device_id: str = "ABC123",
+    hub_id: str = "HUB001",
+) -> Device:
+    return Device(
+        id=device_id,
+        hub_id=hub_id,
+        name="Front Door",
+        device_type=device_type,
+        room_id=room_id,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses={},
+        battery=None,
+    )
+
+
+class TestBuildDeviceInfo:
+    def test_includes_device_id_as_serial_number(self) -> None:
+        info = build_device_info(_make_device(device_id="DEV42"))
+        assert info["serial_number"] == "DEV42"
+
+    def test_identifiers_use_device_id(self) -> None:
+        info = build_device_info(_make_device(device_id="DEV42"))
+        assert (DOMAIN, "DEV42") in info["identifiers"]
+
+    def test_non_hub_device_has_via_device(self) -> None:
+        info = build_device_info(_make_device(device_type="door_protect", hub_id="HUB7"))
+        assert info["via_device"] == (DOMAIN, "HUB7")
+
+    def test_hub_device_has_no_via_device(self) -> None:
+        info = build_device_info(_make_device(device_type="hub_two_4g", device_id="HUB7"))
+        assert "via_device" not in info
+
+    def test_suggested_area_set_from_room(self) -> None:
+        rooms = {"r1": Room(id="r1", name="Kitchen", space_id="s1")}
+        info = build_device_info(_make_device(room_id="r1"), rooms)
+        assert info["suggested_area"] == "Kitchen"
+
+    def test_no_suggested_area_when_room_id_missing(self) -> None:
+        rooms = {"r1": Room(id="r1", name="Kitchen", space_id="s1")}
+        info = build_device_info(_make_device(room_id=None), rooms)
+        assert "suggested_area" not in info
+
+    def test_no_suggested_area_when_room_not_in_map(self) -> None:
+        rooms = {"r1": Room(id="r1", name="Kitchen", space_id="s1")}
+        info = build_device_info(_make_device(room_id="r2"), rooms)
+        assert "suggested_area" not in info
+
+    def test_no_suggested_area_when_rooms_omitted(self) -> None:
+        info = build_device_info(_make_device(room_id="r1"))
+        assert "suggested_area" not in info
+
+    def test_model_humanized_from_device_type(self) -> None:
+        info = build_device_info(_make_device(device_type="motion_protect_outdoor"))
+        assert info["model"] == "Motion Protect Outdoor"

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -14,6 +14,7 @@ class TestAjaxSecurityEvent:
         coordinator.spaces = {
             "space-1": MagicMock(hub_id="hub-1", name="Home"),
         }
+        coordinator.devices = {}
         return AjaxSecurityEvent(coordinator=coordinator, space_id="space-1")
 
     def test_unique_id(self) -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,6 +4,7 @@ from custom_components.aegis_ajax.api.models import (
     BatteryInfo,
     Device,
     DeviceCommand,
+    Room,
     Space,
 )
 from custom_components.aegis_ajax.const import (
@@ -102,6 +103,14 @@ class TestDevice:
             battery=None,
         )
         assert device.is_online is False
+
+
+class TestRoom:
+    def test_creation(self) -> None:
+        room = Room(id="r1", name="Kitchen", space_id="s1")
+        assert room.id == "r1"
+        assert room.name == "Kitchen"
+        assert room.space_id == "s1"
 
 
 class TestDeviceCommand:

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -117,9 +117,35 @@ class TestAjaxSensor:
         device = self._make_device({})
         coordinator = MagicMock()
         coordinator.devices = {"dev-1": device}
+        coordinator.rooms = {}
         sensor = AjaxSensor(coordinator=coordinator, device_id="dev-1", sensor_key="battery_level")
         assert sensor._attr_device_info is not None
         assert ("aegis_ajax", "dev-1") in sensor._attr_device_info["identifiers"]
+        # Issue #55: expose Ajax device id as HA serial number
+        assert sensor._attr_device_info.get("serial_number") == "dev-1"
+
+    def test_device_info_includes_suggested_area_from_room(self) -> None:
+        from custom_components.aegis_ajax.api.models import Room
+
+        device = Device(
+            id="dev-r",
+            hub_id="hub-1",
+            name="Hallway Sensor",
+            device_type="motion_protect",
+            room_id="room-9",
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+        coordinator = MagicMock()
+        coordinator.devices = {"dev-r": device}
+        coordinator.rooms = {"room-9": Room(id="room-9", name="Hallway", space_id="s1")}
+        sensor = AjaxSensor(coordinator=coordinator, device_id="dev-r", sensor_key="battery_level")
+        assert sensor._attr_device_info is not None
+        assert sensor._attr_device_info.get("suggested_area") == "Hallway"
 
     def test_device_info_without_device(self) -> None:
         coordinator = MagicMock()

--- a/tests/unit/test_spaces.py
+++ b/tests/unit/test_spaces.py
@@ -11,6 +11,9 @@ from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
 
 _FIND_SPACES_BASE = "v3.mobilegwsvc.service.find_user_spaces_with_pagination"
+_STREAM_SPACE_REQUEST = "systems.ajax.api.mobile.v2.space.stream_space_updates_request_pb2"
+_SPACE_GRPC = "systems.ajax.api.mobile.v2.space.space_endpoints_pb2_grpc"
+_SPACE_LOCATOR = "systems.ajax.api.mobile.v2.common.space.space_locator_pb2"
 
 
 class TestParseSpace:
@@ -136,6 +139,114 @@ class TestListSpaces:
             spaces = await api.list_spaces()
 
         assert spaces == []
+
+
+class _AsyncIter:
+    """Minimal async iterator that mirrors the grpc stream API used by SpacesApi."""
+
+    def __init__(self, src: list) -> None:
+        self._src = list(src)
+
+    def __aiter__(self) -> _AsyncIter:
+        return self
+
+    async def __anext__(self) -> object:
+        if not self._src:
+            raise StopAsyncIteration
+        return self._src.pop(0)
+
+    def cancel(self) -> None:
+        self._src.clear()
+
+
+def _async_iter(items: list) -> _AsyncIter:
+    return _AsyncIter(items)
+
+
+class TestListRooms:
+    @pytest.mark.asyncio
+    async def test_list_rooms_returns_snapshot_rooms(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        room1 = MagicMock()
+        room1.id = "r1"
+        room1.name = "Kitchen"
+        room2 = MagicMock()
+        room2.id = "r2"
+        room2.name = "Bedroom"
+
+        snapshot_msg = MagicMock()
+        snapshot_msg.HasField.side_effect = lambda f: f == "success"
+        snapshot_msg.success.WhichOneof.return_value = "snapshot"
+        snapshot_msg.success.snapshot.rooms = [room1, room2]
+
+        update_msg = MagicMock()
+        update_msg.HasField.side_effect = lambda f: f == "success"
+        update_msg.success.WhichOneof.return_value = "update"
+
+        stream = _async_iter([snapshot_msg, update_msg])
+        stub_instance = MagicMock()
+        stub_instance.stream = MagicMock(return_value=stream)
+        stub_class = MagicMock(return_value=stub_instance)
+
+        request_pb2 = MagicMock()
+        grpc_module = MagicMock(SpaceServiceStub=stub_class)
+        locator_pb2 = MagicMock()
+        locator_pb2.SpaceLocator = MagicMock(return_value="locator-marker")
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _STREAM_SPACE_REQUEST: request_pb2,
+                _SPACE_GRPC: grpc_module,
+                _SPACE_LOCATOR: locator_pb2,
+            },
+        ):
+            rooms = await api.list_rooms("space-1")
+
+        assert len(rooms) == 2
+        assert rooms[0].id == "r1"
+        assert rooms[0].name == "Kitchen"
+        assert rooms[0].space_id == "space-1"
+        assert rooms[1].name == "Bedroom"
+        # We close the stream after the first snapshot rather than draining it
+        assert stream._src == []
+        locator_pb2.SpaceLocator.assert_called_once_with(space_id="space-1")
+
+    @pytest.mark.asyncio
+    async def test_list_rooms_returns_empty_on_failure(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        failure_msg = MagicMock()
+        failure_msg.HasField.side_effect = lambda f: f == "failure"
+
+        stream = _async_iter([failure_msg])
+        stub_instance = MagicMock()
+        stub_instance.stream = MagicMock(return_value=stream)
+
+        request_pb2 = MagicMock()
+        grpc_module = MagicMock(SpaceServiceStub=MagicMock(return_value=stub_instance))
+        locator_pb2 = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _STREAM_SPACE_REQUEST: request_pb2,
+                _SPACE_GRPC: grpc_module,
+                _SPACE_LOCATOR: locator_pb2,
+            },
+        ):
+            rooms = await api.list_rooms("space-1")
+
+        assert rooms == []
 
 
 _PANIC_REQUEST = "systems.ajax.api.mobile.v2.space.press_panic_button_request_pb2"


### PR DESCRIPTION
## Summary
- Each Ajax device entry now carries `serial_number` (the device's hex hardware id, the same one shown under *Service info → Identifier* in the Ajax mobile app), so users can identify a specific sensor without walking around triggering each one.
- The Ajax room name is mapped to HA's `suggested_area`, so HA auto-assigns devices to matching areas the first time the integration is set up.
- DeviceInfo construction centralised in `entity.build_device_info`; rooms are fetched once per hour via `SpaceService.stream` and cached on the coordinator.

Refs #55

## Test plan
- [x] `ruff check` / `ruff format --check` pass
- [x] `mypy` passes
- [x] `vulture` passes (no new dead code)
- [x] 854 unit tests pass, coverage 80.45%
- [ ] Verify on real HA: open Settings → Devices, check a sensor exposes a Serial number and that devices land in an area matching their Ajax room on a fresh install
- [ ] Existing installs: confirm `suggested_area` does *not* override an area the user has already set manually (HA only applies it on first device creation)