### PR TITLE
chore: bump version to 1.2.1-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-beta.9] - 2026-04-27
+
+### Fixed
+- The Transmitter Jeweller exposed the new `wire_input_alert` entity from beta.8 but it never toggled, because the device emits the bridged sensor's alert through the `transmitter_status` proto oneof (field 75) rather than `wire_input_status` (field 74). Both oneofs are now handled identically by the snapshot parser, the stream forwarder, and the coordinator's status update / REMOVE paths, so the entity reflects the wired sensor's state in real time. (#65)
+
 ## [1.2.1-beta.8] - 2026-04-27
 
 ### Fixed

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.1-beta.8"
+    "version": "1.2.1-beta.9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.1-beta.8"
+version = "1.2.1-beta.9"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release bump for the Transmitter Jeweller `transmitter_status` handler that landed via #69.

## Changelog entry
> The Transmitter Jeweller exposed the new `wire_input_alert` entity from beta.8 but it never toggled, because the device emits the bridged sensor's alert through the `transmitter_status` proto oneof (field 75) rather than `wire_input_status` (field 74). Both oneofs are now handled identically by the snapshot parser, the stream forwarder, and the coordinator's status update / REMOVE paths, so the entity reflects the wired sensor's state in real time. (#65)

## Test plan
- [x] CI green on `main` after #69 merge
- [ ] Tag-based release workflow publishes the prerelease automatically once this is merged