### PR TITLE
chore: bump version to 1.2.1-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-beta.8] - 2026-04-27
+
+### Fixed
+- The Transmitter Jeweller (Ajax `transmitter`), which bridges a third-party wired sensor to the hub, now exposes a `wire_input_alert` binary sensor in addition to the case tamper, so the intrusion line of the bridged sensor is reflected in HA. The entity OR-reduces the three oneofs hub firmwares may use to signal the wired alert (`wire_input_status`, `external_contact_broken`, `external_contact_alert`), matching the existing handling for `wire_input` / `wire_input_mt`. (#65)
+
 ## [1.2.1-beta.7] - 2026-04-27
 
 ### Fixed

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.1-beta.7"
+    "version": "1.2.1-beta.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.1-beta.7"
+version = "1.2.1-beta.8"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release bump for the Transmitter Jeweller intrusion sensor fix that landed via #66.

## Changelog entry
> The Transmitter Jeweller (Ajax `transmitter`), which bridges a third-party wired sensor to the hub, now exposes a `wire_input_alert` binary sensor in addition to the case tamper, so the intrusion line of the bridged sensor is reflected in HA. The entity OR-reduces the three oneofs hub firmwares may use to signal the wired alert (`wire_input_status`, `external_contact_broken`, `external_contact_alert`), matching the existing handling for `wire_input` / `wire_input_mt`. (#65)

## Test plan
- [x] CI green on `main` after #66 merge
- [ ] Tag-based release workflow publishes the prerelease automatically once this is merged