### PR TITLE
fix: route Transmitter Jeweller wired alert through wire_input_alert

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -228,12 +228,19 @@ class DevicesApi:
                 result["external_contact_broken"] = True
             elif which == "external_contact_alert":
                 result["external_contact_alert"] = True
-            elif which == "wire_input_status":
-                ws = status.wire_input_status
-                result["wire_input_alert"] = bool(ws.is_alert) if hasattr(ws, "is_alert") else True
-                if hasattr(ws, "type"):
+            elif which in ("wire_input_status", "transmitter_status"):
+                # Both oneofs share the same shape (is_alert + CustomAlarmType)
+                # but different devices use different ones: WireInput / WireInputMt
+                # use `wire_input_status`, the wireless Transmitter Jeweller
+                # uses `transmitter_status`. Map both to the same internal keys
+                # so the unified safety entity reflects either source.
+                sub = getattr(status, which)
+                result["wire_input_alert"] = (
+                    bool(sub.is_alert) if hasattr(sub, "is_alert") else True
+                )
+                if hasattr(sub, "type"):
                     result["wire_input_alarm_type"] = _ALARM_TYPE_NAMES.get(
-                        int(ws.type), "unspecified"
+                        int(sub.type), "unspecified"
                     )
             elif which == "case_drilling_detected":
                 result["case_drilling"] = True
@@ -377,13 +384,16 @@ class DevicesApi:
 
                                         op = int(update.status_update.update_type)
                                         payload: dict[str, Any] = {"op": op}
-                                        if status_name == "wire_input_status":
-                                            ws = status.wire_input_status
-                                            if hasattr(ws, "is_alert"):
-                                                payload["is_alert"] = bool(ws.is_alert)
-                                            if hasattr(ws, "type"):
+                                        if status_name in (
+                                            "wire_input_status",
+                                            "transmitter_status",
+                                        ):
+                                            sub = getattr(status, status_name)
+                                            if hasattr(sub, "is_alert"):
+                                                payload["is_alert"] = bool(sub.is_alert)
+                                            if hasattr(sub, "type"):
                                                 payload["alarm_type"] = _ALARM_TYPE_NAMES.get(
-                                                    int(ws.type), "unspecified"
+                                                    int(sub.type), "unspecified"
                                                 )
                                         elif status_name == "temperature":
                                             payload["value"] = status.temperature.value

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -48,6 +48,7 @@ _STATUS_KEY_MAP: dict[str, str] = {
     "glass_break_detected": "glass_break",
     "vibration_detected": "vibration",
     "wire_input_status": "wire_input_alert",
+    "transmitter_status": "wire_input_alert",
 }
 
 # Statuses whose snapshot parser writes more than the single mapped key.
@@ -58,6 +59,7 @@ _STATUS_EXTRA_KEYS: dict[str, tuple[str, ...]] = {
     "life_quality": ("temperature", "humidity", "co2"),
     "gsm_status": ("mobile_network_type", "gsm_connected"),
     "wire_input_status": ("wire_input_alarm_type",),
+    "transmitter_status": ("wire_input_alarm_type",),
 }
 
 
@@ -387,9 +389,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             new_statuses.update(data["values"])
         elif "value" in data:
             new_statuses[key] = data["value"]
-        elif status_name == "wire_input_status" and "is_alert" in data:
+        elif status_name in ("wire_input_status", "transmitter_status") and "is_alert" in data:
             # Respect the actual alert boolean so the entity toggles back to
             # off when the wired contact closes (op=UPDATE with is_alert=False).
+            # Both oneofs map to the same `wire_input_alert` key via
+            # `_STATUS_KEY_MAP`.
             new_statuses[key] = bool(data["is_alert"])
             if "alarm_type" in data:
                 new_statuses["wire_input_alarm_type"] = data["alarm_type"]

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -479,6 +479,64 @@ class TestStreamHandlers:
         assert "wire_input_alert" not in coordinator.devices["d1"].statuses
         assert "wire_input_alarm_type" not in coordinator.devices["d1"].statuses
 
+    def test_handle_status_update_transmitter_status_alert_writes_wire_input_alert(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+
+        coordinator._handle_status_update(
+            "d1",
+            "transmitter_status",
+            {"op": 2, "is_alert": True, "alarm_type": "intrusion"},
+        )
+
+        statuses = coordinator.devices["d1"].statuses
+        assert statuses.get("wire_input_alert") is True
+        assert statuses.get("wire_input_alarm_type") == "intrusion"
+
+    def test_handle_status_update_transmitter_status_clear_writes_false(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        device = Device(
+            id="d1",
+            hub_id="hub-1",
+            name="Transmitter",
+            device_type="transmitter",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={"wire_input_alert": True, "wire_input_alarm_type": "intrusion"},
+            battery=None,
+        )
+        coordinator.devices["d1"] = device
+
+        coordinator._handle_status_update("d1", "transmitter_status", {"op": 2, "is_alert": False})
+
+        assert coordinator.devices["d1"].statuses.get("wire_input_alert") is False
+
+    def test_handle_status_update_transmitter_status_remove_drops_both_keys(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        device = Device(
+            id="d1",
+            hub_id="hub-1",
+            name="Transmitter",
+            device_type="transmitter",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={"wire_input_alert": True, "wire_input_alarm_type": "intrusion"},
+            battery=None,
+        )
+        coordinator.devices["d1"] = device
+
+        coordinator._handle_status_update("d1", "transmitter_status", {"op": 3})
+
+        statuses = coordinator.devices["d1"].statuses
+        assert "wire_input_alert" not in statuses
+        assert "wire_input_alarm_type" not in statuses
+
     def test_handle_status_update_life_quality_remove_drops_all_sub_keys(self) -> None:
         coordinator = self._make_coordinator_with_stream()
         device = Device(

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -321,6 +321,27 @@ class TestStatusParser:
         assert result.get("wire_input_alert") is True
         assert result.get("wire_input_alarm_type") == "unspecified"
 
+    def test_transmitter_status_alerting(self) -> None:
+        # Issue #65 follow-up: the Transmitter Jeweller emits its own oneof
+        # `transmitter_status` (proto field 75) with the same shape as
+        # `wire_input_status`. It must populate the same wire_input_alert key
+        # so the unified safety entity reflects the bridged sensor.
+        status = MagicMock()
+        status.WhichOneof.return_value = "transmitter_status"
+        status.transmitter_status.is_alert = True
+        status.transmitter_status.type = 1  # INTRUSION
+        result = DevicesApi._parse_statuses([status])
+        assert result.get("wire_input_alert") is True
+        assert result.get("wire_input_alarm_type") == "intrusion"
+
+    def test_transmitter_status_not_alerting(self) -> None:
+        status = MagicMock()
+        status.WhichOneof.return_value = "transmitter_status"
+        status.transmitter_status.is_alert = False
+        status.transmitter_status.type = 0
+        result = DevicesApi._parse_statuses([status])
+        assert result.get("wire_input_alert") is False
+
     def test_case_drilling_detected(self) -> None:
         status = MagicMock()
         status.WhichOneof.return_value = "case_drilling_detected"
@@ -762,6 +783,52 @@ class TestStartDeviceStream:
         _, status_name, data = status_received[0]
         assert status_name == "temperature"
         assert data == {"op": 2, "value": 19}
+
+    @pytest.mark.asyncio
+    async def test_status_update_transmitter_status_forwards_alert_and_type(self) -> None:
+        """transmitter_status updates must forward is_alert + alarm_type, not boolean True."""
+        api = self._make_api()
+
+        update_msg = MagicMock()
+        update_msg.HasField.side_effect = lambda field: field == "success"
+        update_msg.success.WhichOneof.return_value = "updates"
+
+        single_update = MagicMock()
+        single_update.WhichOneof.return_value = "status_update"
+        single_update.device_id.hub_light_device_id.device_id = "dev-tr"
+        single_update.status_update.status.WhichOneof.return_value = "transmitter_status"
+        single_update.status_update.status.transmitter_status.is_alert = True
+        single_update.status_update.status.transmitter_status.type = 1  # INTRUSION
+        single_update.status_update.update_type = 2  # UPDATE
+
+        update_msg.success.updates.updates = [single_update]
+
+        async def _aiter() -> AsyncGenerator[MagicMock, None]:
+            yield update_msg
+
+        status_received: list[tuple[str, str, dict]] = []
+
+        def on_snap(devices: list) -> None:
+            pass
+
+        def on_status(device_id: str, status_name: str, data: dict) -> None:
+            status_received.append((device_id, status_name, data))
+
+        with (
+            patch.dict("sys.modules", _make_stream_patch_modules(_aiter)),
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            mock_sleep.side_effect = asyncio.CancelledError()
+            task = await api.start_device_stream("space-1", on_snap, on_status)
+            with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+                await asyncio.wait_for(task, timeout=2.0)
+
+        assert len(status_received) == 1
+        _, status_name, data = status_received[0]
+        assert status_name == "transmitter_status"
+        assert data["op"] == 2
+        assert data["is_alert"] is True
+        assert data["alarm_type"] == "intrusion"
 
     @pytest.mark.asyncio
     async def test_snapshot_update_calls_on_devices_snapshot(self) -> None:


### PR DESCRIPTION
## Summary
Follow-up to #66. Reporter @K3ndaar confirmed the new `wire_input_alert` entity appears on the Transmitter Jeweller after `v1.2.1-beta.8`, but doesn't flip when the bridged sensor triggers. Their diagnostics dump shows the device's `statuses` gain a key called `transmitter_status` on alert and lose it on safe — that's the proto oneof we weren't handling.

The Transmitter Jeweller emits the bridged sensor's alert through the **`transmitter_status` oneof (proto field 75)**, not `wire_input_status` (field 74). Both share the same shape (`is_alert` + `CustomAlarmType type`), but our snapshot parser, stream forwarder, and coordinator only recognised `wire_input_status`. The alert was being stored as `transmitter_status: True` (generic boolean fallback), which nothing reads, so the entity stayed at off.

The fix:
- `api/devices.py` `_parse_statuses` and `start_device_stream` now treat both oneofs identically, populating the same `wire_input_alert` / `wire_input_alarm_type` keys.
- `coordinator.py` `_STATUS_KEY_MAP` adds `transmitter_status → wire_input_alert` so ADD/UPDATE events arriving through the stream land on the right key.
- `_STATUS_EXTRA_KEYS` extends REMOVE to also drop `wire_input_alarm_type` for `transmitter_status`, matching `wire_input_status`.

The OR-reduce in `binary_sensor.py:_WIRE_INPUT_DEVICE_TYPES` already includes `transmitter` (added in #66), so once the value lands in `wire_input_alert` the entity reflects it.

Refs #65

## Test plan
- [x] 6 new unit tests covering snapshot parse, stream forwarding, coordinator update (alert + clear), and REMOVE op for `transmitter_status`
- [x] Existing `wire_input_status` tests still pass (the unified branches preserve behaviour)
- [x] `ruff` / `ruff format --check` / `mypy` / `vulture` clean
- [x] 869 unit tests pass, coverage 80.19%
- [ ] Verify on a real Transmitter Jeweller bridging a third-party sensor (per @K3ndaar's setup): trigger the bridged sensor, confirm `wire_input_alert` flips on, return to safe and confirm it flips off