### PR TITLE
chore: bump version to 1.2.1-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-beta.6] - 2026-04-27
+
+### Fixed
+- Numeric/structured sensor values streamed in real time (temperature, humidity, CO2, signal strength, GSM/SIM/NFC/Wi-Fi diagnostics) were being overwritten with `True` whenever an ADD/UPDATE event arrived between snapshots, causing temperature entities to drop to `1 °C` intermittently on `DoorProtect Plus` and `MotionCam` devices among others. The stream parser now extracts the actual values (mirroring the snapshot path) and the coordinator applies them as scalars or sub-keys instead of coercing every non-binary update to a boolean. (#59)
+
 ## [1.2.1-beta.5] - 2026-04-27
 
 ### Added

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.1-beta.5"
+    "version": "1.2.1-beta.6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.1-beta.5"
+version = "1.2.1-beta.6"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release bump for the streamed scalar sensor values fix that landed via #60.

## Changelog entry
> Numeric/structured sensor values streamed in real time (temperature, humidity, CO2, signal strength, GSM/SIM/NFC/Wi-Fi diagnostics) were being overwritten with `True` whenever an ADD/UPDATE event arrived between snapshots, causing temperature entities to drop to `1 °C` intermittently on `DoorProtect Plus` and `MotionCam` devices among others. The stream parser now extracts the actual values (mirroring the snapshot path) and the coordinator applies them as scalars or sub-keys instead of coercing every non-binary update to a boolean. (#59)

## Test plan
- [x] CI green on `main` after #60 merge
- [ ] Tag-based release workflow publishes the prerelease automatically once this is merged