### PR TITLE
feat(alarm): per-group alarm_control_panel for spaces in Group/Zone Mode

### DIFF
--- a/custom_components/aegis_ajax/alarm_control_panel.py
+++ b/custom_components/aegis_ajax/alarm_control_panel.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from custom_components.aegis_ajax.api.models import Space
+    from custom_components.aegis_ajax.api.models import Group, Space
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -217,10 +217,17 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
-    entities = [
-        AjaxAlarmControlPanel(coordinator=coordinator, space_id=space_id)
-        for space_id in coordinator.spaces
-    ]
+    entities: list[AlarmControlPanelEntity] = []
+    for space_id, space in coordinator.spaces.items():
+        if space.group_mode_enabled and space.groups:
+            entities.extend(
+                AjaxGroupAlarmControlPanel(
+                    coordinator=coordinator, space_id=space_id, group_id=group.id
+                )
+                for group in space.groups
+            )
+        else:
+            entities.append(AjaxAlarmControlPanel(coordinator=coordinator, space_id=space_id))
     async_add_entities(entities)
 
 
@@ -396,5 +403,136 @@ class AjaxAlarmControlPanel(CoordinatorEntity[AjaxCobrandedCoordinator], AlarmCo
         expiry = asyncio.get_running_loop().time() + 10
         self.coordinator._optimistic_space_states[self._space_id] = (expiry, new_state)
         # Notify HA of the state change (may not have hass during tests)
+        if self.hass is not None:
+            self.async_write_ha_state()
+
+
+class AjaxGroupAlarmControlPanel(
+    CoordinatorEntity[AjaxCobrandedCoordinator], AlarmControlPanelEntity
+):
+    """Alarm control panel for a single Ajax security group.
+
+    Created per `Group` when the parent space is in Group/Zone mode. Calls
+    `SpaceSecurityService/armGroup` and `disarmGroup` so each panel can be
+    armed/disarmed independently. Night mode is intentionally not exposed
+    on per-group panels — the underlying flag is space-wide on Ajax, so
+    surfacing it per group would mislead users about scope.
+    """
+
+    _attr_has_entity_name = True
+    _attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, space_id: str, group_id: str) -> None:
+        super().__init__(coordinator)
+        self._space_id = space_id
+        self._group_id = group_id
+        self._attr_unique_id = f"aegis_ajax_alarm_{space_id}_group_{group_id}"
+        space = coordinator.spaces.get(space_id)
+        group = space.get_group(group_id) if space else None
+        self._attr_name = group.name if group else f"Group {group_id}"
+        hub_id = space.hub_id if space else space_id
+        hub_device = coordinator.devices.get(hub_id)
+        if hub_device:
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, hub_id)},
+                name=space.name if space else "Ajax Hub",
+                manufacturer=MANUFACTURER,
+                model="Hub",
+            )
+
+    def _get_options(self) -> dict[str, Any]:
+        entry = self.coordinator.config_entry
+        return dict(entry.options) if entry is not None else {}
+
+    @property
+    def code_arm_required(self) -> bool:
+        return bool(self._get_options().get("use_pin_code", False))
+
+    def _validate_code(self, code: str | None) -> None:
+        if not self.code_arm_required:
+            return
+        stored_hash = self._get_options().get("pin_code_hash", "")
+        computed = hashlib.sha256(code.encode()).hexdigest() if code else ""
+        if not code or not hmac.compare_digest(computed, stored_hash):
+            raise HomeAssistantError("Invalid alarm code")
+
+    @property
+    def _force_arm(self) -> bool:
+        return bool(self._get_options().get(CONF_FORCE_ARM, False))
+
+    @property
+    def _space(self) -> Space | None:
+        return self.coordinator.spaces.get(self._space_id)
+
+    @property
+    def _group(self) -> Group | None:
+        space = self._space
+        return space.get_group(self._group_id) if space else None
+
+    @property
+    def available(self) -> bool:
+        space = self._space
+        return space is not None and space.is_online and self._group is not None
+
+    @property
+    def alarm_state(self) -> AlarmControlPanelState | None:
+        group = self._group
+        if group is None:
+            return None
+        return map_security_state(group.security_state)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        space = self._space
+        group = self._group
+        if space is None or group is None:
+            return {}
+        return {
+            "hub_id": space.hub_id,
+            "space_id": space.id,
+            "group_id": group.id,
+            "group_name": group.name,
+            "connection_status": space.connection_status.name,
+        }
+
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        self._validate_code(code)
+        from custom_components.aegis_ajax.api.security import SecurityError  # noqa: PLC0415
+
+        try:
+            await self.coordinator.security_api.arm_group(
+                self._space_id, self._group_id, ignore_alarms=self._force_arm
+            )
+        except SecurityError as err:
+            raise HomeAssistantError(str(err)) from err
+        self._optimistic_state_update(SecurityState.ARMED)
+        await self.coordinator.async_request_refresh()
+
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        self._validate_code(code)
+        from custom_components.aegis_ajax.api.security import SecurityError  # noqa: PLC0415
+
+        try:
+            await self.coordinator.security_api.disarm_group(self._space_id, self._group_id)
+        except SecurityError as err:
+            raise HomeAssistantError(str(err)) from err
+        self._optimistic_state_update(SecurityState.DISARMED)
+        await self.coordinator.async_request_refresh()
+
+    def _optimistic_state_update(self, new_state: SecurityState) -> None:
+        from dataclasses import replace  # noqa: PLC0415
+
+        space = self._space
+        group = self._group
+        if space is None or group is None:
+            return
+        try:
+            new_group = replace(group, security_state=new_state)
+            new_groups = tuple(new_group if g.id == self._group_id else g for g in space.groups)
+            self.coordinator.spaces[self._space_id] = replace(space, groups=new_groups)
+        except TypeError:
+            return  # not a real dataclass (e.g. during tests)
         if self.hass is not None:
             self.async_write_ha_state()

--- a/custom_components/aegis_ajax/api/models.py
+++ b/custom_components/aegis_ajax/api/models.py
@@ -31,6 +31,31 @@ class MonitoringCompany:
 
 
 @dataclass(frozen=True)
+class Group:
+    """Represents an Ajax security group inside a space.
+
+    A group is a subset of devices that can be armed/disarmed independently.
+    The Ajax mobile app exposes this feature as "Group Mode" on older
+    firmwares and "Zone Mode" on newer ones; the underlying gRPC payload is
+    the same `GroupSecurity` message in both cases.
+    """
+
+    id: str
+    space_id: str
+    name: str
+    security_state: SecurityState
+    sorting_key: str = ""
+
+    @property
+    def is_armed(self) -> bool:
+        return self.security_state in (
+            SecurityState.ARMED,
+            SecurityState.NIGHT_MODE,
+            SecurityState.PARTIALLY_ARMED,
+        )
+
+
+@dataclass(frozen=True)
 class Space:
     """Represents an Ajax space (hub)."""
 
@@ -42,6 +67,8 @@ class Space:
     malfunctions_count: int
     monitoring_companies: tuple[MonitoringCompany, ...] = field(default_factory=tuple)
     monitoring_companies_loaded: bool = False
+    groups: tuple[Group, ...] = field(default_factory=tuple)
+    group_mode_enabled: bool = False
 
     @property
     def is_online(self) -> bool:
@@ -67,6 +94,9 @@ class Space:
     def has_monitoring(self) -> bool:
         return bool(self.approved_monitoring_companies)
 
+    def get_group(self, group_id: str) -> Group | None:
+        return next((g for g in self.groups if g.id == group_id), None)
+
 
 @dataclass(frozen=True)
 class Room:
@@ -84,6 +114,8 @@ class SpaceSnapshot:
     rooms: tuple[Room, ...] = field(default_factory=tuple)
     monitoring_companies: tuple[MonitoringCompany, ...] = field(default_factory=tuple)
     monitoring_companies_loaded: bool = False
+    groups: tuple[Group, ...] = field(default_factory=tuple)
+    group_mode_enabled: bool = False
 
 
 @dataclass(frozen=True)

--- a/custom_components/aegis_ajax/api/spaces.py
+++ b/custom_components/aegis_ajax/api/spaces.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from custom_components.aegis_ajax.api.models import (
+    Group,
     MonitoringCompany,
     MonitoringCompanyStatus,
     Room,
@@ -13,6 +14,16 @@ from custom_components.aegis_ajax.api.models import (
     SpaceSnapshot,
 )
 from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
+
+# GroupSecurity.State proto enum:
+#   GROUP_SECURITY_STATE_NONE = 0
+#   GROUP_SECURITY_STATE_ARMED = 1
+#   GROUP_SECURITY_STATE_DISARMED = 2
+_GROUP_STATE_MAP: dict[int, SecurityState] = {
+    0: SecurityState.NONE,
+    1: SecurityState.ARMED,
+    2: SecurityState.DISARMED,
+}
 
 if TYPE_CHECKING:
     from custom_components.aegis_ajax.api.client import AjaxGrpcClient
@@ -41,6 +52,51 @@ class SpacesApi:
             connection_status=ConnectionStatus(proto_space.hub_connection_status),
             malfunctions_count=proto_space.malfunctions_count,
         )
+
+    @staticmethod
+    def parse_groups(proto_security: Any, space_id: str) -> tuple[tuple[Group, ...], bool]:  # noqa: ANN401
+        """Extract groups + group-mode flag from a `SpaceSecurity` proto.
+
+        Combines the group definitions in `security.groups[]` (id, name,
+        sorting_key) with the per-group security states in
+        `security.mode.group_mode.groups[]` keyed by `group_id`. When the
+        space is in regular mode (no group_mode oneof), returns an empty
+        tuple regardless of whether group definitions exist — the official
+        Ajax UI does the same.
+        """
+        if not hasattr(proto_security, "groups") or not hasattr(proto_security, "mode"):
+            return (), False
+        mode = proto_security.mode
+        group_mode_active = hasattr(mode, "WhichOneof") and mode.WhichOneof("mode") == "group_mode"
+        if not group_mode_active:
+            return (), False
+
+        # Per-group state map keyed by group_id.
+        states: dict[str, SecurityState] = {}
+        if hasattr(mode, "group_mode") and hasattr(mode.group_mode, "groups"):
+            for group_security in mode.group_mode.groups:
+                gid = getattr(group_security, "group_id", "")
+                if not gid:
+                    continue
+                proto_state = getattr(group_security, "state", 0)
+                states[gid] = _GROUP_STATE_MAP.get(int(proto_state), SecurityState.NONE)
+
+        groups: list[Group] = []
+        for proto_group in proto_security.groups:
+            gid = getattr(proto_group, "id", "")
+            if not gid:
+                continue
+            groups.append(
+                Group(
+                    id=gid,
+                    space_id=space_id,
+                    name=getattr(proto_group, "name", "") or "",
+                    security_state=states.get(gid, SecurityState.NONE),
+                    sorting_key=getattr(proto_group, "sorting_key", "") or "",
+                )
+            )
+        groups.sort(key=lambda g: (g.sorting_key, g.name))
+        return tuple(groups), True
 
     @staticmethod
     def parse_monitoring_company(proto_company: Any) -> MonitoringCompany:  # noqa: ANN401
@@ -102,6 +158,8 @@ class SpacesApi:
 
         rooms: list[Room] = []
         monitoring_companies: list[MonitoringCompany] = []
+        groups: tuple[Group, ...] = ()
+        group_mode_enabled: bool = False
         try:
             async for msg in stream:
                 if msg.HasField("failure"):
@@ -111,10 +169,13 @@ class SpacesApi:
                     continue
                 if msg.success.WhichOneof("success") != "snapshot":
                     continue
-                for proto_room in msg.success.snapshot.rooms:
+                snapshot = msg.success.snapshot
+                for proto_room in snapshot.rooms:
                     rooms.append(Room(id=proto_room.id, name=proto_room.name, space_id=space_id))
-                for proto_company in msg.success.snapshot.monitoring_companies:
+                for proto_company in snapshot.monitoring_companies:
                     monitoring_companies.append(self.parse_monitoring_company(proto_company))
+                if hasattr(snapshot, "security"):
+                    groups, group_mode_enabled = self.parse_groups(snapshot.security, space_id)
                 break
         finally:
             cancel = getattr(stream, "cancel", None)
@@ -125,6 +186,8 @@ class SpacesApi:
             rooms=tuple(rooms),
             monitoring_companies=tuple(monitoring_companies),
             monitoring_companies_loaded=True,
+            groups=groups,
+            group_mode_enabled=group_mode_enabled,
         )
 
     async def list_rooms(self, space_id: str) -> list[Room]:

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -262,6 +262,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                             current_space,
                             monitoring_companies=snapshot.monitoring_companies,
                             monitoring_companies_loaded=snapshot.monitoring_companies_loaded,
+                            groups=snapshot.groups,
+                            group_mode_enabled=snapshot.group_mode_enabled,
                         )
                 self.rooms = refreshed_rooms
                 self._rooms_last_fetch = now

--- a/tests/unit/test_alarm_control_panel.py
+++ b/tests/unit/test_alarm_control_panel.py
@@ -9,9 +9,10 @@ import pytest
 
 from custom_components.aegis_ajax.alarm_control_panel import (
     AjaxAlarmControlPanel,
+    AjaxGroupAlarmControlPanel,
     map_security_state,
 )
-from custom_components.aegis_ajax.api.models import Space
+from custom_components.aegis_ajax.api.models import Group, Space
 from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
 
 
@@ -307,3 +308,113 @@ class TestAlarmControlPanel:
         with pytest.raises(HomeAssistantError):
             await panel.async_alarm_arm_away(code="0000")
         coordinator.security_api.arm.assert_not_called()
+
+
+class TestGroupAlarmControlPanel:
+    def _make_space_with_groups(
+        self,
+        group_states: list[tuple[str, str, SecurityState]] | None = None,
+        online: bool = True,
+    ) -> Space:
+        groups = tuple(
+            Group(id=gid, space_id="s1", name=name, security_state=state, sorting_key=gid)
+            for gid, name, state in (group_states or [("g1", "Villa", SecurityState.DISARMED)])
+        )
+        return Space(
+            id="s1",
+            hub_id="h1",
+            name="Home",
+            security_state=SecurityState.PARTIALLY_ARMED,
+            connection_status=ConnectionStatus.ONLINE if online else ConnectionStatus.OFFLINE,
+            malfunctions_count=0,
+            groups=groups,
+            group_mode_enabled=True,
+        )
+
+    def _make_coordinator(self) -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.config_entry.options = {}
+        return coordinator
+
+    def test_unique_id_per_group(self) -> None:
+        coordinator = self._make_coordinator()
+        panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
+        assert panel.unique_id == "aegis_ajax_alarm_s1_group_g1"
+
+    def test_name_is_group_name(self) -> None:
+        coordinator = self._make_coordinator()
+        coordinator.spaces = {
+            "s1": self._make_space_with_groups([("g1", "Villa", SecurityState.DISARMED)])
+        }
+        coordinator.devices = {}
+        coordinator.rooms = {}
+        panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
+        assert panel.name == "Villa"
+
+    def test_alarm_state_reflects_group_state(self) -> None:
+        from homeassistant.components.alarm_control_panel import (
+            AlarmControlPanelState,
+        )
+
+        coordinator = self._make_coordinator()
+        coordinator.spaces = {
+            "s1": self._make_space_with_groups(
+                [("g1", "Villa", SecurityState.ARMED), ("g2", "Apartment", SecurityState.DISARMED)]
+            )
+        }
+        coordinator.devices = {}
+        coordinator.rooms = {}
+        p1 = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
+        p2 = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g2")
+        assert p1.alarm_state == AlarmControlPanelState.ARMED_AWAY
+        assert p2.alarm_state == AlarmControlPanelState.DISARMED
+
+    def test_unavailable_when_group_missing(self) -> None:
+        coordinator = self._make_coordinator()
+        coordinator.spaces = {"s1": self._make_space_with_groups()}
+        coordinator.devices = {}
+        coordinator.rooms = {}
+        panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="ghost")
+        assert panel.available is False
+
+    def test_extra_attributes(self) -> None:
+        coordinator = self._make_coordinator()
+        coordinator.spaces = {
+            "s1": self._make_space_with_groups([("g1", "Villa", SecurityState.ARMED)])
+        }
+        coordinator.devices = {}
+        coordinator.rooms = {}
+        panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
+        attrs = panel.extra_state_attributes
+        assert attrs["group_id"] == "g1"
+        assert attrs["group_name"] == "Villa"
+        assert attrs["space_id"] == "s1"
+        assert attrs["hub_id"] == "h1"
+
+    @pytest.mark.asyncio
+    async def test_arm_calls_arm_group(self) -> None:
+        coordinator = self._make_coordinator()
+        coordinator.spaces = {
+            "s1": self._make_space_with_groups([("g1", "Villa", SecurityState.DISARMED)])
+        }
+        coordinator.devices = {}
+        coordinator.rooms = {}
+        coordinator.security_api.arm_group = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+        panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
+        await panel.async_alarm_arm_away()
+        coordinator.security_api.arm_group.assert_called_once_with("s1", "g1", ignore_alarms=False)
+
+    @pytest.mark.asyncio
+    async def test_disarm_calls_disarm_group(self) -> None:
+        coordinator = self._make_coordinator()
+        coordinator.spaces = {
+            "s1": self._make_space_with_groups([("g1", "Villa", SecurityState.ARMED)])
+        }
+        coordinator.devices = {}
+        coordinator.rooms = {}
+        coordinator.security_api.disarm_group = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+        panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
+        await panel.async_alarm_disarm()
+        coordinator.security_api.disarm_group.assert_called_once_with("s1", "g1")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,6 +4,7 @@ from custom_components.aegis_ajax.api.models import (
     BatteryInfo,
     Device,
     DeviceCommand,
+    Group,
     Room,
     Space,
 )
@@ -103,6 +104,62 @@ class TestDevice:
             battery=None,
         )
         assert device.is_online is False
+
+
+class TestGroup:
+    def test_creation(self) -> None:
+        group = Group(
+            id="grp-1",
+            space_id="space-1",
+            name="Villa",
+            security_state=SecurityState.DISARMED,
+            sorting_key="01",
+        )
+        assert group.id == "grp-1"
+        assert group.name == "Villa"
+        assert group.is_armed is False
+
+    def test_is_armed(self) -> None:
+        for state in (SecurityState.ARMED, SecurityState.NIGHT_MODE, SecurityState.PARTIALLY_ARMED):
+            group = Group(
+                id="g",
+                space_id="s",
+                name="X",
+                security_state=state,
+            )
+            assert group.is_armed is True
+
+
+class TestSpaceGroups:
+    def test_get_group_by_id(self) -> None:
+        g1 = Group(id="g1", space_id="s1", name="Villa", security_state=SecurityState.ARMED)
+        g2 = Group(id="g2", space_id="s1", name="Apartment", security_state=SecurityState.DISARMED)
+        space = Space(
+            id="s1",
+            hub_id="h1",
+            name="Home",
+            security_state=SecurityState.PARTIALLY_ARMED,
+            connection_status=ConnectionStatus.ONLINE,
+            malfunctions_count=0,
+            groups=(g1, g2),
+            group_mode_enabled=True,
+        )
+        assert space.get_group("g1") is g1
+        assert space.get_group("g2") is g2
+        assert space.get_group("unknown") is None
+        assert space.group_mode_enabled is True
+
+    def test_default_no_groups(self) -> None:
+        space = Space(
+            id="s1",
+            hub_id="h1",
+            name="Home",
+            security_state=SecurityState.DISARMED,
+            connection_status=ConnectionStatus.ONLINE,
+            malfunctions_count=0,
+        )
+        assert space.groups == ()
+        assert space.group_mode_enabled is False
 
 
 class TestRoom:

--- a/tests/unit/test_spaces.py
+++ b/tests/unit/test_spaces.py
@@ -6,6 +6,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from google.protobuf.wrappers_pb2 import StringValue
+from systems.ajax.api.mobile.v2.common.space.security import (
+    space_security_mode_pb2,
+    space_security_pb2,
+)
+from systems.ajax.api.mobile.v2.common.space.security.group import (
+    group_mode_space_security_pb2,
+    group_pb2,
+    group_security_pb2,
+)
+from systems.ajax.api.mobile.v2.common.space.security.regular import (
+    regular_mode_space_security_pb2,
+)
 
 from custom_components.aegis_ajax.api.models import (
     MonitoringCompanyStatus,
@@ -85,6 +97,87 @@ class TestParseSpace:
         assert isinstance(result.name, str)
         assert result.name == "Secure Co"
         assert result.status == MonitoringCompanyStatus.APPROVED
+
+
+class TestParseGroups:
+    """Parse group definitions + per-group security state from a SpaceSecurity proto."""
+
+    def _build_security(
+        self,
+        groups: list[tuple[str, str, str]] | None = None,
+        states: dict[str, int] | None = None,
+        mode: str = "group_mode",
+    ) -> space_security_pb2.SpaceSecurity:
+        proto_groups = [
+            group_pb2.Group(id=gid, name=name, sorting_key=sort_key)
+            for gid, name, sort_key in (groups or [])
+        ]
+        if mode == "group_mode":
+            group_securities = [
+                group_security_pb2.GroupSecurity(group_id=gid, state=state)
+                for gid, state in (states or {}).items()
+            ]
+            mode_msg = space_security_mode_pb2.SpaceSecurityMode(
+                group_mode=group_mode_space_security_pb2.GroupModeSpaceSecurity(
+                    groups=group_securities,
+                )
+            )
+        else:
+            mode_msg = space_security_mode_pb2.SpaceSecurityMode(
+                regular_mode=regular_mode_space_security_pb2.RegularModeSpaceSecurity()
+            )
+        return space_security_pb2.SpaceSecurity(groups=proto_groups, mode=mode_msg)
+
+    def test_two_groups_with_distinct_states(self) -> None:
+        security = self._build_security(
+            groups=[("g1", "Villa", "01"), ("g2", "Apartment", "02")],
+            states={"g1": 1, "g2": 2},  # ARMED, DISARMED
+        )
+        groups, enabled = SpacesApi.parse_groups(security, space_id="space-1")
+
+        assert enabled is True
+        assert [g.id for g in groups] == ["g1", "g2"]
+        assert [g.name for g in groups] == ["Villa", "Apartment"]
+        assert [g.security_state for g in groups] == [SecurityState.ARMED, SecurityState.DISARMED]
+        assert all(g.space_id == "space-1" for g in groups)
+
+    def test_groups_sorted_by_sorting_key(self) -> None:
+        security = self._build_security(
+            groups=[
+                ("g1", "Z-First-Insertion", "02"),
+                ("g2", "A-Second-Insertion", "01"),
+            ],
+            states={"g1": 2, "g2": 2},
+        )
+        groups, _ = SpacesApi.parse_groups(security, space_id="space-1")
+        assert [g.sorting_key for g in groups] == ["01", "02"]
+        assert groups[0].name == "A-Second-Insertion"
+
+    def test_state_unknown_when_security_missing_for_group(self) -> None:
+        security = self._build_security(
+            groups=[("g1", "Villa", "01")],
+            states={},  # no per-group state in mode.group_mode.groups
+        )
+        groups, enabled = SpacesApi.parse_groups(security, space_id="s")
+        assert enabled is True
+        assert groups[0].security_state == SecurityState.NONE
+
+    def test_returns_empty_when_regular_mode(self) -> None:
+        security = self._build_security(
+            groups=[("g1", "Villa", "01")],  # definitions exist but mode is regular
+            mode="regular_mode",
+        )
+        groups, enabled = SpacesApi.parse_groups(security, space_id="s")
+        assert groups == ()
+        assert enabled is False
+
+    def test_skips_groups_without_id(self) -> None:
+        security = self._build_security(
+            groups=[("", "Bad", "00"), ("g1", "Good", "01")],
+            states={"g1": 1},
+        )
+        groups, _ = SpacesApi.parse_groups(security, space_id="s")
+        assert [g.id for g in groups] == ["g1"]
 
 
 class TestListSpaces:


### PR DESCRIPTION
## Summary

Initial implementation of per-group `alarm_control_panel` entities, addressing #84 (Picchios — "Group") and #86 (Cingar01 — "Zone-level alarm_control_panel"). Both features map to the same Ajax payload (`GroupSecurity` proto): "Zone Mode" is the rename of "Group Mode" on newer firmwares.

When a space has Group/Zone Mode enabled, the integration now exposes **one `alarm_control_panel` entity per group** instead of a single space-wide panel. Each group entity arms/disarms independently via the existing `armGroup`/`disarmGroup` gRPC calls and reports its own state.

## Status: DRAFT — needs real-hardware validation

This is the smallest viable slice and is opened as a draft because the maintainer does not have a Group-Mode hub locally. Two scoped follow-ups expected before merge:

1. **Real-hardware verification** by users on Group/Zone Mode hubs (see test plan).
2. Possible per-group state-refresh latency tuning if the hourly snapshot cadence proves too slow in practice (see "Known limitations").

## Changes

- New `Group` dataclass and `Space.groups` / `Space.group_mode_enabled` fields, populated from the snapshot's `security` field (`security.groups[]` for definitions, `security.mode.group_mode.groups[]` for per-group state).
- `SpacesApi.parse_groups` extracts both, returns groups sorted by `sorting_key` then `name`.
- `AjaxGroupAlarmControlPanel` mirrors the per-space panel but scoped to a single group. Each panel exposes `group_id`, `group_name`, `space_id`, `hub_id`, `connection_status` as state attributes for use in automations.
- The coordinator merges groups into the cached `Space` during the hourly snapshot refresh.

## Known limitations (intentional in this slice)

- **Per-group state refresh cadence**: today, snapshot pull runs at most once per hour. Local arm/disarm from HA gets an immediate optimistic update; remote arm/disarm from the official Ajax app may take up to one hour to reflect in HA. A long-lived `SpaceService/stream` subscription that listens for `update.security_mode.group_mode.groups[]` events is the right fix; deferred to a follow-up to keep this PR focused.
- **Night mode** is not exposed on per-group panels. Ajax stores `night_mode_enabled` at the space level (single flag for the whole space), so surfacing it per group would mislead users about scope. Available via the existing space-level panel when not in Group Mode.
- **FCM `event.security_event` enrichment** with `zone_id`/`zone_name` (the second part of #86) is **not** in this PR. That work needs the FCM payload that arrives when arming a single group, which the maintainer cannot reproduce locally — needs the debug log requested from @Cingar01 in #86.
- README / strings.json updates intentionally postponed until a tester confirms the entities behave correctly.

## Test plan

### Automated (already passing)

- [x] 16 new unit tests covering parsing (5), `Group` model (4), and per-group panel behaviour (7).
- [x] Full suite green: 931 tests passing, coverage 81.6% (above the 80% gate).
- [x] `make check` clean (lint, format, typecheck, dead code).
- [x] Pre-push hook re-ran the full check successfully without volume mount.

### Manual — requested from @Picchios and @Cingar01

Please install this branch and report back on:

- [ ] After integration reload, you see N `alarm_control_panel.*` entities, where N = number of groups visible in your Ajax app.
- [ ] Entity name matches each group's name in the Ajax app.
- [ ] Initial state of each entity matches what's shown in the Ajax app (one armed, one disarmed, etc).
- [ ] Arming/disarming a single group from HA reflects in the Ajax app within a few seconds.
- [ ] Arming/disarming from the Ajax app eventually shows up in HA (may take up to one hour due to the snapshot cadence — see Known limitations).
- [ ] State attributes of each panel include `group_id`, `group_name`, `space_id`, `hub_id`.

Logs at debug level for `custom_components.aegis_ajax` during these flows would be hugely helpful for tightening the implementation in the follow-up PRs.

Refs #84
Refs #86