### PR TITLE
Derive CRA status from monitoring companies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.ruff_cache
+.pytest_cache
+.mypy_cache
+.coverage
+.codex
+.codex.file.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3-beta.1] - 2026-04-29
+
+### Fixed
+- The `CRA connection` binary sensor now reflects actual approved monitoring-company assignments from the full `Space` snapshot instead of the hub-status `monitoring.cms_active` flag, which could stay `off` on installations that do have a CRA attached. The integration preserves the legacy entity id / unique id for backwards compatibility, adds a disabled-by-default diagnostic `CRA company` sensor with the approved company name(s), and keeps both entities `unavailable` until the first monitoring snapshot has been loaded so they do not show a false initial `off`. (#78, thanks @bogar)
+
 ## [1.2.2] - 2026-04-28
 
 Stable release rolling up the `1.2.2-beta.1` … `1.2.2-beta.3` line. Closes the two follow-up items left open in `1.2.1` (the FCM-driven instant security state path and the coordinator stall) and adds a community contribution from @bogar.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 
 - **Alarm Control Panel**: Arm away, disarm, night mode, group arming with PIN code support
 - **Force Arm Services**: `aegis_ajax.force_arm` and `aegis_ajax.force_arm_night` to arm ignoring open sensors
-- **Binary Sensors**: Door open/close, motion detection, smoke, leak, tamper, CO, heat, glass break, vibration, CRA monitoring, cellular connection, lid tamper, external contact alert (wired reed switches on DoorProtect/Hub Hybrid inputs), external contact fault, MultiTransmitter wired-input alert with alarm category, anti-masking, interference detection, ethernet link, Wi-Fi link, mains power
+- **Binary Sensors**: Door open/close, motion detection, smoke, leak, tamper, CO, heat, glass break, vibration, CRA monitoring status, cellular connection, lid tamper, external contact alert (wired reed switches on DoorProtect/Hub Hybrid inputs), external contact fault, MultiTransmitter wired-input alert with alarm category, anti-masking, interference detection, ethernet link, Wi-Fi link, mains power
 - **Hub Network**: Real-time hub network data — ethernet/wifi/gsm connection status, Wi-Fi SSID and signal strength, IP addressing, cellular signal strength and network type, power supply status
 - **Sensors**: Battery level, temperature, humidity, CO2, signal strength, GSM type (2G/3G/4G), Wi-Fi signal level, Wi-Fi SSID, Wi-Fi IP, IMEI, Ethernet IP/gateway/DNS, cellular signal/network, connection type
 - **Switches**: Relays, wall switches, sockets (multi-channel support)
@@ -139,7 +139,7 @@ You can type any custom label during setup if yours is not listed.
 
 | Type | Devices | Entities |
 |---|---|---|
-| Hub | Hub, Hub Plus, Hub 4G, Hub Lite, Hub 2, Hub 2 Plus, Hub 2 4G, Hub 3, Hub Hybrid (2 / 4G), Hub Mega, Hub Fibra, Hub Yavir / Yavir Plus, Hub Fire, Hub Superior | Alarm panel, battery, GSM type/connected, CRA monitoring, lid tamper, IMEI, hub network sensors (Ethernet/Wi-Fi/GSM, IP data, cellular signal/network, mains power) |
+| Hub | Hub, Hub Plus, Hub 4G, Hub Lite, Hub 2, Hub 2 Plus, Hub 2 4G, Hub 3, Hub Hybrid (2 / 4G), Hub Mega, Hub Fibra, Hub Yavir / Yavir Plus, Hub Fire, Hub Superior | Alarm panel, battery, GSM type/connected, CRA monitoring status, CRA company (diagnostic), lid tamper, IMEI, hub network sensors (Ethernet/Wi-Fi/GSM, IP data, cellular signal/network, mains power) |
 | Door Sensors | DoorProtect, DoorProtect Plus, DoorProtect Fibra, DoorProtect S, DoorProtect S Plus, DoorProtect Plus Fibra, DoorProtect Plus G3 Fibra, DoorProtect G3 | Door open/close, tamper, vibration (Plus), battery, temperature, signal, external contact alert (wired contact triggered), external contact fault (wiring broken) |
 | Motion Sensors | MotionProtect, MotionProtect Plus, MotionProtect Outdoor, MotionProtect Curtain (and outdoor / mini / plus base variants), MotionProtect S / S Plus, MotionProtect G3 family (incl. Fibra), MotionProtect Plus Fibra / G3 | Motion detected (real-time), tamper, battery, temperature, signal |
 | Cameras | MotionCam, MotionCam Outdoor, MotionCam Fibra (& base), MotionCam G3, MotionCam HD, MotionCam PhOD, MotionCam PhOD Fibra, MotionCam Outdoor PhOD, MotionCam Outdoor 2/4 PhOD, MotionCam S PhOD (& AM), MotionCam Superior PhOD | Photo on-demand capture + storage (PhOD models), motion detected, tamper, battery |
@@ -232,7 +232,8 @@ An [example automations file](docs/automations.yaml) is also available with 24 a
 ## Entity Details
 
 ### Hub sensors
-- **CRA connection** — binary sensor showing if the hub is connected to the monitoring station
+- **CRA connection** — binary sensor showing whether the space has at least one approved monitoring company (CRA)
+- **CRA company** — disabled-by-default diagnostic sensor showing the approved monitoring company name; returns `multiple` if more than one approved CRA is attached
 - **Cellular connected** — binary sensor for GSM/4G connection status
 - **GSM type** — sensor showing connection type (2G/3G/4G)
 - **Hub network sensors** — Ethernet/Wi-Fi connectivity, Wi-Fi SSID/signal, Ethernet/Wi-Fi IP addressing, cellular signal/network, and mains power status
@@ -316,6 +317,7 @@ This integration uses three communication channels. Each entity type depends on 
 | Protocol | Entities | Transport | Notes |
 |----------|----------|-----------|-------|
 | **gRPC stream** | Door open/close, motion, tamper, connectivity, problem, battery, temperature, signal, alarm panel state, switches, lights | `mobile-gw.prod.ajax.systems:443` | Persistent stream, < 1s latency |
+| **gRPC space snapshot** | CRA connection, CRA company, room metadata | Same server | One-shot `SpaceService/stream` snapshot read at startup / refresh time, then cached between polls |
 | **gRPC request** | Arm/disarm, force arm, photo capture trigger | Same server | On-demand commands |
 | **HTS** | Ethernet (IP, gateway, DNS), Wi-Fi (SSID, signal, IP), cellular (signal, network), mains power, connection type | `hts.prod.ajax.systems:443` | Proprietary binary protocol over TCP+TLS |
 | **FCM push** | Security events (alarm, arm/disarm, tamper, panic, fire, flood, motion, door_open, etc.), photo URL retrieval | Firebase Cloud Messaging | Requires FCM credentials (configured in Options) |

--- a/custom_components/aegis_ajax/api/models.py
+++ b/custom_components/aegis_ajax/api/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import IntEnum
 from typing import Any
 
 from custom_components.aegis_ajax.const import (
@@ -10,6 +11,23 @@ from custom_components.aegis_ajax.const import (
     DeviceState,
     SecurityState,
 )
+
+
+class MonitoringCompanyStatus(IntEnum):
+    """Ajax monitoring-company lifecycle states."""
+
+    UNSPECIFIED = 0
+    PENDING_APPROVAL = 1
+    APPROVED = 2
+    PENDING_DELETION = 3
+
+
+@dataclass(frozen=True)
+class MonitoringCompany:
+    """Represents a monitoring company attached to a space."""
+
+    name: str
+    status: MonitoringCompanyStatus
 
 
 @dataclass(frozen=True)
@@ -22,6 +40,8 @@ class Space:
     security_state: SecurityState
     connection_status: ConnectionStatus
     malfunctions_count: int
+    monitoring_companies: tuple[MonitoringCompany, ...] = field(default_factory=tuple)
+    monitoring_companies_loaded: bool = False
 
     @property
     def is_online(self) -> bool:
@@ -35,6 +55,18 @@ class Space:
             SecurityState.PARTIALLY_ARMED,
         )
 
+    @property
+    def approved_monitoring_companies(self) -> tuple[MonitoringCompany, ...]:
+        return tuple(
+            company
+            for company in self.monitoring_companies
+            if company.status == MonitoringCompanyStatus.APPROVED
+        )
+
+    @property
+    def has_monitoring(self) -> bool:
+        return bool(self.approved_monitoring_companies)
+
 
 @dataclass(frozen=True)
 class Room:
@@ -43,6 +75,15 @@ class Room:
     id: str
     name: str
     space_id: str
+
+
+@dataclass(frozen=True)
+class SpaceSnapshot:
+    """Subset of full space snapshot data used by the integration."""
+
+    rooms: tuple[Room, ...] = field(default_factory=tuple)
+    monitoring_companies: tuple[MonitoringCompany, ...] = field(default_factory=tuple)
+    monitoring_companies_loaded: bool = False
 
 
 @dataclass(frozen=True)

--- a/custom_components/aegis_ajax/api/spaces.py
+++ b/custom_components/aegis_ajax/api/spaces.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from custom_components.aegis_ajax.api.models import Room, Space
+from custom_components.aegis_ajax.api.models import (
+    MonitoringCompany,
+    MonitoringCompanyStatus,
+    Room,
+    Space,
+    SpaceSnapshot,
+)
 from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
 
 if TYPE_CHECKING:
@@ -36,6 +42,19 @@ class SpacesApi:
             malfunctions_count=proto_space.malfunctions_count,
         )
 
+    @staticmethod
+    def parse_monitoring_company(proto_company: Any) -> MonitoringCompany:  # noqa: ANN401
+        has_name = hasattr(proto_company, "company_info") and hasattr(
+            proto_company.company_info,
+            "name",
+        )
+        name = proto_company.company_info.name if has_name else ""
+        try:
+            status = MonitoringCompanyStatus(proto_company.status)
+        except ValueError:
+            status = MonitoringCompanyStatus.UNSPECIFIED
+        return MonitoringCompany(name=name, status=status)
+
     async def list_spaces(self) -> list[Space]:
         from v3.mobilegwsvc.service.find_user_spaces_with_pagination import (  # noqa: PLC0415
             endpoint_pb2_grpc,
@@ -55,11 +74,12 @@ class SpacesApi:
 
         return [self.parse_space(s) for s in response.success.spaces]
 
-    async def list_rooms(self, space_id: str) -> list[Room]:
-        """Return the rooms defined in the given space.
+    async def get_space_snapshot(self, space_id: str) -> SpaceSnapshot:
+        """Return a subset of the full space snapshot.
 
         Reads the snapshot message from `SpaceService/stream` and closes
-        the stream — rooms rarely change so we don't keep it open.
+        the stream — rooms and monitoring-company metadata rarely change so
+        we don't keep it open.
         """
         from systems.ajax.api.mobile.v2.common.space import (  # noqa: PLC0415
             space_locator_pb2,
@@ -79,6 +99,7 @@ class SpacesApi:
         stream = stub.stream(request, metadata=metadata, timeout=15)
 
         rooms: list[Room] = []
+        monitoring_companies: list[MonitoringCompany] = []
         try:
             async for msg in stream:
                 if msg.HasField("failure"):
@@ -90,13 +111,24 @@ class SpacesApi:
                     continue
                 for proto_room in msg.success.snapshot.rooms:
                     rooms.append(Room(id=proto_room.id, name=proto_room.name, space_id=space_id))
+                for proto_company in msg.success.snapshot.monitoring_companies:
+                    monitoring_companies.append(self.parse_monitoring_company(proto_company))
                 break
         finally:
             cancel = getattr(stream, "cancel", None)
             if callable(cancel):
                 cancel()
 
-        return rooms
+        return SpaceSnapshot(
+            rooms=tuple(rooms),
+            monitoring_companies=tuple(monitoring_companies),
+            monitoring_companies_loaded=True,
+        )
+
+    async def list_rooms(self, space_id: str) -> list[Room]:
+        """Return the rooms defined in the given space."""
+        snapshot = await self.get_space_snapshot(space_id)
+        return list(snapshot.rooms)
 
     async def press_panic_button(
         self,

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -37,7 +37,6 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
     "tamper": BinarySensorTypeInfo(BinarySensorDeviceClass.TAMPER, "tamper"),
     "co_detected": BinarySensorTypeInfo(BinarySensorDeviceClass.CO),
     "high_temperature": BinarySensorTypeInfo(BinarySensorDeviceClass.HEAT),
-    "monitoring_active": BinarySensorTypeInfo(BinarySensorDeviceClass.CONNECTIVITY, "monitoring"),
     "gsm_connected": BinarySensorTypeInfo(BinarySensorDeviceClass.CONNECTIVITY, "gsm"),
     "lid_opened": BinarySensorTypeInfo(BinarySensorDeviceClass.TAMPER, "lid"),
     "external_contact_broken": BinarySensorTypeInfo(BinarySensorDeviceClass.PROBLEM, "ext_contact"),
@@ -236,24 +235,24 @@ _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
     "keypad_touchscreen_g3": ["tamper"],
     # Hub family. Modern firmwares use `_two`, `_two_plus`, etc.; legacy data
     # may still expose `hub_two_4g`. Keep them all mapped to the same set.
-    "hub": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_plus": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_4g": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_lite": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_two": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_two_plus": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_two_4g": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_two_lte_rtk": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_three": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_fibra": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_hybrid_2": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_hybrid_4g": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_mega": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_void_4g": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_yavir": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_yavir_plus": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_fire": ["monitoring_active", "gsm_connected", "lid_opened"],
-    "hub_superior": ["monitoring_active", "gsm_connected", "lid_opened"],
+    "hub": ["gsm_connected", "lid_opened"],
+    "hub_plus": ["gsm_connected", "lid_opened"],
+    "hub_4g": ["gsm_connected", "lid_opened"],
+    "hub_lite": ["gsm_connected", "lid_opened"],
+    "hub_two": ["gsm_connected", "lid_opened"],
+    "hub_two_plus": ["gsm_connected", "lid_opened"],
+    "hub_two_4g": ["gsm_connected", "lid_opened"],
+    "hub_two_lte_rtk": ["gsm_connected", "lid_opened"],
+    "hub_three": ["gsm_connected", "lid_opened"],
+    "hub_fibra": ["gsm_connected", "lid_opened"],
+    "hub_hybrid_2": ["gsm_connected", "lid_opened"],
+    "hub_hybrid_4g": ["gsm_connected", "lid_opened"],
+    "hub_mega": ["gsm_connected", "lid_opened"],
+    "hub_void_4g": ["gsm_connected", "lid_opened"],
+    "hub_yavir": ["gsm_connected", "lid_opened"],
+    "hub_yavir_plus": ["gsm_connected", "lid_opened"],
+    "hub_fire": ["gsm_connected", "lid_opened"],
+    "hub_superior": ["gsm_connected", "lid_opened"],
 }
 
 
@@ -277,6 +276,7 @@ async def async_setup_entry(
         if space.hub_id:
             hub_device = coordinator.devices.get(space.hub_id)
             if hub_device:
+                entities.append(AjaxCraConnectionSensor(coordinator, space.id, space.hub_id))
                 entities.append(AjaxHubEthernetSensor(coordinator, space.hub_id))
                 entities.append(AjaxHubWifiSensor(coordinator, space.hub_id))
                 entities.append(AjaxHubPowerSensor(coordinator, space.hub_id))
@@ -398,6 +398,33 @@ class AjaxProblemSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySenso
         if device:
             return {"malfunctions_count": device.malfunctions}
         return {}
+
+
+class AjaxCraConnectionSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensorEntity):
+    """Binary sensor reporting whether the space has approved monitoring."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_translation_key = "monitoring"
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, space_id: str, hub_id: str) -> None:
+        super().__init__(coordinator)
+        self._space_id = space_id
+        self._hub_id = hub_id
+        self._attr_unique_id = f"aegis_ajax_{hub_id}_monitoring_active"
+        hub_device = coordinator.devices.get(hub_id)
+        if hub_device:
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
+
+    @property
+    def available(self) -> bool:
+        space = self.coordinator.spaces.get(self._space_id)
+        return space is not None and space.monitoring_companies_loaded
+
+    @property
+    def is_on(self) -> bool:
+        space = self.coordinator.spaces.get(self._space_id)
+        return space.has_monitoring if space is not None else False
 
 
 class _HubNetworkBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensorEntity):

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -213,6 +213,17 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     s = dc_replace(s, security_state=opt[1])
                 elif opt and opt[0] <= now:
                     self._optimistic_space_states.pop(s.id, None)
+                previous = self.spaces.get(s.id)
+                if previous and (
+                    previous.monitoring_companies or previous.monitoring_companies_loaded
+                ):
+                    from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+                    s = dc_replace(
+                        s,
+                        monitoring_companies=previous.monitoring_companies,
+                        monitoring_companies_loaded=previous.monitoring_companies_loaded,
+                    )
                 new_spaces[s.id] = s
             self.spaces = new_spaces
 
@@ -234,15 +245,24 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._rooms_last_fetch is None
                 or now - self._rooms_last_fetch > rooms_refresh_interval
             ):
+                from dataclasses import replace as dc_replace  # noqa: PLC0415
+
                 refreshed_rooms: dict[str, Room] = {}
                 for space_id in self.spaces:
                     try:
-                        space_rooms = await self._spaces_api.list_rooms(space_id)
+                        snapshot = await self._spaces_api.get_space_snapshot(space_id)
                     except Exception:  # noqa: BLE001
                         _LOGGER.debug("Failed to fetch rooms for space %s", space_id, exc_info=True)
                         continue
-                    for room in space_rooms:
+                    for room in snapshot.rooms:
                         refreshed_rooms[room.id] = room
+                    current_space = self.spaces.get(space_id)
+                    if current_space is not None:
+                        self.spaces[space_id] = dc_replace(
+                            current_space,
+                            monitoring_companies=snapshot.monitoring_companies,
+                            monitoring_companies_loaded=snapshot.monitoring_companies_loaded,
+                        )
                 self.rooms = refreshed_rooms
                 self._rooms_last_fetch = now
 

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, Sen
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from custom_components.aegis_ajax.api.models import MonitoringCompanyStatus
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 from custom_components.aegis_ajax.entity import build_device_info
 
@@ -122,6 +123,14 @@ async def async_setup_entry(
     for space in coordinator.spaces.values():
         if space.hub_id in coordinator.sim_info:
             entities.append(AjaxSimImeiSensor(coordinator=coordinator, hub_id=space.hub_id))
+        if space.hub_id and coordinator.devices.get(space.hub_id):
+            entities.append(
+                AjaxHubMonitoringCompanySensor(
+                    coordinator=coordinator,
+                    space_id=space.id,
+                    hub_id=space.hub_id,
+                )
+            )
 
     # Hub-level network sensors from HTS
     for space in coordinator.spaces.values():
@@ -221,6 +230,62 @@ class AjaxSimImeiSensor(AjaxSimBaseSensor):
     def native_value(self) -> str | None:
         sim = self._sim_info
         return sim.imei if sim else None
+
+
+class AjaxHubMonitoringCompanySensor(CoordinatorEntity[AjaxCobrandedCoordinator], SensorEntity):
+    """Diagnostic sensor exposing approved CRA company names for a hub."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "monitoring_company"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, space_id: str, hub_id: str) -> None:
+        super().__init__(coordinator)
+        self._space_id = space_id
+        self._hub_id = hub_id
+        self._attr_unique_id = f"aegis_ajax_{hub_id}_monitoring_company"
+        hub_device = coordinator.devices.get(hub_id)
+        if hub_device:
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
+
+    @property
+    def available(self) -> bool:
+        space = self.coordinator.spaces.get(self._space_id)
+        return space is not None and space.monitoring_companies_loaded
+
+    @property
+    def native_value(self) -> str | None:
+        space = self.coordinator.spaces.get(self._space_id)
+        if space is None:
+            return None
+        approved = [company.name for company in space.approved_monitoring_companies if company.name]
+        if not approved:
+            return None
+        if len(approved) == 1:
+            return approved[0]
+        return "multiple"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, list[str]]:
+        space = self.coordinator.spaces.get(self._space_id)
+        if space is None:
+            return {}
+        attrs: dict[str, list[str]] = {
+            "approved_companies": [],
+            "pending_approval_companies": [],
+            "pending_removal_companies": [],
+        }
+        for company in space.monitoring_companies:
+            if not company.name:
+                continue
+            if company.status == MonitoringCompanyStatus.APPROVED:
+                attrs["approved_companies"].append(company.name)
+            elif company.status == MonitoringCompanyStatus.PENDING_APPROVAL:
+                attrs["pending_approval_companies"].append(company.name)
+            elif company.status == MonitoringCompanyStatus.PENDING_DELETION:
+                attrs["pending_removal_companies"].append(company.name)
+        return attrs
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -165,6 +165,7 @@
             "mains_power": {"name": "Mains power"}
         },
         "sensor": {
+            "monitoring_company": {"name": "CRA company"},
             "signal_strength": {"name": "Signal strength"},
             "mobile_network_type": {"name": "Mobile network type"},
             "wifi_signal_level": {"name": "Wi-Fi signal level"},

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -165,6 +165,7 @@
             "mains_power": {"name": "Alimentació externa"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Companyia CRA"},
             "signal_strength": {"name": "Intensitat de senyal"},
             "mobile_network_type": {"name": "Tipus de xarxa mòbil"},
             "wifi_signal_level": {"name": "Nivell de senyal Wi-Fi"},

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -161,6 +161,7 @@
             "mains_power": {"name": "Napájení ze sítě"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Společnost PCO"},
             "signal_strength": {"name": "Síla signálu"},
             "mobile_network_type": {"name": "Typ mobilní sítě"},
             "wifi_signal_level": {"name": "Úroveň Wi-Fi signálu"},

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -161,6 +161,7 @@
             "mains_power": {"name": "Netzstrom"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Leitstellenanbieter"},
             "signal_strength": {"name": "Signalstärke"},
             "mobile_network_type": {"name": "Mobilfunknetztyp"},
             "wifi_signal_level": {"name": "WLAN-Signalstärke"},

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -165,6 +165,7 @@
             "mains_power": {"name": "Mains power"}
         },
         "sensor": {
+            "monitoring_company": {"name": "CRA company"},
             "signal_strength": {"name": "Signal strength"},
             "mobile_network_type": {"name": "Mobile network type"},
             "wifi_signal_level": {"name": "Wi-Fi signal level"},

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -165,6 +165,7 @@
             "mains_power": {"name": "Alimentación externa"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Compañía CRA"},
             "signal_strength": {"name": "Intensidad de señal"},
             "mobile_network_type": {"name": "Tipo de red móvil"},
             "wifi_signal_level": {"name": "Nivel de señal Wi-Fi"},

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -165,6 +165,7 @@
             "mains_power": {"name": "Alimentation secteur"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Société de télésurveillance"},
             "signal_strength": {"name": "Intensité du signal"},
             "mobile_network_type": {"name": "Type de réseau mobile"},
             "wifi_signal_level": {"name": "Niveau de signal Wi-Fi"},

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -161,6 +161,7 @@
             "mains_power": {"name": "Alimentazione di rete"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Società di vigilanza"},
             "signal_strength": {"name": "Intensità del segnale"},
             "mobile_network_type": {"name": "Tipo di rete mobile"},
             "wifi_signal_level": {"name": "Livello segnale Wi-Fi"},

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -161,6 +161,7 @@
             "mains_power": {"name": "Netstroom"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Meldkamerbedrijf"},
             "signal_strength": {"name": "Signaalsterkte"},
             "mobile_network_type": {"name": "Mobiel netwerktype"},
             "wifi_signal_level": {"name": "Wi-Fi-signaalsterkte"},

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -161,6 +161,7 @@
             "mains_power": {"name": "Zasilanie sieciowe"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Firma monitorująca"},
             "signal_strength": {"name": "Siła sygnału"},
             "mobile_network_type": {"name": "Typ sieci komórkowej"},
             "wifi_signal_level": {"name": "Poziom sygnału Wi-Fi"},

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -165,6 +165,7 @@
             "mains_power": {"name": "Energia externa"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Empresa da central de monitoramento"},
             "signal_strength": {"name": "Intensidade do sinal"},
             "mobile_network_type": {"name": "Tipo de rede móvel"},
             "wifi_signal_level": {"name": "Nível de sinal Wi-Fi"},

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -165,6 +165,7 @@
             "mains_power": {"name": "Alimentação externa"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Empresa CRA"},
             "signal_strength": {"name": "Intensidade do sinal"},
             "mobile_network_type": {"name": "Tipo de rede móvel"},
             "wifi_signal_level": {"name": "Nível de sinal Wi-Fi"},

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -165,6 +165,7 @@
             "mains_power": {"name": "Alimentare rețea"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Companie de monitorizare"},
             "signal_strength": {"name": "Puterea semnalului"},
             "mobile_network_type": {"name": "Tip rețea mobilă"},
             "wifi_signal_level": {"name": "Nivel semnal Wi-Fi"},

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -161,6 +161,7 @@
             "mains_power": {"name": "Şebeke gücü"}
         },
         "sensor": {
+            "monitoring_company": {"name": "İzleme merkezi şirketi"},
             "signal_strength": {"name": "Sinyal gücü"},
             "mobile_network_type": {"name": "Mobil ağ türü"},
             "wifi_signal_level": {"name": "Wi-Fi sinyal seviyesi"},

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -161,6 +161,7 @@
             "mains_power": {"name": "Зовнішнє живлення"}
         },
         "sensor": {
+            "monitoring_company": {"name": "Компанія ЦМО"},
             "signal_strength": {"name": "Рівень сигналу"},
             "mobile_network_type": {"name": "Тип мобільної мережі"},
             "wifi_signal_level": {"name": "Рівень сигналу Wi-Fi"},

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -2,21 +2,28 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
 
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
-from custom_components.aegis_ajax.api.models import Device
+from custom_components.aegis_ajax.api.models import (
+    Device,
+    MonitoringCompany,
+    MonitoringCompanyStatus,
+    Space,
+)
 from custom_components.aegis_ajax.binary_sensor import (
     _DEVICE_TYPE_SENSORS,
     BINARY_SENSOR_TYPES,
     AjaxBinarySensor,
     AjaxConnectivitySensor,
+    AjaxCraConnectionSensor,
     AjaxHubWifiSensor,
     AjaxProblemSensor,
 )
-from custom_components.aegis_ajax.const import DeviceState
+from custom_components.aegis_ajax.const import ConnectionStatus, DeviceState, SecurityState
 
 
 class TestBinarySensorTypes:
@@ -40,9 +47,6 @@ class TestBinarySensorTypes:
 
     def test_high_temperature_type_exists(self) -> None:
         assert "high_temperature" in BINARY_SENSOR_TYPES
-
-    def test_monitoring_active_type_exists(self) -> None:
-        assert "monitoring_active" in BINARY_SENSOR_TYPES
 
     def test_gsm_connected_type_exists(self) -> None:
         assert "gsm_connected" in BINARY_SENSOR_TYPES
@@ -189,31 +193,6 @@ class TestAjaxBinarySensor:
         sensor = AjaxBinarySensor(coordinator=coordinator, device_id="dev-1", status_key="tamper")
         assert sensor.is_on is True
 
-    def test_hub_device_has_no_via_device(self) -> None:
-        from custom_components.aegis_ajax.api.models import Device
-        from custom_components.aegis_ajax.const import DeviceState
-
-        hub_device = Device(
-            id="hub-1",
-            hub_id="hub-1",
-            name="Hub",
-            device_type="hub_two_4g",
-            room_id=None,
-            group_id=None,
-            state=DeviceState.ONLINE,
-            malfunctions=0,
-            bypassed=False,
-            statuses={"monitoring_active": True},
-            battery=None,
-        )
-        coordinator = MagicMock()
-        coordinator.devices = {"hub-1": hub_device}
-        sensor = AjaxBinarySensor(
-            coordinator=coordinator, device_id="hub-1", status_key="monitoring_active"
-        )
-        assert sensor._attr_device_info is not None
-        assert "via_device" not in sensor._attr_device_info
-
     def test_non_hub_device_has_via_device(self) -> None:
         device = self._make_device({})
         coordinator = MagicMock()
@@ -223,30 +202,6 @@ class TestAjaxBinarySensor:
         )
         assert sensor._attr_device_info is not None
         assert sensor._attr_device_info.get("via_device") == ("aegis_ajax", "hub-1")
-
-    def test_monitoring_sensor_has_translation_key(self) -> None:
-        from custom_components.aegis_ajax.api.models import Device
-        from custom_components.aegis_ajax.const import DeviceState
-
-        hub_device = Device(
-            id="hub-1",
-            hub_id="hub-1",
-            name="Hub",
-            device_type="hub_two_4g",
-            room_id=None,
-            group_id=None,
-            state=DeviceState.ONLINE,
-            malfunctions=0,
-            bypassed=False,
-            statuses={},
-            battery=None,
-        )
-        coordinator = MagicMock()
-        coordinator.devices = {"hub-1": hub_device}
-        sensor = AjaxBinarySensor(
-            coordinator=coordinator, device_id="hub-1", status_key="monitoring_active"
-        )
-        assert sensor._attr_translation_key == "monitoring"
 
     def test_motion_sensor_extra_attributes_with_timestamp(self) -> None:
         device = self._make_device({"motion_detected": True, "motion_detected_at": 1700000000})
@@ -274,6 +229,91 @@ class TestAjaxBinarySensor:
         coordinator.devices = {"dev-1": device}
         sensor = AjaxBinarySensor(coordinator=coordinator, device_id="dev-1", status_key="tamper")
         assert sensor.extra_state_attributes == {}
+
+
+class TestAjaxCraConnectionSensor:
+    def _make_hub_device(self) -> Device:
+        return Device(
+            id="hub-1",
+            hub_id="hub-1",
+            name="Hub",
+            device_type="hub_two_4g",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    def _make_space(self, companies: tuple[MonitoringCompany, ...]) -> Space:
+        return Space(
+            id="space-1",
+            hub_id="hub-1",
+            name="Home",
+            security_state=SecurityState.DISARMED,
+            connection_status=ConnectionStatus.ONLINE,
+            malfunctions_count=0,
+            monitoring_companies=companies,
+            monitoring_companies_loaded=True,
+        )
+
+    def test_unique_id_matches_legacy_entity(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": self._make_hub_device()}
+        coordinator.spaces = {"space-1": self._make_space(())}
+
+        sensor = AjaxCraConnectionSensor(coordinator, "space-1", "hub-1")
+
+        assert sensor.unique_id == "aegis_ajax_hub-1_monitoring_active"
+
+    def test_is_on_when_space_has_approved_monitoring_company(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": self._make_hub_device()}
+        coordinator.spaces = {
+            "space-1": self._make_space(
+                (
+                    MonitoringCompany(
+                        name="Central One",
+                        status=MonitoringCompanyStatus.APPROVED,
+                    ),
+                )
+            )
+        }
+
+        sensor = AjaxCraConnectionSensor(coordinator, "space-1", "hub-1")
+
+        assert sensor.is_on is True
+
+    def test_is_off_when_space_has_only_pending_monitoring_company(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": self._make_hub_device()}
+        coordinator.spaces = {
+            "space-1": self._make_space(
+                (
+                    MonitoringCompany(
+                        name="Central One",
+                        status=MonitoringCompanyStatus.PENDING_APPROVAL,
+                    ),
+                )
+            )
+        }
+
+        sensor = AjaxCraConnectionSensor(coordinator, "space-1", "hub-1")
+
+        assert sensor.is_on is False
+
+    def test_is_unavailable_until_monitoring_snapshot_loaded(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": self._make_hub_device()}
+        coordinator.spaces = {
+            "space-1": replace(self._make_space(()), monitoring_companies_loaded=False)
+        }
+
+        sensor = AjaxCraConnectionSensor(coordinator, "space-1", "hub-1")
+
+        assert sensor.available is False
 
 
 class TestDeviceTypeSensors:
@@ -419,8 +459,8 @@ class TestDeviceTypeSensors:
     # Hub family — `hub`, `hub_plus`, `hub_two_4g` were already mapped, but
     # the v3 catalog also names `hub_two`, `hub_two_plus`, `hub_hybrid_*`,
     # `hub_mega`, `hub_lite`, `hub_4g`, `hub_three`, etc. Anyone running a
-    # Hub 2 / Hub 2 Plus was missing the monitoring/gsm/lid entities
-    # because of the same legacy-vs-current naming mismatch.
+    # Hub 2 / Hub 2 Plus was missing the hub-level GSM/lid entities because
+    # of the same legacy-vs-current naming mismatch.
     @pytest.mark.parametrize(
         "device_type",
         [
@@ -444,9 +484,8 @@ class TestDeviceTypeSensors:
             "hub_superior",
         ],
     )
-    def test_hub_family_has_monitoring_sensors(self, device_type: str) -> None:
+    def test_hub_family_has_gsm_and_lid_sensors(self, device_type: str) -> None:
         sensors = _DEVICE_TYPE_SENSORS[device_type]
-        assert "monitoring_active" in sensors
         assert "gsm_connected" in sensors
         assert "lid_opened" in sensors
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
-from custom_components.aegis_ajax.api.models import Device, Space
+from custom_components.aegis_ajax.api.models import (
+    Device,
+    MonitoringCompany,
+    MonitoringCompanyStatus,
+    Room,
+    Space,
+    SpaceSnapshot,
+)
 from custom_components.aegis_ajax.const import ConnectionStatus, DeviceState, SecurityState
 
 
@@ -102,16 +110,16 @@ class TestCoordinatorInit:
 class TestRoomsRefresh:
     @pytest.mark.asyncio
     async def test_rooms_populated_from_spaces_api(self) -> None:
-        from custom_components.aegis_ajax.api.models import Room
-
         coordinator = _make_coordinator()
         coordinator._client.session.is_authenticated = True
         coordinator._streams_started = True
 
         coordinator._spaces_api = MagicMock()
         coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
-        coordinator._spaces_api.list_rooms = AsyncMock(
-            return_value=[Room(id="r1", name="Kitchen", space_id="s1")]
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(
+            return_value=SpaceSnapshot(
+                rooms=(Room(id="r1", name="Kitchen", space_id="s1"),),
+            )
         )
         coordinator._devices_api = MagicMock()
         coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
@@ -128,13 +136,46 @@ class TestRoomsRefresh:
 
         coordinator._spaces_api = MagicMock()
         coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
-        coordinator._spaces_api.list_rooms = AsyncMock(side_effect=RuntimeError("oops"))
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(side_effect=RuntimeError("oops"))
         coordinator._devices_api = MagicMock()
         coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
 
         # Should not raise — failure is downgraded to debug log
         await coordinator._async_update_data()
         assert coordinator.rooms == {}
+
+    @pytest.mark.asyncio
+    async def test_monitoring_companies_populated_from_space_snapshot(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(
+            return_value=SpaceSnapshot(
+                monitoring_companies=(
+                    MonitoringCompany(
+                        name="Central One",
+                        status=MonitoringCompanyStatus.APPROVED,
+                    ),
+                ),
+                monitoring_companies_loaded=True,
+            )
+        )
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        assert coordinator.spaces["s1"].has_monitoring is True
+        assert coordinator.spaces["s1"].approved_monitoring_companies == (
+            MonitoringCompany(
+                name="Central One",
+                status=MonitoringCompanyStatus.APPROVED,
+            ),
+        )
+        assert coordinator.spaces["s1"].monitoring_companies_loaded is True
 
 
 class TestAsyncUpdateData:
@@ -189,6 +230,40 @@ class TestAsyncUpdateData:
         result = await coordinator._async_update_data()
         assert "s1" in result["spaces"]
         assert "s2" not in result["spaces"]
+
+    @pytest.mark.asyncio
+    async def test_update_data_preserves_cached_monitoring_companies_between_snapshot_refreshes(
+        self,
+    ) -> None:
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._rooms_last_fetch = asyncio.get_running_loop().time()
+        coordinator.spaces["s1"] = replace(
+            _make_space("s1"),
+            monitoring_companies=(
+                MonitoringCompany(
+                    name="Central One",
+                    status=MonitoringCompanyStatus.APPROVED,
+                ),
+            ),
+            monitoring_companies_loaded=True,
+        )
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        assert coordinator.spaces["s1"].approved_monitoring_companies == (
+            MonitoringCompany(
+                name="Central One",
+                status=MonitoringCompanyStatus.APPROVED,
+            ),
+        )
+        assert coordinator.spaces["s1"].monitoring_companies_loaded is True
 
     @pytest.mark.asyncio
     async def test_update_data_raises_update_failed_on_error(self) -> None:

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from unittest.mock import MagicMock
 
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
 from custom_components.aegis_ajax.api.hub_object import SimCardInfo
-from custom_components.aegis_ajax.api.models import BatteryInfo, Device
-from custom_components.aegis_ajax.const import DeviceState
+from custom_components.aegis_ajax.api.models import (
+    BatteryInfo,
+    Device,
+    MonitoringCompany,
+    MonitoringCompanyStatus,
+    Space,
+)
+from custom_components.aegis_ajax.const import ConnectionStatus, DeviceState, SecurityState
 from custom_components.aegis_ajax.sensor import (
     SENSOR_TYPES,
     AjaxHubCellularNetworkSensor,
@@ -15,6 +22,7 @@ from custom_components.aegis_ajax.sensor import (
     AjaxHubEthernetDnsSensor,
     AjaxHubEthernetGatewaySensor,
     AjaxHubEthernetIpSensor,
+    AjaxHubMonitoringCompanySensor,
     AjaxHubWifiIpSensor,
     AjaxHubWifiSignalSensor,
     AjaxHubWifiSsidSensor,
@@ -417,3 +425,85 @@ class TestHubNetworkSensors:
         assert AjaxHubEthernetGatewaySensor(coordinator, "hub-1").available is True
         assert AjaxHubEthernetDnsSensor(coordinator, "hub-1").available is True
         assert AjaxHubCellularNetworkSensor(coordinator, "hub-1").available is True
+
+
+class TestHubMonitoringCompanySensor:
+    def _make_space(self, companies: tuple[MonitoringCompany, ...]) -> Space:
+        return Space(
+            id="space-1",
+            hub_id="hub-1",
+            name="Home",
+            security_state=SecurityState.DISARMED,
+            connection_status=ConnectionStatus.ONLINE,
+            malfunctions_count=0,
+            monitoring_companies=companies,
+            monitoring_companies_loaded=True,
+        )
+
+    def _make_coordinator(self, companies: tuple[MonitoringCompany, ...]) -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": _make_hub_device("hub-1")}
+        coordinator.spaces = {"space-1": self._make_space(companies)}
+        return coordinator
+
+    def test_native_value_returns_company_name_for_single_approved_company(self) -> None:
+        coordinator = self._make_coordinator(
+            (
+                MonitoringCompany(
+                    name="Central One",
+                    status=MonitoringCompanyStatus.APPROVED,
+                ),
+            )
+        )
+        sensor = AjaxHubMonitoringCompanySensor(coordinator, "space-1", "hub-1")
+        assert sensor.native_value == "Central One"
+
+    def test_native_value_returns_multiple_for_multiple_approved_companies(self) -> None:
+        coordinator = self._make_coordinator(
+            (
+                MonitoringCompany(
+                    name="Central One",
+                    status=MonitoringCompanyStatus.APPROVED,
+                ),
+                MonitoringCompany(
+                    name="Central Two",
+                    status=MonitoringCompanyStatus.APPROVED,
+                ),
+            )
+        )
+        sensor = AjaxHubMonitoringCompanySensor(coordinator, "space-1", "hub-1")
+        assert sensor.native_value == "multiple"
+
+    def test_extra_state_attributes_group_companies_by_status(self) -> None:
+        coordinator = self._make_coordinator(
+            (
+                MonitoringCompany(
+                    name="Central One",
+                    status=MonitoringCompanyStatus.APPROVED,
+                ),
+                MonitoringCompany(
+                    name="Central Two",
+                    status=MonitoringCompanyStatus.PENDING_APPROVAL,
+                ),
+                MonitoringCompany(
+                    name="Central Three",
+                    status=MonitoringCompanyStatus.PENDING_DELETION,
+                ),
+            )
+        )
+        sensor = AjaxHubMonitoringCompanySensor(coordinator, "space-1", "hub-1")
+        assert sensor.extra_state_attributes == {
+            "approved_companies": ["Central One"],
+            "pending_approval_companies": ["Central Two"],
+            "pending_removal_companies": ["Central Three"],
+        }
+
+    def test_is_unavailable_until_monitoring_snapshot_loaded(self) -> None:
+        coordinator = self._make_coordinator(())
+        coordinator.spaces["space-1"] = replace(
+            coordinator.spaces["space-1"], monitoring_companies_loaded=False
+        )
+
+        sensor = AjaxHubMonitoringCompanySensor(coordinator, "space-1", "hub-1")
+
+        assert sensor.available is False

--- a/tests/unit/test_spaces.py
+++ b/tests/unit/test_spaces.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.aegis_ajax.api.models import Space
+from custom_components.aegis_ajax.api.models import (
+    MonitoringCompanyStatus,
+    Space,
+    SpaceSnapshot,
+)
 from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
 
@@ -33,6 +37,7 @@ class TestParseSpace:
         assert result.name == "My Home"
         assert result.security_state == SecurityState.DISARMED
         assert result.connection_status == ConnectionStatus.ONLINE
+        assert result.monitoring_companies_loaded is False
 
     def test_parse_space_armed(self) -> None:
         proto_space = MagicMock()
@@ -58,6 +63,16 @@ class TestParseSpace:
 
         result = SpacesApi.parse_space(proto_space)
         assert result.hub_id == ""
+
+    def test_parse_monitoring_company(self) -> None:
+        proto_company = MagicMock()
+        proto_company.company_info.name = "Secure Co"
+        proto_company.status = 2
+
+        result = SpacesApi.parse_monitoring_company(proto_company)
+
+        assert result.name == "Secure Co"
+        assert result.status == MonitoringCompanyStatus.APPROVED
 
 
 class TestListSpaces:
@@ -183,6 +198,7 @@ class TestListRooms:
         snapshot_msg.HasField.side_effect = lambda f: f == "success"
         snapshot_msg.success.WhichOneof.return_value = "snapshot"
         snapshot_msg.success.snapshot.rooms = [room1, room2]
+        snapshot_msg.success.snapshot.monitoring_companies = []
 
         update_msg = MagicMock()
         update_msg.HasField.side_effect = lambda f: f == "success"
@@ -247,6 +263,62 @@ class TestListRooms:
             rooms = await api.list_rooms("space-1")
 
         assert rooms == []
+
+
+class TestGetSpaceSnapshot:
+    @pytest.mark.asyncio
+    async def test_returns_rooms_and_monitoring_companies(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        room = MagicMock()
+        room.id = "r1"
+        room.name = "Kitchen"
+
+        approved = MagicMock()
+        approved.company_info.name = "Central One"
+        approved.status = 2
+
+        pending = MagicMock()
+        pending.company_info.name = "Central Two"
+        pending.status = 1
+
+        snapshot_msg = MagicMock()
+        snapshot_msg.HasField.side_effect = lambda f: f == "success"
+        snapshot_msg.success.WhichOneof.return_value = "snapshot"
+        snapshot_msg.success.snapshot.rooms = [room]
+        snapshot_msg.success.snapshot.monitoring_companies = [approved, pending]
+
+        stream = _async_iter([snapshot_msg])
+        stub_instance = MagicMock()
+        stub_instance.stream = MagicMock(return_value=stream)
+
+        request_pb2 = MagicMock()
+        grpc_module = MagicMock(SpaceServiceStub=MagicMock(return_value=stub_instance))
+        locator_pb2 = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _STREAM_SPACE_REQUEST: request_pb2,
+                _SPACE_GRPC: grpc_module,
+                _SPACE_LOCATOR: locator_pb2,
+            },
+        ):
+            snapshot = await api.get_space_snapshot("space-1")
+
+        assert isinstance(snapshot, SpaceSnapshot)
+        assert len(snapshot.rooms) == 1
+        assert snapshot.rooms[0].id == "r1"
+        assert snapshot.rooms[0].name == "Kitchen"
+        assert snapshot.monitoring_companies[0].name == "Central One"
+        assert snapshot.monitoring_companies[0].status == MonitoringCompanyStatus.APPROVED
+        assert snapshot.monitoring_companies[1].name == "Central Two"
+        assert snapshot.monitoring_companies[1].status == MonitoringCompanyStatus.PENDING_APPROVAL
+        assert snapshot.monitoring_companies_loaded is True
 
 
 _PANIC_REQUEST = "systems.ajax.api.mobile.v2.space.press_panic_button_request_pb2"


### PR DESCRIPTION
## Summary

Derive the `CRA connection` entity from space-level monitoring companies instead of the device-status `monitoring.cms_active` flag.

This keeps the existing entity id/unique id stable while aligning the binary sensor with the actual user-facing concept of an approved monitoring service. The change also adds a diagnostic `CRA company` sensor that exposes the approved company name, or `multiple` when more than one approved company is present, with grouped company lists in attributes.

Relates to #78.

## Test plan

- [ ] `make check` passes locally on a freshly built Docker image
- [x] New behaviour covered by unit tests in `tests/unit/`
- [ ] Coverage stays at or above the 80% threshold
- [ ] User-facing strings updated in `strings.json` and the 14 translation files
- [ ] `README.md` / `CHANGELOG.md` updated when the change is user-visible

Additional validation performed:

- `pytest tests/unit/test_binary_sensor.py tests/unit/test_sensor.py tests/unit/test_spaces.py tests/unit/test_coordinator.py -q` in Docker
- `ruff check` on the touched implementation and test files in Docker

## Notes for the reviewer

- The `CRA connection` binary sensor now uses `Space.monitoring_companies` and reports `on` when at least one company is `APPROVED`.
- The legacy unique id for `CRA connection` is preserved to avoid orphaning the existing entity.
- The coordinator now reuses the existing space snapshot stream call to cache monitoring-company metadata alongside rooms.
