### PR TITLE
chore: bump version to 1.2.1-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-beta.7] - 2026-04-27
+
+### Fixed
+- REMOVE events on the device stream now clear every `device.statuses` key the snapshot parser writes for that status, not just the one matching the proto field name. Previously `life_quality`, `gsm_status`, and `motion_detected` left stale sub-keys behind (`temperature`/`humidity`/`co2`, `mobile_network_type`/`gsm_connected`, `motion_detected_at`) that lingered until the next full snapshot. Centralised the parent-to-extra-keys mapping so future additions stay in sync. (#61)
+
 ## [1.2.1-beta.6] - 2026-04-27
 
 ### Fixed

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.1-beta.6"
+    "version": "1.2.1-beta.7"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.1-beta.6"
+version = "1.2.1-beta.7"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release bump for the multi-value REMOVE op fix that landed via #63.

## Changelog entry
> REMOVE events on the device stream now clear every `device.statuses` key the snapshot parser writes for that status, not just the one matching the proto field name. Previously `life_quality`, `gsm_status`, and `motion_detected` left stale sub-keys behind (`temperature`/`humidity`/`co2`, `mobile_network_type`/`gsm_connected`, `motion_detected_at`) that lingered until the next full snapshot. (#61)

## Test plan
- [x] CI green on `main` after #63 merge
- [ ] Tag-based release workflow publishes the prerelease automatically once this is merged