### PR TITLE
fix: 1.2.2 beta line — HTS auth timeout, SpaceEventQualifier, idle HTS, FCM dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2-beta.1] - 2026-04-28
+
+### Fixed
+- The FCM-driven instant `security_state` shortcut now fires for arm / disarm / night-mode pushes in co-brand setups where it had been silently falling through to the legacy poll-refresh path. The push payload encodes the primary transition in a `SpaceEventQualifier` (inside `SpaceNotificationContent.qualifier`), but the parser only inspected `HubEventQualifier` candidates, which in those payloads carry secondary zone-incident tags such as `ext_contact_opened` / `roller_shutter_alarm`. The parser now tries `SpaceEventQualifier` first and maps the `space_armed` / `space_disarmed` / `space_night_mode_*` family to a new `SPACE_EVENT_TAG_MAP`, falling back to `HubEventQualifier` for genuine hub-level events (alarm, tamper, …). The `event.aegis_security_event` entity also benefits because it shares the same parser. (#68)
+- The HTS authentication handshake is now bounded by an overall 20s timeout. Previously `_authenticate()` only relied on the per-chunk `READ_TIMEOUT`, so a server that kept the TCP connection alive while feeding bytes slowly could keep the handshake await alive forever — blocking `_async_update_data()` for hours and freezing the alarm panel state. On timeout the connection is closed and `HtsConnectionError` is raised, so the coordinator surfaces `UpdateFailed` and reschedules the next poll on the normal cadence. (#74)
+
 ## [1.2.1] - 2026-04-28
 
 Stable release rolling up the `1.2.1-beta.1` … `1.2.1-beta.10` line. Highlights:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2-beta.3] - 2026-04-28
+
+### Fixed
+- Automations bound to `event.aegis_security_event` no longer trigger twice for every arm / disarm / night-mode transition. The Ajax FCM backend dispatches **two separate FCM messages** per security event (a user-facing `Notification` and a silent `DispatchEvent`) ~20–30 ms apart, both carrying the same `SpaceEventQualifier`. With the new in-memory shortcut from #68 they were both reaching the event-fire / refresh path. The notification listener now dedupes by Ajax `notification_id` over a 5 s window: the second push short-circuits before `_parse_and_fire_event` and `async_request_refresh()`. Photo-URL extraction and notification-id-future resolution stay above the dedupe gate, and pushes without an extractable `notification_id` skip dedupe (defensive). The alarm panel state path was already idempotent so panel state and HTS data are unchanged. (#80)
+
 ## [1.2.2-beta.2] - 2026-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2-beta.2] - 2026-04-28
+
+### Fixed
+- HTS-backed hub-network sensors (`connection_type`, Wi-Fi SSID / IP / signal, ethernet IP / gateway / DNS, cellular network) no longer flap to `unavailable` on healthy idle connections. The HTS listen loop used to treat the very first `READ_TIMEOUT=40s` of inbound silence as a hard disconnect — but a healthy server can legitimately stay quiet beyond that window. The loop now tolerates up to `MAX_CONSECUTIVE_READ_TIMEOUTS=3` consecutive idle timeouts (~120s of full silence) before closing, resetting the counter on any real inbound message. A failed PING still closes the connection immediately, so genuine disconnects are detected without delay. (#76, thanks @bogar 🙏)
+
 ## [1.2.2-beta.1] - 2026-04-28
 
 ### Fixed

--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -52,6 +52,10 @@ HTS_HOST = "hts.prod.ajax.systems"
 HTS_PORT = 443
 PING_INTERVAL = 30
 READ_TIMEOUT = 40
+# Bound the full 4-step auth handshake. Without this, a server that keeps the
+# TCP connection alive but feeds bytes slowly can keep `_receive_message()`'s
+# per-chunk reads under READ_TIMEOUT forever, so the coroutine never resolves.
+AUTH_TIMEOUT = 20
 
 
 class HtsConnectionError(Exception):
@@ -152,7 +156,10 @@ class HtsClient:
             raise HtsConnectionError(f"Cannot connect to {self._host}:{self._port}: {exc}") from exc
 
         try:
-            return await self._authenticate()
+            return await asyncio.wait_for(self._authenticate(), timeout=AUTH_TIMEOUT)
+        except TimeoutError as exc:
+            await self.close()
+            raise HtsConnectionError(f"HTS auth handshake timed out after {AUTH_TIMEOUT}s") from exc
         except Exception:
             await self.close()
             raise

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -174,6 +174,7 @@ EVENT_DOMAIN = f"{DOMAIN}_event"
 # the resulting space-level state (PARTIALLY_ARMED, ARMED, …) depends on the
 # other groups; let the next poll resolve it.
 RAW_TAG_TO_SECURITY_STATE: dict[str, SecurityState] = {
+    # HubEventTag tags (sub-incidents that imply a space-level transition)
     "arm": SecurityState.ARMED,
     "arm_attempt": SecurityState.ARMED,
     "arm_with_malfunctions": SecurityState.ARMED,
@@ -182,6 +183,20 @@ RAW_TAG_TO_SECURITY_STATE: dict[str, SecurityState] = {
     "night_mode_on": SecurityState.NIGHT_MODE,
     "night_mode_off": SecurityState.DISARMED,
     "duress_night_mode_off": SecurityState.DISARMED,
+    # SpaceEventTag tags (the actual primary arm/disarm push from co-brand
+    # FCM payloads — see #68; HubEventQualifier candidates in the same payload
+    # only carry secondary zone-incident info such as `ext_contact_opened`).
+    "space_armed": SecurityState.ARMED,
+    "space_armed_with_malfunctions": SecurityState.ARMED,
+    "space_auto_armed": SecurityState.ARMED,
+    "space_auto_armed_with_malfunctions": SecurityState.ARMED,
+    "space_disarmed": SecurityState.DISARMED,
+    "space_auto_disarmed": SecurityState.DISARMED,
+    "space_duress_disarmed": SecurityState.DISARMED,
+    "space_night_mode_on": SecurityState.NIGHT_MODE,
+    "space_night_mode_on_with_malfunctions": SecurityState.NIGHT_MODE,
+    "space_night_mode_off": SecurityState.DISARMED,
+    "space_duress_night_mode_off": SecurityState.DISARMED,
 }
 
 
@@ -233,4 +248,29 @@ HUB_EVENT_TAG_MAP: dict[str, str] = {
     "door_opened": "door_open",
 }
 
-ALL_EVENT_TYPES: list[str] = sorted(set(HUB_EVENT_TAG_MAP.values()))
+# Map SpaceEventTag oneof field names to simplified HA event types. Used in
+# parallel to HUB_EVENT_TAG_MAP because arm/disarm pushes carry a
+# SpaceEventQualifier (in SpaceNotificationContent.qualifier), not a
+# HubEventQualifier — the former is what we need for #68 to fire.
+# `space_group_*` tags are intentionally omitted: they describe a single
+# group's transition and the resulting space-level state can only be resolved
+# from the next poll.
+SPACE_EVENT_TAG_MAP: dict[str, str] = {
+    "space_armed": "arm",
+    "space_armed_with_malfunctions": "arm",
+    "space_auto_armed": "arm",
+    "space_auto_armed_with_malfunctions": "arm",
+    "space_disarmed": "disarm",
+    "space_auto_disarmed": "disarm",
+    "space_duress_disarmed": "disarm",
+    "space_night_mode_on": "arm_night",
+    "space_night_mode_on_with_malfunctions": "arm_night",
+    "space_night_mode_off": "disarm_night",
+    "space_duress_night_mode_off": "disarm_night",
+    "space_panic_button_pressed": "panic",
+}
+
+
+ALL_EVENT_TYPES: list[str] = sorted(
+    set(HUB_EVENT_TAG_MAP.values()) | set(SPACE_EVENT_TAG_MAP.values())
+)

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.2-beta.2"
+    "version": "1.2.2-beta.3"
 }

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.1"
+    "version": "1.2.2-beta.1"
 }

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.2.2-beta.1"
+    "version": "1.2.2-beta.2"
 }

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import logging
 import re
+import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -27,6 +28,12 @@ _LOGGER = logging.getLogger(__name__)
 
 STORAGE_KEY = f"{DOMAIN}_fcm_credentials"
 STORAGE_VERSION = 1
+
+# Ajax dispatches two FCM messages per security transition (one user-facing
+# Notification + one silent DispatchEvent), separated by ~20-30 ms server-side.
+# Both share the same Ajax notification_id, so we suppress duplicate event-fire
+# and refresh paths within this window. See #80.
+NOTIFICATION_DEDUPE_WINDOW_SECONDS = 5.0
 
 
 class AjaxNotificationListener:
@@ -54,6 +61,9 @@ class AjaxNotificationListener:
         self._photo_callbacks: dict[str, asyncio.Future[str | None]] = {}
         self._notification_id_callbacks: dict[str, asyncio.Future[str | None]] = {}
         self._last_notification_id: str | None = None
+        # notification_id → time.monotonic() of first sighting; used to suppress
+        # the second of the two FCM messages Ajax sends per event (#80).
+        self._recent_notification_ids: dict[str, float] = {}
 
     async def async_start(self) -> None:
         """Register with FCM and start listening for push notifications."""
@@ -204,6 +214,7 @@ class AjaxNotificationListener:
                 _LOGGER.debug("Failed to parse ENCODED_DATA from push")
 
         # Extract notification_id for photo URL retrieval
+        notif_id: str | None = None
         if encoded_data:
             notif_id = self.extract_notification_id(encoded_data)
             if notif_id:
@@ -218,6 +229,17 @@ class AjaxNotificationListener:
                         _LOGGER.debug("Resolved notification_id for device %s", device_id)
                         break
 
+        # Dedupe Ajax's two-FCM-per-event dispatch (#80). Pushes without an
+        # extractable notification_id fall through unchanged so a parser miss
+        # never silences an unrelated event.
+        if notif_id and self._is_duplicate_notification(notif_id):
+            _LOGGER.debug(
+                "Duplicate notification_id %s within %.0fs window; skipping fire/refresh",
+                notif_id[:20],
+                NOTIFICATION_DEDUPE_WINDOW_SECONDS,
+            )
+            return
+
         # Parse event from ENCODED_DATA using compiled protos
         if encoded_data:
             self._parse_and_fire_event(encoded_data)
@@ -228,6 +250,24 @@ class AjaxNotificationListener:
                 self._hass.async_create_task,
                 self._coordinator.async_request_refresh(),
             )
+
+    def _is_duplicate_notification(self, notif_id: str) -> bool:
+        """Return True if *notif_id* was seen within the dedupe window.
+
+        Records the sighting on first call so the second push within the
+        window is suppressed. Stale entries are pruned on every call to
+        keep the dict bounded.
+        """
+        now = time.monotonic()
+        cutoff = now - NOTIFICATION_DEDUPE_WINDOW_SECONDS
+        # Prune expired entries.
+        self._recent_notification_ids = {
+            k: v for k, v in self._recent_notification_ids.items() if v > cutoff
+        }
+        if notif_id in self._recent_notification_ids:
+            return True
+        self._recent_notification_ids[notif_id] = now
+        return False
 
     async def wait_for_photo_url(self, device_id: str, timeout: float = 15.0) -> str | None:
         """Wait for a photo URL to arrive via push notification."""

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -15,6 +15,7 @@ from custom_components.aegis_ajax.const import (
     DOMAIN,
     HUB_EVENT_TAG_MAP,
     RAW_TAG_TO_SECURITY_STATE,
+    SPACE_EVENT_TAG_MAP,
 )
 
 if TYPE_CHECKING:
@@ -335,21 +336,54 @@ class AjaxNotificationListener:
             return self._extract_event_raw(raw)
 
     def _extract_event_with_compiled_protos(self, raw: bytes) -> tuple[str, dict[str, Any]] | None:
-        """Parse event by finding HubEventQualifier embedded in raw protobuf."""
+        """Parse event by finding a Hub or Space event qualifier in raw protobuf.
+
+        Arm/disarm pushes embed a `SpaceEventQualifier` (`SpaceNotificationContent.
+        qualifier`) — try those first (#68). The same payload often also carries
+        unrelated `HubEventQualifier` candidates describing zone-level
+        sub-incidents (`ext_contact_opened`, `roller_shutter_alarm`); they are
+        the legitimate primary tag for hub-level pushes (alarm, tamper, …) so
+        they remain the fallback.
+        """
         from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (  # noqa: PLC0415, E501
-            qualifier_pb2,
+            qualifier_pb2 as hub_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (  # noqa: PLC0415, E501
+            qualifier_pb2 as space_qualifier_pb2,
         )
 
-        for candidate in self._find_embedded_messages(raw):
+        candidates = self._find_embedded_messages(raw)
+
+        # Pass 1 — SpaceEventQualifier (arm/disarm/night/panic at space level).
+        for candidate in candidates:
             try:
-                qualifier = qualifier_pb2.HubEventQualifier()
+                space_q = space_qualifier_pb2.SpaceEventQualifier()
+                space_q.ParseFromString(candidate)
+            except Exception:
+                continue
+            if not space_q.HasField("tag"):
+                continue
+            tag_field = space_q.tag.WhichOneof("event_tag_case")
+            if tag_field and tag_field in SPACE_EVENT_TAG_MAP:
+                event_type = SPACE_EVENT_TAG_MAP[tag_field]
+                data: dict[str, Any] = {"raw_tag": tag_field}
+                if space_q.HasField("transition"):
+                    trans_field = space_q.transition.WhichOneof("transition")
+                    if trans_field:
+                        data["transition"] = trans_field
+                return event_type, data
+
+        # Pass 2 — HubEventQualifier (zone-level events: alarm, tamper, …).
+        for candidate in candidates:
+            try:
+                qualifier = hub_qualifier_pb2.HubEventQualifier()
                 qualifier.ParseFromString(candidate)
                 if qualifier.HasField("tag"):
                     tag = qualifier.tag
                     tag_field = tag.WhichOneof("event_tag_case")
                     if tag_field and tag_field in HUB_EVENT_TAG_MAP:
                         event_type = HUB_EVENT_TAG_MAP[tag_field]
-                        data: dict[str, Any] = {"raw_tag": tag_field}
+                        data = {"raw_tag": tag_field}
                         if qualifier.HasField("transition"):
                             trans_field = qualifier.transition.WhichOneof("transition")
                             if trans_field:

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.aegis_ajax.api.hts.client import (
+    AUTH_TIMEOUT,
     HTS_HOST,
     HTS_PORT,
     HtsClient,
+    HtsConnectionError,
 )
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
 from custom_components.aegis_ajax.api.hts.messages import HtsMessage, MsgType, tlv_encode
@@ -214,6 +216,48 @@ class TestSendMessage:
 
         assert len(captured) == 1
         assert isinstance(captured[0], bytes)
+
+
+class TestConnectAuthTimeout:
+    """Issue #74: connect() must bound the auth handshake."""
+
+    @pytest.mark.asyncio
+    async def test_authenticate_hang_raises_connection_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _make_client()
+
+        # Pretend the TCP+TLS dial succeeded so we go straight into auth.
+        async def _fake_open_connection(*_args: object, **_kwargs: object) -> tuple:
+            return MagicMock(), MagicMock()
+
+        monkeypatch.setattr(
+            "custom_components.aegis_ajax.api.hts.client.asyncio.open_connection",
+            _fake_open_connection,
+        )
+
+        # Make the handshake hang forever — exactly the symptom in #74.
+        async def _hang() -> None:
+            await asyncio.Event().wait()
+
+        async def _fake_authenticate() -> object:
+            await _hang()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(client, "_authenticate", _fake_authenticate)
+        monkeypatch.setattr(client, "close", AsyncMock())
+
+        # Override the timeout so the test doesn't actually wait 20s.
+        monkeypatch.setattr("custom_components.aegis_ajax.api.hts.client.AUTH_TIMEOUT", 0.05)
+
+        with pytest.raises(HtsConnectionError, match="auth handshake timed out"):
+            await client.connect()
+
+        client.close.assert_awaited()
+
+    def test_auth_timeout_default(self) -> None:
+        # Sanity check: default budget is bounded and reasonable.
+        assert 1 <= AUTH_TIMEOUT <= 60
 
 
 class TestHandleUpdate:

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -496,3 +496,95 @@ class TestExtractEventCompiledProtos:
         event_type, data = result
         assert event_type == "alarm"
         assert data["raw_tag"] == "intrusion_alarm"
+
+
+class TestNotificationDedupe:
+    """Issue #80: Ajax dispatches two FCM messages per security transition with
+    identical notification_id; the second must not double-fire automations."""
+
+    def _make_listener(self) -> tuple[AjaxNotificationListener, MagicMock, MagicMock]:
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.is_running.return_value = True
+        coordinator = MagicMock()
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator._space_ids = []
+        listener = AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
+        return listener, hass, coordinator
+
+    def test_duplicate_notification_id_skips_second_fire(self) -> None:
+        listener, hass, _ = self._make_listener()
+
+        # Two pushes with the same encoded data → same notification_id.
+        listener._on_notification({"ENCODED_DATA": _REAL_PUSH_ENCODED_DATA}, "pid-1")
+        listener._on_notification({"ENCODED_DATA": _REAL_PUSH_ENCODED_DATA}, "pid-2")
+
+        # First push triggered the refresh; second one short-circuited.
+        assert hass.loop.call_soon_threadsafe.call_count == 1
+
+    def test_distinct_notification_ids_both_fire(self) -> None:
+        listener, hass, _ = self._make_listener()
+
+        # First push uses the canonical real payload (notif_id = …D89E).
+        listener._on_notification({"ENCODED_DATA": _REAL_PUSH_ENCODED_DATA}, "pid-1")
+
+        # Second push has a different 64-char hex notification_id embedded in the
+        # raw bytes — extract_notification_id picks the first 64-hex match.
+        other_notif_id = "AAAA" + "B" * 60
+        encoded = base64.b64encode(other_notif_id.encode()).decode()
+        listener._on_notification({"ENCODED_DATA": encoded}, "pid-2")
+
+        assert hass.loop.call_soon_threadsafe.call_count == 2
+
+    def test_duplicate_outside_window_fires_again(self) -> None:
+        from custom_components.aegis_ajax.notification import (  # noqa: PLC0415
+            NOTIFICATION_DEDUPE_WINDOW_SECONDS,
+        )
+
+        listener, hass, _ = self._make_listener()
+
+        with patch("custom_components.aegis_ajax.notification.time.monotonic") as monotonic:
+            monotonic.return_value = 1000.0
+            listener._on_notification({"ENCODED_DATA": _REAL_PUSH_ENCODED_DATA}, "pid-1")
+
+            # Second push beyond the dedupe window — should fire again.
+            monotonic.return_value = 1000.0 + NOTIFICATION_DEDUPE_WINDOW_SECONDS + 0.1
+            listener._on_notification({"ENCODED_DATA": _REAL_PUSH_ENCODED_DATA}, "pid-2")
+
+        assert hass.loop.call_soon_threadsafe.call_count == 2
+
+    def test_push_without_notification_id_does_not_dedupe(self) -> None:
+        # Defensive: if extract_notification_id returns None (parser miss), we
+        # never want to silence the second push by accident.
+        listener, hass, _ = self._make_listener()
+
+        # Encoded data without a 64-char hex string → notif_id is None.
+        encoded = base64.b64encode(b"no hex id present here, just text").decode()
+
+        listener._on_notification({"ENCODED_DATA": encoded}, "pid-1")
+        listener._on_notification({"ENCODED_DATA": encoded}, "pid-2")
+
+        assert hass.loop.call_soon_threadsafe.call_count == 2
+
+    def test_dedupe_dict_pruned_to_recent_entries(self) -> None:
+        from custom_components.aegis_ajax.notification import (  # noqa: PLC0415
+            NOTIFICATION_DEDUPE_WINDOW_SECONDS,
+        )
+
+        listener, _, _ = self._make_listener()
+
+        with patch("custom_components.aegis_ajax.notification.time.monotonic") as monotonic:
+            monotonic.return_value = 1000.0
+            listener._on_notification({"ENCODED_DATA": _REAL_PUSH_ENCODED_DATA}, "pid-1")
+            assert _EXPECTED_NOTIFICATION_ID in listener._recent_notification_ids
+
+            # A later, distinct push prunes the expired entry.
+            monotonic.return_value = 1000.0 + NOTIFICATION_DEDUPE_WINDOW_SECONDS + 1.0
+            other = "FFFF" + "E" * 60
+            listener._on_notification(
+                {"ENCODED_DATA": base64.b64encode(other.encode()).decode()},
+                "pid-2",
+            )
+
+        assert _EXPECTED_NOTIFICATION_ID not in listener._recent_notification_ids
+        assert other in listener._recent_notification_ids

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -309,3 +309,190 @@ class TestApplySecurityStateFromEvent:
         listener._apply_security_state_from_event("space-1", {"raw_tag": "arm"})
 
         hass.loop.call_soon_threadsafe.assert_not_called()
+
+    def test_space_armed_tag_dispatches_armed_state(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "space_armed"})
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.apply_push_security_state, "space-1", SecurityState.ARMED
+        )
+
+    def test_space_disarmed_tag_dispatches_disarmed_state(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "space_disarmed"})
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.apply_push_security_state, "space-1", SecurityState.DISARMED
+        )
+
+    def test_space_night_mode_on_dispatches_night_mode_state(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "space_night_mode_on"})
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.apply_push_security_state, "space-1", SecurityState.NIGHT_MODE
+        )
+
+    def test_space_group_armed_does_not_dispatch(self) -> None:
+        # Group-level transitions don't determine the space-level state alone.
+        listener, hass, _ = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "space_group_armed"})
+
+        hass.loop.call_soon_threadsafe.assert_not_called()
+
+
+class TestExtractEventCompiledProtos:
+    """Issue #68: arm/disarm pushes carry a SpaceEventQualifier, not Hub one."""
+
+    def _make_listener(self) -> AjaxNotificationListener:
+        hass = MagicMock()
+        coordinator = MagicMock()
+        return AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
+
+    @staticmethod
+    def _wrap(payload: bytes) -> bytes:
+        # Embed `payload` as a length-delimited submessage of an outer parent
+        # (field 1, wire type 2) so `_find_embedded_messages` surfaces it.
+        # `_find_embedded_messages` filters candidates with `4 < length < 500`,
+        # so callers must pass payloads of >=5 bytes (qualifier + transition
+        # always satisfies that in real FCM data).
+        assert len(payload) > 4
+        return b"\x0a" + bytes([len(payload)]) + payload
+
+    def test_space_armed_qualifier_resolved_first(self) -> None:
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
+            transition_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (  # noqa: E501
+            qualifier_pb2 as space_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (
+            tag_pb2 as space_tag_pb2,
+        )
+
+        qualifier = space_qualifier_pb2.SpaceEventQualifier(
+            tag=space_tag_pb2.SpaceEventTag(space_armed=space_tag_pb2.SpaceArmed()),
+            transition=transition_pb2.EventTransition(
+                impulse=transition_pb2.EventTransition.Impulse()
+            ),
+        )
+        wrapped = self._wrap(qualifier.SerializeToString())
+
+        listener = self._make_listener()
+        result = listener._extract_event_with_compiled_protos(wrapped)
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "arm"
+        assert data["raw_tag"] == "space_armed"
+
+    def test_space_disarmed_qualifier(self) -> None:
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
+            transition_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (  # noqa: E501
+            qualifier_pb2 as space_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (
+            tag_pb2 as space_tag_pb2,
+        )
+
+        qualifier = space_qualifier_pb2.SpaceEventQualifier(
+            tag=space_tag_pb2.SpaceEventTag(space_disarmed=space_tag_pb2.SpaceDisarmed()),
+            transition=transition_pb2.EventTransition(
+                impulse=transition_pb2.EventTransition.Impulse()
+            ),
+        )
+        wrapped = self._wrap(qualifier.SerializeToString())
+
+        listener = self._make_listener()
+        result = listener._extract_event_with_compiled_protos(wrapped)
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "disarm"
+        assert data["raw_tag"] == "space_disarmed"
+
+    def test_space_qualifier_preferred_over_hub_subincident(self) -> None:
+        # When both a SpaceEventQualifier (primary) and a HubEventQualifier
+        # (sub-incident, e.g. ext_contact_opened) are present in the same
+        # payload, the space-level transition wins.
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
+            transition_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (  # noqa: E501
+            qualifier_pb2 as hub_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (
+            tag_pb2 as hub_tag_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (  # noqa: E501
+            qualifier_pb2 as space_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (
+            tag_pb2 as space_tag_pb2,
+        )
+
+        space_q = space_qualifier_pb2.SpaceEventQualifier(
+            tag=space_tag_pb2.SpaceEventTag(space_night_mode_on=space_tag_pb2.SpaceNightModeOn()),
+            transition=transition_pb2.EventTransition(
+                impulse=transition_pb2.EventTransition.Impulse()
+            ),
+        )
+        hub_q = hub_qualifier_pb2.HubEventQualifier(
+            tag=hub_tag_pb2.HubEventTag(intrusion_alarm=hub_tag_pb2.IntrusionAlarm()),
+            transition=transition_pb2.EventTransition(
+                triggered=transition_pb2.EventTransition.Triggered()
+            ),
+        )
+        # Place the hub qualifier BEFORE the space one so the test would fail
+        # if we were still picking the first parseable HubEventQualifier.
+        wrapped = self._wrap(hub_q.SerializeToString()) + self._wrap(space_q.SerializeToString())
+
+        listener = self._make_listener()
+        result = listener._extract_event_with_compiled_protos(wrapped)
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "arm_night"
+        assert data["raw_tag"] == "space_night_mode_on"
+
+    def test_hub_qualifier_used_when_no_space_qualifier(self) -> None:
+        # Hub-level events (alarm, tamper, …) still resolve through the
+        # existing HubEventQualifier path.
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
+            transition_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (  # noqa: E501
+            qualifier_pb2 as hub_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (
+            tag_pb2 as hub_tag_pb2,
+        )
+
+        qualifier = hub_qualifier_pb2.HubEventQualifier(
+            tag=hub_tag_pb2.HubEventTag(intrusion_alarm=hub_tag_pb2.IntrusionAlarm()),
+            transition=transition_pb2.EventTransition(
+                triggered=transition_pb2.EventTransition.Triggered()
+            ),
+        )
+        wrapped = self._wrap(qualifier.SerializeToString())
+
+        listener = self._make_listener()
+        result = listener._extract_event_with_compiled_protos(wrapped)
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "alarm"
+        assert data["raw_tag"] == "intrusion_alarm"


### PR DESCRIPTION
Consolidates the work shipped through `1.2.2-beta.1` → `1.2.2-beta.3` so it can land on `main` ahead of the `1.2.2` stable bump.

## What's in
- **#74** — HTS auth handshake bounded by `AUTH_TIMEOUT=20s` so a server feeding bytes slowly cannot keep `_authenticate()` alive forever. On timeout the connection closes and `HtsConnectionError` propagates so the coordinator surfaces `UpdateFailed` and reschedules the next poll. (`AUTH_TIMEOUT`, `connect()` in `api/hts/client.py`.)
- **#68** — FCM arm/disarm/night-mode pushes finally drive the in-memory shortcut. The parser now tries `SpaceEventQualifier` (where the primary `space_armed` / `space_disarmed` / `space_night_mode_*` tags live, inside `SpaceNotificationContent.qualifier`) before falling back to `HubEventQualifier` for genuine hub-level events. New `SPACE_EVENT_TAG_MAP` plus `space_*` entries in `RAW_TAG_TO_SECURITY_STATE` and `ALL_EVENT_TYPES`.
- **#76** — Idle HTS read timeouts are now tolerated up to `MAX_CONSECUTIVE_READ_TIMEOUTS=3` (~120s of total silence) before closing, with the counter resetting on any inbound message, and the `_ping_loop` exception path explicitly closes the connection on a write/drain failure (replacing the previous `contextlib.suppress`). Authored by @bogar in PR #77, already merged into `main`; included here via the merge commit so this PR resolves cleanly without re-landing the same commit.
- **#80** — Ajax dispatches **two** FCM messages per security transition (a user-facing `Notification` + a silent `DispatchEvent`) ~20–30 ms apart with the same `notification_id`. The notification listener now dedupes by `notification_id` over a 5 s window, so the second push short-circuits before `_parse_and_fire_event` and `async_request_refresh()`. Photo-URL extraction and notification-id-future resolution remain above the dedupe gate. Pushes without an extractable `notification_id` skip dedupe defensively.

## Validation on real-HA (`1.2.2-beta.3`)
- `HTS connected, 1 hub(s)` in 4 s on a fresh restart — the new `AUTH_TIMEOUT` is not exercised by the happy path.
- Arm-night and disarm from the Ajax mobile app: `event.aegis_security_event` now fires with `raw_tag=space_armed` / `space_disarmed` / `space_night_mode_*` and `alarm_control_panel.last_changed` lands within 20–40 ms of the push (vs the previous 5-min poll lag in co-brand setups).
- Each transition produces a single `Manually updated aegis_ajax data` plus a single `Finished fetching aegis_ajax data` plus a single automation run; the second FCM push triggers the new `Duplicate notification_id … within 5s window; skipping fire/refresh` line and is otherwise a no-op.
- 30+ minutes of post-restart monitoring with no `unavailable` flap on `binary_sensor.*ethernet`, `binary_sensor.*celular_conectado`, `sensor.*ip_ethernet`, etc.

## Tests
- `make check` inside a freshly built Docker image without volume mount: 904 unit tests pass, coverage 81.04%, ruff + format + mypy + vulture clean.
- New tests cover `SpaceEventQualifier` parsing for `space_armed` / `space_disarmed` / `space_night_mode_on`, priority over a sub-incident `HubEventQualifier`, fall-through to `HubEventQualifier` for hub-level events, the auth handshake timeout path, the dedupe gate (in-window suppression, distinct ids both fire, beyond-window fires again, no-id skips dedupe, dict pruning).

## Notes for the merge
- Version on `main` after merging will be `1.2.2-beta.3`. The `1.2.2` stable bump + tag is intentionally **not** part of this PR — it will follow once beta.3 has had a couple of days of real-HA soak time.
- `CHANGELOG.md` already documents the three beta entries; the stable bump will collapse them into a `1.2.2` rollup.
- This PR contains the same `#76` commits already on `main` (via PR #77's merge commit). The merge into this branch was done with `git merge origin/main --no-ff` so GitHub should detect the duplicates and merge cleanly without re-landing them.