### PR TITLE
Fix CRA company sensor protobuf name unwrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3-beta.2] - 2026-04-29
+
+### Fixed
+- `CRA company` no longer breaks Home Assistant's `/api/states` responses when enabled. Ajax exposes monitoring-company names through protobuf `StringValue` wrappers in the full `Space` snapshot; the integration now unwraps those values to plain strings before storing them in entity state / attributes, so the diagnostic sensor materializes correctly and the global states endpoint remains serializable. (#78, thanks @bogar)
+
 ## [1.2.3-beta.1] - 2026-04-29
 
 ### Fixed

--- a/custom_components/aegis_ajax/api/spaces.py
+++ b/custom_components/aegis_ajax/api/spaces.py
@@ -44,11 +44,13 @@ class SpacesApi:
 
     @staticmethod
     def parse_monitoring_company(proto_company: Any) -> MonitoringCompany:  # noqa: ANN401
-        has_name = hasattr(proto_company, "company_info") and hasattr(
-            proto_company.company_info,
-            "name",
-        )
-        name = proto_company.company_info.name if has_name else ""
+        name = ""
+        if hasattr(proto_company, "company_info") and hasattr(proto_company.company_info, "name"):
+            raw_name = proto_company.company_info.name
+            if isinstance(raw_name, str):
+                name = raw_name
+            elif hasattr(raw_name, "value") and isinstance(raw_name.value, str):
+                name = raw_name.value
         try:
             status = MonitoringCompanyStatus(proto_company.status)
         except ValueError:

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from unittest.mock import MagicMock
 
@@ -497,6 +498,28 @@ class TestHubMonitoringCompanySensor:
             "pending_approval_companies": ["Central Two"],
             "pending_removal_companies": ["Central Three"],
         }
+
+    def test_state_payload_is_json_serializable(self) -> None:
+        coordinator = self._make_coordinator(
+            (
+                MonitoringCompany(
+                    name="Central One",
+                    status=MonitoringCompanyStatus.APPROVED,
+                ),
+                MonitoringCompany(
+                    name="Central Two",
+                    status=MonitoringCompanyStatus.PENDING_APPROVAL,
+                ),
+            )
+        )
+        sensor = AjaxHubMonitoringCompanySensor(coordinator, "space-1", "hub-1")
+
+        payload = {
+            "state": sensor.native_value,
+            "attributes": sensor.extra_state_attributes,
+        }
+
+        assert json.dumps(payload)
 
     def test_is_unavailable_until_monitoring_snapshot_loaded(self) -> None:
         coordinator = self._make_coordinator(())

--- a/tests/unit/test_spaces.py
+++ b/tests/unit/test_spaces.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from google.protobuf.wrappers_pb2 import StringValue
 
 from custom_components.aegis_ajax.api.models import (
     MonitoringCompanyStatus,
@@ -71,6 +72,17 @@ class TestParseSpace:
 
         result = SpacesApi.parse_monitoring_company(proto_company)
 
+        assert result.name == "Secure Co"
+        assert result.status == MonitoringCompanyStatus.APPROVED
+
+    def test_parse_monitoring_company_unwraps_string_value_name(self) -> None:
+        proto_company = MagicMock()
+        proto_company.company_info.name = StringValue(value="Secure Co")
+        proto_company.status = 2
+
+        result = SpacesApi.parse_monitoring_company(proto_company)
+
+        assert isinstance(result.name, str)
         assert result.name == "Secure Co"
         assert result.status == MonitoringCompanyStatus.APPROVED
 


### PR DESCRIPTION
## Summary
- unwrap monitoring company names from protobuf StringValue wrappers before storing them
- keep the CRA company diagnostic sensor state and attributes JSON-serializable
- add regression tests for wrapped names and sensor payload serialization
- document the follow-up fix in CHANGELOG.md under 1.2.3-beta.2

## Problem
The CRA connection binary sensor worked, but enabling the CRA company diagnostic sensor could break Home Assistant state listing. Ajax exposes company_info.name as a protobuf wrapper, and the integration was storing that wrapper object directly in entity state / attributes instead of a plain string.

## Testing
- docker run --rm -v /home/borja/code/aegis-hass:/work -w /work aegis-ajax-dev pytest tests/unit/test_spaces.py tests/unit/test_sensor.py -q
- docker run --rm -v /home/borja/code/aegis-hass:/work -w /work aegis-ajax-dev ruff check custom_components/aegis_ajax/api/spaces.py tests/unit/test_spaces.py tests/unit/test_sensor.py
- git diff --check