### PR TITLE
feat: apply security_state from FCM arm/disarm push without poll wait

### DIFF
--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -167,6 +167,24 @@ DEFAULT_AUTO_CREATE_LABELS = True
 
 EVENT_DOMAIN = f"{DOMAIN}_event"
 
+# Map HubEventTag oneof field names to the resulting space `security_state`
+# when the corresponding push event arrives. Used to refresh the alarm panel
+# instantly from the FCM payload instead of waiting for the next poll.
+# `group_*` tags are intentionally omitted — they only affect a subgroup, so
+# the resulting space-level state (PARTIALLY_ARMED, ARMED, …) depends on the
+# other groups; let the next poll resolve it.
+RAW_TAG_TO_SECURITY_STATE: dict[str, SecurityState] = {
+    "arm": SecurityState.ARMED,
+    "arm_attempt": SecurityState.ARMED,
+    "arm_with_malfunctions": SecurityState.ARMED,
+    "disarm": SecurityState.DISARMED,
+    "duress_disarm": SecurityState.DISARMED,
+    "night_mode_on": SecurityState.NIGHT_MODE,
+    "night_mode_off": SecurityState.DISARMED,
+    "duress_night_mode_off": SecurityState.DISARMED,
+}
+
+
 # Map HubEventTag oneof field names to simplified HA event types
 HUB_EVENT_TAG_MAP: dict[str, str] = {
     # Arming

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -353,6 +353,35 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except Exception:
                 _LOGGER.exception("Failed to start device stream for space %s", space_id)
 
+    def apply_push_security_state(self, space_id: str, new_state: Any) -> None:  # noqa: ANN401
+        """Apply a security_state derived from an FCM arm/disarm push event.
+
+        Updates `coordinator.spaces[space_id]` in-memory and immediately notifies
+        listeners via `async_set_updated_data`, so the alarm panel reflects the
+        change without waiting for the next poll cycle. No-ops when:
+        - the space is unknown to the coordinator,
+        - the new state matches the current state,
+        - an HA-initiated optimistic state is still active for that space (the
+          push is treated as racing with our own command and ignored to avoid
+          flicker; the next poll reconciles).
+        """
+        import time  # noqa: PLC0415
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        space = self.spaces.get(space_id)
+        if space is None:
+            return
+        # `time.monotonic()` is the same source `asyncio.BaseEventLoop.time()`
+        # uses for the optimistic-state expiry stored from arm/disarm callsites.
+        now = time.monotonic()
+        opt = self._optimistic_space_states.get(space_id)
+        if opt and opt[0] > now:
+            return
+        if space.security_state == new_state:
+            return
+        self.spaces[space_id] = dc_replace(space, security_state=new_state)
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
     def _handle_devices_snapshot(self, devices: list[Device]) -> None:
         """Handle initial snapshot or full device snapshot update from stream."""
         for device in devices:

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.storage import Store
 from custom_components.aegis_ajax.const import (
     DOMAIN,
     HUB_EVENT_TAG_MAP,
+    RAW_TAG_TO_SECURITY_STATE,
 )
 
 if TYPE_CHECKING:
@@ -284,12 +285,33 @@ class AjaxNotificationListener:
                 target_space = self._find_space_for_event(raw)
                 if target_space:
                     self._coordinator.fire_push_event(target_space, event_type, event_data)
+                    self._apply_security_state_from_event(target_space, event_data)
                 else:
                     # Fallback: single-space installations or unknown hub
                     for space_id in self._coordinator._space_ids:
                         self._coordinator.fire_push_event(space_id, event_type, event_data)
+                        self._apply_security_state_from_event(space_id, event_data)
         except Exception:
             _LOGGER.debug("Failed to parse event from push notification", exc_info=True)
+
+    def _apply_security_state_from_event(self, space_id: str, event_data: dict[str, Any]) -> None:
+        """If the push event implies a new space security_state, push it now (#68).
+
+        The FCM callback runs on the firebase_messaging worker thread, so we
+        dispatch the update to the HA event loop via call_soon_threadsafe.
+        """
+        raw_tag = event_data.get("raw_tag")
+        if not isinstance(raw_tag, str):
+            return
+        new_state = RAW_TAG_TO_SECURITY_STATE.get(raw_tag)
+        if new_state is None:
+            return
+        if self._hass.loop and self._hass.loop.is_running():
+            self._hass.loop.call_soon_threadsafe(
+                self._coordinator.apply_push_security_state,
+                space_id,
+                new_state,
+            )
 
     def _find_space_for_event(self, raw: bytes) -> str | None:
         """Try to match the event to a space by finding a known hub_id in raw bytes."""

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -695,3 +695,99 @@ class TestStreamHandlers:
 
         coordinator._devices_api.start_device_stream = MagicMock()
         coordinator._devices_api.start_device_stream.assert_not_called()
+
+
+class TestApplyPushSecurityState:
+    """Direct security_state updates from FCM arm/disarm pushes (#68)."""
+
+    def _make_coordinator_with_space(
+        self, security_state: SecurityState = SecurityState.DISARMED
+    ) -> AjaxCobrandedCoordinator:  # noqa: F821
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        hass = MagicMock()
+        client = MagicMock()
+        with patch(
+            "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+            return_value=None,
+        ):
+            coordinator = AjaxCobrandedCoordinator(
+                hass=hass, client=client, space_ids=["s1"], poll_interval=300
+            )
+        coordinator.hass = hass
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.spaces = {
+            "s1": Space(
+                id="s1",
+                hub_id="hub-1",
+                name="Home",
+                security_state=security_state,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+            )
+        }
+        return coordinator
+
+    def test_arm_push_updates_security_state(self) -> None:
+        coordinator = self._make_coordinator_with_space(SecurityState.DISARMED)
+
+        coordinator.apply_push_security_state("s1", SecurityState.ARMED)
+
+        assert coordinator.spaces["s1"].security_state == SecurityState.ARMED
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_night_mode_push_updates_security_state(self) -> None:
+        coordinator = self._make_coordinator_with_space(SecurityState.DISARMED)
+
+        coordinator.apply_push_security_state("s1", SecurityState.NIGHT_MODE)
+
+        assert coordinator.spaces["s1"].security_state == SecurityState.NIGHT_MODE
+
+    def test_disarm_push_updates_security_state(self) -> None:
+        coordinator = self._make_coordinator_with_space(SecurityState.ARMED)
+
+        coordinator.apply_push_security_state("s1", SecurityState.DISARMED)
+
+        assert coordinator.spaces["s1"].security_state == SecurityState.DISARMED
+
+    def test_no_change_skips_update(self) -> None:
+        coordinator = self._make_coordinator_with_space(SecurityState.ARMED)
+
+        coordinator.apply_push_security_state("s1", SecurityState.ARMED)
+
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_unknown_space_no_op(self) -> None:
+        coordinator = self._make_coordinator_with_space(SecurityState.DISARMED)
+
+        coordinator.apply_push_security_state("unknown", SecurityState.ARMED)
+
+        # Original space untouched, no update fired
+        assert coordinator.spaces["s1"].security_state == SecurityState.DISARMED
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_active_optimistic_state_is_respected(self) -> None:
+        # Local arm-from-HA registers an optimistic state. A contradictory
+        # push arriving before its 10s expiry must not flip the panel back.
+        import time
+
+        coordinator = self._make_coordinator_with_space(SecurityState.ARMED)
+        future = time.monotonic() + 60
+        coordinator._optimistic_space_states["s1"] = (future, SecurityState.ARMED)
+
+        coordinator.apply_push_security_state("s1", SecurityState.DISARMED)
+
+        assert coordinator.spaces["s1"].security_state == SecurityState.ARMED
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_expired_optimistic_state_does_not_block(self) -> None:
+        import time
+
+        coordinator = self._make_coordinator_with_space(SecurityState.DISARMED)
+        past = time.monotonic() - 60
+        coordinator._optimistic_space_states["s1"] = (past, SecurityState.ARMED)
+
+        coordinator.apply_push_security_state("s1", SecurityState.ARMED)
+
+        assert coordinator.spaces["s1"].security_state == SecurityState.ARMED
+        coordinator.async_set_updated_data.assert_called_once()

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -233,3 +233,79 @@ class TestNotificationListener:
         result = await listener.wait_for_notification_id("dev-99", timeout=0.05)
         assert result is None
         assert "dev-99" not in listener._notification_id_callbacks
+
+
+class TestApplySecurityStateFromEvent:
+    """Issue #68: arm/disarm pushes update space security_state instantly."""
+
+    def _make_listener(self) -> tuple[AjaxNotificationListener, MagicMock, MagicMock]:
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.is_running.return_value = True
+        coordinator = MagicMock()
+        listener = AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
+        return listener, hass, coordinator
+
+    def test_arm_tag_dispatches_armed_state(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "arm"})
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.apply_push_security_state, "space-1", SecurityState.ARMED
+        )
+
+    def test_disarm_tag_dispatches_disarmed_state(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "disarm"})
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.apply_push_security_state, "space-1", SecurityState.DISARMED
+        )
+
+    def test_night_mode_on_dispatches_night_mode_state(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "night_mode_on"})
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.apply_push_security_state, "space-1", SecurityState.NIGHT_MODE
+        )
+
+    def test_group_arm_tag_does_not_dispatch(self) -> None:
+        # group_* tags only affect a subgroup; let the next poll resolve the
+        # space-level state instead of guessing it from the push.
+        listener, hass, _ = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "group_arm"})
+
+        hass.loop.call_soon_threadsafe.assert_not_called()
+
+    def test_unmapped_tag_does_not_dispatch(self) -> None:
+        listener, hass, _ = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "intrusion_alarm"})
+
+        hass.loop.call_soon_threadsafe.assert_not_called()
+
+    def test_missing_raw_tag_does_not_dispatch(self) -> None:
+        listener, hass, _ = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {})
+
+        hass.loop.call_soon_threadsafe.assert_not_called()
+
+    def test_no_dispatch_when_loop_not_running(self) -> None:
+        listener, hass, _ = self._make_listener()
+        hass.loop.is_running.return_value = False
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "arm"})
+
+        hass.loop.call_soon_threadsafe.assert_not_called()


### PR DESCRIPTION
## Summary
Closes the asymmetry users keep reporting (#46): with FCM enabled, when someone arms or disarms the system from outside HA (Ajax mobile app, scheduler, keyfob…), the push event already arrives in real time but the alarm panel state stayed at its previous value for up to one poll cycle (default 5 min) because the only path that updated `coordinator.spaces[...].security_state` was `list_spaces()` during a refresh.

This change reads the event tag we already parse in `notification.py:_parse_and_fire_event` (used to fire the `event.aegis_security_event` entity) and uses it to update the space's `security_state` directly via a new `coordinator.apply_push_security_state(space_id, new_state)` method, then notifies entities via `async_set_updated_data`. The alarm panel now reflects external arm/disarm instantly when FCM is wired.

## Mapping decisions

`RAW_TAG_TO_SECURITY_STATE` in `const.py` covers the unambiguous tags:

| Raw tag                  | Resulting state |
| ------------------------ | --------------- |
| `arm`                    | `ARMED`         |
| `arm_attempt`            | `ARMED`         |
| `arm_with_malfunctions`  | `ARMED`         |
| `disarm`                 | `DISARMED`      |
| `duress_disarm`          | `DISARMED`      |
| `night_mode_on`          | `NIGHT_MODE`    |
| `night_mode_off`         | `DISARMED`      |
| `duress_night_mode_off`  | `DISARMED`      |

`group_*` tags are intentionally **omitted** — they only affect a subgroup, so the resulting space-level state depends on the other groups (could be `PARTIALLY_ARMED`, still `ARMED`, etc.). Those keep falling through to the regular `async_request_refresh()` path so the next poll resolves the right value.

## Race handling

`_optimistic_space_states` (set by `alarm_control_panel` when HA itself fires arm/disarm) takes precedence: a contradictory push arriving inside the 10s optimistic window is ignored to avoid flicker, the next poll reconciles. Tests cover both the active-optimistic-blocks and expired-optimistic-passes-through cases.

The push handler runs on the firebase_messaging worker thread, so the dispatch goes through `hass.loop.call_soon_threadsafe` — same pattern as the existing `async_request_refresh()` call at the bottom of `_on_notification`.

Refs #68, #46

## Test plan
- [x] 7 new coordinator tests for `apply_push_security_state`: arm/disarm/night-mode update, no-change skip, unknown space no-op, active vs expired optimistic state
- [x] 7 new notification tests for `_apply_security_state_from_event`: arm/disarm/night-mode tag dispatch, group tag skip, unmapped tag skip, missing raw_tag, loop-not-running short-circuit
- [x] `ruff` / `ruff format --check` / `mypy` / `vulture` clean
- [x] 883 unit tests pass, coverage 80.28%
- [ ] Verify on a real FCM-enabled setup: arm/disarm from the Ajax mobile app and confirm the HA alarm panel updates within seconds (not 5 minutes)