### PR TITLE
fix: preserve streamed scalar sensor values

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -440,9 +440,7 @@ class DevicesApi:
                                                 else True
                                             )
                                         elif status_name == "wifi_signal_level_status":
-                                            payload["value"] = int(
-                                                status.wifi_signal_level_status
-                                            )
+                                            payload["value"] = int(status.wifi_signal_level_status)
 
                                         on_status_update(
                                             device_id,

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -369,10 +369,12 @@ class DevicesApi:
                                         except AttributeError:
                                             _LOGGER.debug("Could not extract device_id from update")
                                             continue
+
                                         status = update.status_update.status
                                         status_name = status.WhichOneof("status")
                                         if status_name is None:
                                             continue
+
                                         op = int(update.status_update.update_type)
                                         payload: dict[str, Any] = {"op": op}
                                         if status_name == "wire_input_status":
@@ -383,6 +385,65 @@ class DevicesApi:
                                                 payload["alarm_type"] = _ALARM_TYPE_NAMES.get(
                                                     int(ws.type), "unspecified"
                                                 )
+                                        elif status_name == "temperature":
+                                            payload["value"] = status.temperature.value
+                                        elif status_name == "life_quality":
+                                            lq = status.life_quality
+                                            values: dict[str, Any] = {}
+                                            if hasattr(lq, "actual_temperature"):
+                                                values["temperature"] = lq.actual_temperature
+                                            if hasattr(lq, "actual_humidity"):
+                                                values["humidity"] = lq.actual_humidity
+                                            if hasattr(lq, "actual_co2"):
+                                                values["co2"] = lq.actual_co2
+                                            if values:
+                                                payload["values"] = values
+                                        elif status_name == "signal_strength":
+                                            signal_int = int(
+                                                status.signal_strength.device_signal_level
+                                            )
+                                            payload["value"] = _SIGNAL_LEVEL_MAP.get(
+                                                signal_int, f"Unknown ({signal_int})"
+                                            )
+                                        elif status_name == "gsm_status":
+                                            gsm = status.gsm_status
+                                            gsm_int = int(gsm.type) if hasattr(gsm, "type") else 0
+                                            payload["values"] = {
+                                                "mobile_network_type": _GSM_TYPE_MAP.get(
+                                                    gsm_int, "Unknown"
+                                                ),
+                                                "gsm_connected": (
+                                                    int(gsm.status) == 2
+                                                    if hasattr(gsm, "status")
+                                                    else False
+                                                ),
+                                            }
+                                        elif status_name == "monitoring":
+                                            payload["value"] = (
+                                                bool(status.monitoring.cms_active)
+                                                if hasattr(status.monitoring, "cms_active")
+                                                else False
+                                            )
+                                        elif status_name == "sim_status":
+                                            sim_int = (
+                                                int(status.sim_status.sim_card_status)
+                                                if hasattr(status.sim_status, "sim_card_status")
+                                                else 0
+                                            )
+                                            payload["value"] = _SIM_STATUS_MAP.get(
+                                                sim_int, f"Unknown ({sim_int})"
+                                            )
+                                        elif status_name == "nfc":
+                                            payload["value"] = (
+                                                bool(status.nfc.enabled)
+                                                if hasattr(status.nfc, "enabled")
+                                                else True
+                                            )
+                                        elif status_name == "wifi_signal_level_status":
+                                            payload["value"] = int(
+                                                status.wifi_signal_level_status
+                                            )
+
                                         on_status_update(
                                             device_id,
                                             status_name,

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -373,6 +373,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             new_statuses.pop(key, None)
             if status_name == "wire_input_status":
                 new_statuses.pop("wire_input_alarm_type", None)
+        elif "values" in data:
+            new_statuses.update(data["values"])
+        elif "value" in data:
+            new_statuses[key] = data["value"]
         elif status_name == "wire_input_status" and "is_alert" in data:
             # Respect the actual alert boolean so the entity toggles back to
             # off when the wired contact closes (op=UPDATE with is_alert=False).

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -370,6 +370,29 @@ class TestStreamHandlers:
 
         assert coordinator.devices["d1"].statuses.get("high_temperature") is True
 
+    def test_handle_status_update_temperature_preserves_numeric_value(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+
+        coordinator._handle_status_update("d1", "temperature", {"op": 2, "value": 19})
+
+        assert coordinator.devices["d1"].statuses.get("temperature") == 19
+        assert coordinator.devices["d1"].statuses.get("temperature") is not True
+
+    def test_handle_status_update_life_quality_updates_temperature_humidity_and_co2(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+
+        coordinator._handle_status_update(
+            "d1",
+            "life_quality",
+            {"op": 2, "values": {"temperature": 21, "humidity": 58, "co2": 742}},
+        )
+
+        assert coordinator.devices["d1"].statuses.get("temperature") == 21
+        assert coordinator.devices["d1"].statuses.get("humidity") == 58
+        assert coordinator.devices["d1"].statuses.get("co2") == 742
+
     def test_handle_status_update_case_drilling_maps_correctly(self) -> None:
         coordinator = self._make_coordinator_with_stream()
         coordinator.devices["d1"] = _make_device("d1")

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -721,6 +721,49 @@ class TestStartDeviceStream:
         assert data["op"] == 3
 
     @pytest.mark.asyncio
+    async def test_status_update_temperature_preserves_numeric_value(self) -> None:
+        """Temperature updates must forward the actual reading, not boolean True."""
+        api = self._make_api()
+
+        update_msg = MagicMock()
+        update_msg.HasField.side_effect = lambda field: field == "success"
+        update_msg.success.WhichOneof.return_value = "updates"
+
+        single_update = MagicMock()
+        single_update.WhichOneof.return_value = "status_update"
+        single_update.device_id.hub_light_device_id.device_id = "dev-temp"
+        single_update.status_update.status.WhichOneof.return_value = "temperature"
+        single_update.status_update.status.temperature.value = 19
+        single_update.status_update.update_type = 2  # UPDATE
+
+        update_msg.success.updates.updates = [single_update]
+
+        async def _aiter() -> AsyncGenerator[MagicMock, None]:
+            yield update_msg
+
+        status_received: list[tuple[str, str, dict]] = []
+
+        def on_snap(devices: list) -> None:
+            pass
+
+        def on_status(device_id: str, status_name: str, data: dict) -> None:
+            status_received.append((device_id, status_name, data))
+
+        with (
+            patch.dict("sys.modules", _make_stream_patch_modules(_aiter)),
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            mock_sleep.side_effect = asyncio.CancelledError()
+            task = await api.start_device_stream("space-1", on_snap, on_status)
+            with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+                await asyncio.wait_for(task, timeout=2.0)
+
+        assert len(status_received) == 1
+        _, status_name, data = status_received[0]
+        assert status_name == "temperature"
+        assert data == {"op": 2, "value": 19}
+
+    @pytest.mark.asyncio
     async def test_snapshot_update_calls_on_devices_snapshot(self) -> None:
         """snapshot_update in Updates triggers on_devices_snapshot."""
         api = self._make_api()


### PR DESCRIPTION
## Summary

Fix real-time stream handling for non-binary sensor values so they are preserved as scalar/structured payloads instead of being coerced to `True`.

This fixes the visible `1 °C` symptom reported in `DoorProtect Plus` and `MotionCam` temperature entities, where a streamed `temperature` update could end up stored as `True`, which Home Assistant then renders as `1`.

Related to #59

## What changed

- Preserve scalar payloads for streamed `temperature` updates
- Preserve structured values for streamed `life_quality` updates:
  - `temperature`
  - `humidity`
  - `co2`
- Preserve other streamed non-binary values that already have snapshot parsing:
  - `signal_strength`
  - `gsm_status`
  - `monitoring`
  - `sim_status`
  - `nfc`
  - `wifi_signal_level_status`
- Update the coordinator to apply `value` / `values` payloads directly instead of treating every non-remove update as a boolean flag

## Why

Snapshot parsing already handled numeric temperature correctly, but the real-time stream path was forwarding many updates as just `{ "op": ... }`. The coordinator then treated generic ADD/UPDATE events as `True`, corrupting in-memory state for non-binary statuses until the next full snapshot refresh.

## Tests

- Added stream-level test that verifies `temperature` status updates forward the numeric value
- Added coordinator-level test that verifies `temperature` does not become `True`
- Added coordinator-level test for `life_quality` multi-value updates

## Verification

Validated with focused unit tests in Docker:

- `tests/unit/test_devices.py`
- `tests/unit/test_coordinator.py`
