### PR TITLE
fix: clear sub-keys on REMOVE for multi-value streamed statuses

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -50,6 +50,16 @@ _STATUS_KEY_MAP: dict[str, str] = {
     "wire_input_status": "wire_input_alert",
 }
 
+# Statuses whose snapshot parser writes more than the single mapped key.
+# Used by the REMOVE op so stale sub-keys don't linger after the hub drops
+# the parent status from the stream.
+_STATUS_EXTRA_KEYS: dict[str, tuple[str, ...]] = {
+    "motion_detected": ("motion_detected_at",),
+    "life_quality": ("temperature", "humidity", "co2"),
+    "gsm_status": ("mobile_network_type", "gsm_connected"),
+    "wire_input_status": ("wire_input_alarm_type",),
+}
+
 
 class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def __init__(
@@ -371,8 +381,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if op == 3:  # REMOVE
             new_statuses.pop(key, None)
-            if status_name == "wire_input_status":
-                new_statuses.pop("wire_input_alarm_type", None)
+            for sub_key in _STATUS_EXTRA_KEYS.get(status_name, ()):
+                new_statuses.pop(sub_key, None)
         elif "values" in data:
             new_statuses.update(data["values"])
         elif "value" in data:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -479,6 +479,76 @@ class TestStreamHandlers:
         assert "wire_input_alert" not in coordinator.devices["d1"].statuses
         assert "wire_input_alarm_type" not in coordinator.devices["d1"].statuses
 
+    def test_handle_status_update_life_quality_remove_drops_all_sub_keys(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        device = Device(
+            id="d1",
+            hub_id="hub-1",
+            name="Life Quality",
+            device_type="life_quality",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={"temperature": 21, "humidity": 58, "co2": 742},
+            battery=None,
+        )
+        coordinator.devices["d1"] = device
+
+        coordinator._handle_status_update("d1", "life_quality", {"op": 3})
+
+        statuses = coordinator.devices["d1"].statuses
+        assert "temperature" not in statuses
+        assert "humidity" not in statuses
+        assert "co2" not in statuses
+
+    def test_handle_status_update_gsm_status_remove_drops_all_sub_keys(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        device = Device(
+            id="d1",
+            hub_id="hub-1",
+            name="Hub",
+            device_type="hub_two_4g",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={"mobile_network_type": "4G", "gsm_connected": True},
+            battery=None,
+        )
+        coordinator.devices["d1"] = device
+
+        coordinator._handle_status_update("d1", "gsm_status", {"op": 3})
+
+        statuses = coordinator.devices["d1"].statuses
+        assert "mobile_network_type" not in statuses
+        assert "gsm_connected" not in statuses
+
+    def test_handle_status_update_motion_remove_drops_detected_at(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        device = Device(
+            id="d1",
+            hub_id="hub-1",
+            name="Motion",
+            device_type="motion_protect",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={"motion_detected": True, "motion_detected_at": 1700000000},
+            battery=None,
+        )
+        coordinator.devices["d1"] = device
+
+        coordinator._handle_status_update("d1", "motion_detected", {"op": 3})
+
+        statuses = coordinator.devices["d1"].statuses
+        assert "motion_detected" not in statuses
+        assert "motion_detected_at" not in statuses
+
     def test_handle_status_update_unknown_device_is_ignored(self) -> None:
         coordinator = self._make_coordinator_with_stream()
         # No devices in coordinator


### PR DESCRIPTION
## Summary
REMOVE events on the device stream only popped the parent status name. For statuses whose snapshot parser fans out into multiple `device.statuses` keys this was a no-op, leaving stale values until the next full snapshot rewrote them.

Affected statuses:
- `life_quality` → leaked `temperature`, `humidity`, `co2`
- `gsm_status` → leaked `mobile_network_type`, `gsm_connected`
- `motion_detected` → leaked `motion_detected_at`

Centralised the mapping in a new `_STATUS_EXTRA_KEYS` table in `coordinator.py` and looped over it in the REMOVE branch. The existing `wire_input_status` → `wire_input_alarm_type` special case folds into the same table.

Refs #61

## Test plan
- [x] Three new unit tests cover REMOVE for `life_quality`, `gsm_status`, `motion_detected`
- [x] Existing `wire_input_status` REMOVE test still green via the same path
- [x] `ruff` / `ruff format --check` / `mypy` / `vulture` clean
- [x] 860 unit tests pass, coverage 80.03%
- [ ] Verify on real HA: arm/disarm + motion events, confirm life-quality readings don't leak across sensor offline events