### PR TITLE
chore: bump version to 1.2.1-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1-beta.10] - 2026-04-27
+
+### Changed
+- The alarm control panel now reflects external arm/disarm/night-mode events in real time when FCM is configured: the integration applies the new `security_state` directly from the parsed push payload instead of waiting for the next poll cycle (up to 5 min). HA-initiated optimistic state still wins inside its 10s race window, and `group_*` tags keep falling through to the regular refresh path because their resulting space-level state depends on the other groups. (#68, #46)
+
 ## [1.2.1-beta.9] - 2026-04-27
 
 ### Fixed

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.1-beta.9"
+    "version": "1.2.1-beta.10"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.1-beta.9"
+version = "1.2.1-beta.10"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
## Summary
Release bump for the FCM-driven instant security_state update that landed via #71.

## Changelog entry
> The alarm control panel now reflects external arm/disarm/night-mode events in real time when FCM is configured: the integration applies the new `security_state` directly from the parsed push payload instead of waiting for the next poll cycle (up to 5 min). HA-initiated optimistic state still wins inside its 10s race window, and `group_*` tags keep falling through to the regular refresh path because their resulting space-level state depends on the other groups. (#68, #46)

## Test plan
- [x] CI green on `main` after #71 merge
- [ ] Tag-based release workflow publishes the prerelease automatically once this is merged