### PR TITLE
Handle idle HTS read timeouts before reconnecting

### DIFF
--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -52,6 +52,7 @@ HTS_HOST = "hts.prod.ajax.systems"
 HTS_PORT = 443
 PING_INTERVAL = 30
 READ_TIMEOUT = 40
+MAX_CONSECUTIVE_READ_TIMEOUTS = 3
 
 
 class HtsConnectionError(Exception):
@@ -98,6 +99,7 @@ class HtsClient:
         self._ping_task: asyncio.Task[None] | None = None
         self._data_request_task: asyncio.Task[None] | None = None
         self._read_buf = bytearray()
+        self._consecutive_read_timeouts = 0
         self._hub_states: dict[str, HubNetworkState] = {}
         self._on_state_update: Callable[[str, HubNetworkState], None] | None = None
         self._refresh_tasks: dict[str, asyncio.Task[None]] = {}
@@ -478,11 +480,23 @@ class HtsClient:
                 try:
                     msg = await self._receive_message()
                 except TimeoutError:
-                    _LOGGER.warning("HTS read timeout; closing connection")
-                    break
+                    self._consecutive_read_timeouts += 1
+                    if self._consecutive_read_timeouts >= MAX_CONSECUTIVE_READ_TIMEOUTS:
+                        _LOGGER.warning(
+                            "HTS read timeout %d times in a row; closing connection",
+                            self._consecutive_read_timeouts,
+                        )
+                        break
+                    _LOGGER.debug(
+                        "HTS read timeout %d/%d with no inbound data; keeping connection open",
+                        self._consecutive_read_timeouts,
+                        MAX_CONSECUTIVE_READ_TIMEOUTS,
+                    )
+                    continue
                 except ConnectionError as exc:
                     _LOGGER.warning("HTS connection error in listen: %s", exc)
                     break
+                self._consecutive_read_timeouts = 0
 
                 if not msg.is_no_ack and msg.msg_type != MsgType.ACK:
                     try:
@@ -661,8 +675,12 @@ class HtsClient:
         while self._connected:
             await asyncio.sleep(PING_INTERVAL)
             if self._connected:
-                with contextlib.suppress(Exception):
+                try:
                     await self._send_message(MsgType.PING, b"")
+                except Exception as exc:  # noqa: BLE001
+                    _LOGGER.warning("HTS ping failed; closing connection: %s", exc)
+                    self._connected = False
+                    break
 
     # ------------------------------------------------------------------
     # Close

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -10,6 +10,7 @@ import pytest
 from custom_components.aegis_ajax.api.hts.client import (
     HTS_HOST,
     HTS_PORT,
+    MAX_CONSECUTIVE_READ_TIMEOUTS,
     HtsClient,
 )
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
@@ -308,3 +309,55 @@ class TestHandleUpdate:
         await asyncio.sleep(0)
 
         client.request_hub_data.assert_awaited_once_with("12345678")
+
+    @pytest.mark.asyncio
+    async def test_listen_keeps_connection_open_on_idle_read_timeout(self) -> None:
+        client = _make_client()
+        client._connected = True
+        ack = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.ACK,
+            payload=b"",
+        )
+        client._receive_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[TimeoutError, ack, ConnectionError("closed")]
+        )
+
+        await client.listen()
+
+        assert client._receive_message.await_count == 3
+        assert client._consecutive_read_timeouts == 0
+
+    @pytest.mark.asyncio
+    async def test_listen_closes_after_max_consecutive_idle_timeouts(self) -> None:
+        client = _make_client()
+        client._connected = True
+        client._receive_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[TimeoutError] * MAX_CONSECUTIVE_READ_TIMEOUTS
+        )
+
+        await client.listen()
+
+        assert client._receive_message.await_count == MAX_CONSECUTIVE_READ_TIMEOUTS
+        assert client._consecutive_read_timeouts == MAX_CONSECUTIVE_READ_TIMEOUTS
+
+    @pytest.mark.asyncio
+    async def test_ping_loop_marks_disconnected_on_send_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.aegis_ajax.api.hts.client.PING_INTERVAL",
+            0,
+        )
+        client = _make_client()
+        client._connected = True
+        client._send_message = AsyncMock(side_effect=OSError("socket closed"))  # type: ignore[method-assign]
+
+        await client._ping_loop()
+
+        assert client._connected is False
+        client._send_message.assert_awaited_once_with(MsgType.PING, b"")

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -10,6 +10,11 @@ from custom_components.aegis_ajax.api.models import BatteryInfo, Device
 from custom_components.aegis_ajax.const import DeviceState
 from custom_components.aegis_ajax.sensor import (
     SENSOR_TYPES,
+    AjaxHubCellularNetworkSensor,
+    AjaxHubConnectionTypeSensor,
+    AjaxHubEthernetDnsSensor,
+    AjaxHubEthernetGatewaySensor,
+    AjaxHubEthernetIpSensor,
     AjaxHubWifiIpSensor,
     AjaxHubWifiSignalSensor,
     AjaxHubWifiSsidSensor,
@@ -371,3 +376,44 @@ class TestHubWifiSensors:
         assert AjaxHubWifiSsidSensor(coordinator, "hub-1").native_value is None
         assert AjaxHubWifiIpSensor(coordinator, "hub-1").native_value is None
         assert AjaxHubWifiSignalSensor(coordinator, "hub-1").native_value == "unknown"
+
+
+class TestHubNetworkSensors:
+    def _make_coordinator(self, hub_id: str = "hub-1") -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.devices = {hub_id: _make_hub_device(hub_id)}
+        coordinator.hub_network = {
+            hub_id: HubNetworkState(
+                ethernet_connected=True,
+                ethernet_ip="192.0.2.10",
+                ethernet_gateway="192.0.2.1",
+                ethernet_dns="192.0.2.53",
+                gsm_network_type="4g",
+            )
+        }
+        return coordinator
+
+    def test_connection_type_sensor_returns_primary_connection(self) -> None:
+        coordinator = self._make_coordinator()
+        sensor = AjaxHubConnectionTypeSensor(coordinator, "hub-1")
+        assert sensor.native_value == "ethernet"
+
+    def test_hub_network_sensors_unavailable_when_hts_state_missing(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": _make_hub_device("hub-1")}
+        coordinator.hub_network = {}
+
+        assert AjaxHubConnectionTypeSensor(coordinator, "hub-1").available is False
+        assert AjaxHubWifiSsidSensor(coordinator, "hub-1").available is False
+        assert AjaxHubEthernetIpSensor(coordinator, "hub-1").available is False
+        assert AjaxHubCellularNetworkSensor(coordinator, "hub-1").available is False
+
+    def test_hub_network_sensors_share_availability_with_hts_state(self) -> None:
+        coordinator = self._make_coordinator()
+
+        assert AjaxHubConnectionTypeSensor(coordinator, "hub-1").available is True
+        assert AjaxHubWifiSsidSensor(coordinator, "hub-1").available is True
+        assert AjaxHubEthernetIpSensor(coordinator, "hub-1").available is True
+        assert AjaxHubEthernetGatewaySensor(coordinator, "hub-1").available is True
+        assert AjaxHubEthernetDnsSensor(coordinator, "hub-1").available is True
+        assert AjaxHubCellularNetworkSensor(coordinator, "hub-1").available is True


### PR DESCRIPTION
## Summary

Handle idle HTS read timeouts more conservatively so hub-network sensors do not flap to `unavailable` on otherwise healthy connections.

This changes the HTS client to tolerate a bounded number of consecutive read timeouts before reconnecting, instead of treating the first idle timeout as a hard disconnect. It also keeps ping-send failures as an immediate disconnect signal.

Relates to #76.

## Test plan

- [ ] `make check` passes locally on a freshly built Docker image
- [x] New behaviour covered by unit tests in `tests/unit/`
- [ ] Coverage stays at or above the 80% threshold
- [ ] User-facing strings updated in `strings.json` and the 14 translation files
- [ ] `README.md` / `CHANGELOG.md` updated when the change is user-visible

Additional validation performed:

- `pytest tests/unit/test_sensor.py tests/unit/hts/test_client.py -q` in Docker
- `ruff check tests/unit/test_sensor.py tests/unit/hts/test_client.py` in Docker

## Notes for the reviewer

- The issue appears limited to HTS-backed `hub_network` entities.
- The reconnect policy is intentionally bounded: isolated idle timeouts are tolerated, but repeated consecutive timeouts still trigger reconnect and state clearing.
