### PR TITLE
docs(readme): clarify where FCM api_key actually lives

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ The required fields (configured in the integration's Options flow, stored secure
 
 ### How to obtain FCM credentials
 
-The FCM credentials can be found in the app's resources (`res/values/strings.xml`) or native libraries. Look for `google_app_id`, `gcm_defaultSenderId`, `project_id`, and `google_api_key`.
+Three of the four values are plain strings in the app's `res/values/strings.xml`: `project_id`, `gcm_defaultSenderId` and `google_app_id`. The fourth, `google_api_key`, is **not** in `strings.xml` (the value there is a placeholder); it ships inside `lib/<arch>/libnative-lib.so` bundled with the APK.
 
 If FCM credentials are not configured, the integration will still work using the persistent gRPC stream for real-time updates. FCM adds an additional push notification channel for faster event delivery and enables Photo on Demand URL retrieval.
 


### PR DESCRIPTION
## Summary

- Splits the "How to obtain FCM credentials" section into the three values that live in `res/values/strings.xml` (`project_id`, `gcm_defaultSenderId`, `google_app_id`) and the `google_api_key`, which is bundled inside `lib/<arch>/libnative-lib.so`.
- Calls out explicitly that the value of `google_api_key` in `strings.xml` is a placeholder so users don't waste time grepping for it there.

## Why

In #83 a user with a standard Ajax setup tried to extract the FCM credentials following the README and hit a dead end on `google_api_key` — the section's "or" wording incorrectly implied all four values could be in either location. This is a docs-only clarification.

## Test plan

- [x] make check (lint, typecheck, tests, dead code) passed via the pre-push CI hook (915 tests).
- [x] Render preview of README.md on GitHub looks correct in the new "How to obtain FCM credentials" subsection.

Refs #83