### PR TITLE
fix: expose intrusion sensor on Transmitter Jeweller devices

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -56,7 +56,7 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
 # Devices whose single "alert" entity should OR-reduce several hub status
 # oneofs into one state, because Ajax hub firmwares disagree on which oneof
 # carries the open/closed transition for wired inputs.
-_WIRE_INPUT_DEVICE_TYPES: frozenset[str] = frozenset({"wire_input", "wire_input_mt"})
+_WIRE_INPUT_DEVICE_TYPES: frozenset[str] = frozenset({"wire_input", "wire_input_mt", "transmitter"})
 _WIRE_INPUT_ALERT_SOURCES: tuple[str, ...] = (
     "wire_input_alert",
     "external_contact_broken",
@@ -215,7 +215,7 @@ _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
     "range_extender": [],
     "range_extender_2": [],
     "range_extender_2_fire": ["smoke_detected", "high_temperature", "tamper"],
-    "transmitter": ["tamper"],
+    "transmitter": ["tamper", "wire_input_alert"],
     "multi_transmitter": ["tamper"],
     "multi_transmitter_fibra": ["tamper"],
     "wire_input": ["tamper", "wire_input_alert"],

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -487,6 +487,14 @@ class TestDeviceTypeSensors:
     def test_wire_input_keeps_tamper(self) -> None:
         assert "tamper" in _DEVICE_TYPE_SENSORS["wire_input"]
 
+    def test_transmitter_has_wire_input_alert_sensor(self) -> None:
+        # Issue #65: Transmitter Jeweller exposes only tamper, not the
+        # intrusion line carried by the wired sensor it bridges.
+        assert "wire_input_alert" in _DEVICE_TYPE_SENSORS["transmitter"]
+
+    def test_transmitter_keeps_tamper(self) -> None:
+        assert "tamper" in _DEVICE_TYPE_SENSORS["transmitter"]
+
 
 class TestWireInputAlertSensor:
     """Binary sensor behaviour for wired-input alerts (MultiTransmitter children)."""
@@ -571,6 +579,32 @@ class TestWireInputAlertSensor:
             coordinator=coordinator, device_id="wi-1", status_key="wire_input_alert"
         )
         assert sensor.is_on is False
+
+    def test_transmitter_wire_input_alert_or_reduces_external_contact(self) -> None:
+        # Issue #65: the Transmitter Jeweller may surface the intrusion line
+        # via any of wire_input_status / external_contact_broken /
+        # external_contact_alert depending on hub firmware. The unified
+        # entity must reflect any of them.
+        for source in ("wire_input_alert", "external_contact_broken", "external_contact_alert"):
+            device = Device(
+                id="tr-1",
+                hub_id="hub-1",
+                name="Transmitter",
+                device_type="transmitter",
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={source: True},
+                battery=None,
+            )
+            coordinator = MagicMock()
+            coordinator.devices = {"tr-1": device}
+            sensor = AjaxBinarySensor(
+                coordinator=coordinator, device_id="tr-1", status_key="wire_input_alert"
+            )
+            assert sensor.is_on is True, f"OR-reduce missed {source} on transmitter"
 
     def test_door_protect_external_contact_broken_not_routed_as_alert(self) -> None:
         # Sanity check: the composite OR must apply ONLY to wire_input devices,


### PR DESCRIPTION
## Summary
The Transmitter Jeweller (Ajax `transmitter` object type) is the wireless bridge that connects an external wired sensor (door contact, magnetic, third-party PIR…) to an Ajax hub. Before this PR we only exposed the case tamper for it, so the user had no entity in HA reflecting whether the bridged sensor was triggered.

The fix:
- Added `wire_input_alert` to the `transmitter` device's sensor set.
- Added `transmitter` to `_WIRE_INPUT_DEVICE_TYPES` so the entity OR-reduces the three oneofs hub firmwares may use for the wired alert (`wire_input_status`, `external_contact_broken`, `external_contact_alert`), mirroring how `wire_input` / `wire_input_mt` are already handled.

If a given Ajax cloud setup surfaces the alert through a child `wire_input` device instead of the parent transmitter, the new entity stays at off — no regression.

Refs #65

## Test plan
- [x] Two new unit tests cover the device-type sensor list and the OR-reduce across all three sources for `transmitter`
- [x] Existing `wire_input_mt` / `wire_input` / DoorProtect tests still pass (the OR-reduce continues to NOT apply to DoorProtect)
- [x] `ruff` / `ruff format --check` / `mypy` / `vulture` clean
- [x] 863 unit tests pass, coverage 80.03%
- [ ] Verify on a real setup with a Transmitter Jeweller bridging a third-party sensor: arm the system, trigger the wired sensor, confirm the new `wire_input_alert` entity flips on