### PR TITLE
fix(alarm): group panels usable end-to-end (proto names, state, whole-house)

### DIFF
--- a/custom_components/aegis_ajax/alarm_control_panel.py
+++ b/custom_components/aegis_ajax/alarm_control_panel.py
@@ -219,6 +219,14 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[AlarmControlPanelEntity] = []
     for space_id, space in coordinator.spaces.items():
+        # Always create the space-level panel. It carries night-mode support
+        # (Ajax exposes night mode only at the space level) and acts as the
+        # "arm everything" / "disarm everything" control. In group mode the
+        # space-level arm/disarm cascades down to all groups server-side.
+        entities.append(AjaxAlarmControlPanel(coordinator=coordinator, space_id=space_id))
+        # In group mode, additionally expose one panel per group for
+        # independent arm/disarm. Group panels deliberately do NOT expose
+        # night mode — the protocol has no per-group night-mode endpoint.
         if space.group_mode_enabled and space.groups:
             entities.extend(
                 AjaxGroupAlarmControlPanel(
@@ -226,8 +234,6 @@ async def async_setup_entry(
                 )
                 for group in space.groups
             )
-        else:
-            entities.append(AjaxAlarmControlPanel(coordinator=coordinator, space_id=space_id))
     async_add_entities(entities)
 
 

--- a/custom_components/aegis_ajax/api/security.py
+++ b/custom_components/aegis_ajax/api/security.py
@@ -146,7 +146,7 @@ class SecurityApi:
         metadata = self._client._session.get_call_metadata()
         stub = space_security_endpoints_pb2_grpc.SpaceSecurityServiceStub(channel)
 
-        request = arm_group_request_pb2.ArmGroupRequest(
+        request = arm_group_request_pb2.ArmSpaceGroupRequest(
             space_locator=space_locator_pb2.SpaceLocator(space_id=space_id),
             group_id=group_id,
             ignore_alarms=ignore_alarms,
@@ -170,7 +170,7 @@ class SecurityApi:
         metadata = self._client._session.get_call_metadata()
         stub = space_security_endpoints_pb2_grpc.SpaceSecurityServiceStub(channel)
 
-        request = disarm_group_request_pb2.DisarmGroupRequest(
+        request = disarm_group_request_pb2.DisarmSpaceGroupRequest(
             space_locator=space_locator_pb2.SpaceLocator(space_id=space_id),
             group_id=group_id,
         )

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -214,16 +214,26 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 elif opt and opt[0] <= now:
                     self._optimistic_space_states.pop(s.id, None)
                 previous = self.spaces.get(s.id)
-                if previous and (
-                    previous.monitoring_companies or previous.monitoring_companies_loaded
-                ):
+                if previous:
                     from dataclasses import replace as dc_replace  # noqa: PLC0415
 
-                    s = dc_replace(
-                        s,
-                        monitoring_companies=previous.monitoring_companies,
-                        monitoring_companies_loaded=previous.monitoring_companies_loaded,
-                    )
+                    if previous.monitoring_companies or previous.monitoring_companies_loaded:
+                        s = dc_replace(
+                            s,
+                            monitoring_companies=previous.monitoring_companies,
+                            monitoring_companies_loaded=previous.monitoring_companies_loaded,
+                        )
+                    # Preserve group definitions + group_mode flag across polls.
+                    # `list_spaces()` does not return them — only the hourly
+                    # snapshot path does. Without this, every poll between
+                    # snapshot refreshes wipes the cached groups and per-group
+                    # alarm panels go unavailable.
+                    if previous.groups or previous.group_mode_enabled:
+                        s = dc_replace(
+                            s,
+                            groups=previous.groups,
+                            group_mode_enabled=previous.group_mode_enabled,
+                        )
                 new_spaces[s.id] = s
             self.spaces = new_spaces
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+# Wire up the proto search path before any test module is collected, so that
+# `from systems.ajax.api...` imports at module top level resolve in tests
+# that don't import the integration first. Must come after stdlib/third-party
+# imports to keep ruff's import-sorter happy, but before any test module
+# collection can attempt a `systems.*` import — pytest imports conftest first.
+from custom_components.aegis_ajax.api import _proto_path as _proto_path  # noqa: E402, F401
+
 
 @pytest.fixture
 def mock_grpc_channel() -> MagicMock:

--- a/tests/unit/test_alarm_control_panel.py
+++ b/tests/unit/test_alarm_control_panel.py
@@ -418,3 +418,61 @@ class TestGroupAlarmControlPanel:
         panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
         await panel.async_alarm_disarm()
         coordinator.security_api.disarm_group.assert_called_once_with("s1", "g1")
+
+
+class TestAsyncSetupEntry:
+    """`async_setup_entry` always creates the space-level panel.
+    In group mode it ALSO creates one per-group panel.
+    """
+
+    def _coordinator_with_space(self, *, group_mode: bool, groups: tuple) -> MagicMock:  # type: ignore[type-arg]
+        coordinator = MagicMock()
+        coordinator.spaces = {
+            "s1": Space(
+                id="s1",
+                hub_id="h1",
+                name="Home",
+                security_state=SecurityState.DISARMED,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+                groups=groups,
+                group_mode_enabled=group_mode,
+            )
+        }
+        coordinator.devices = {}
+        coordinator.rooms = {}
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_creates_only_space_panel_when_no_group_mode(self) -> None:
+        from custom_components.aegis_ajax.alarm_control_panel import async_setup_entry
+
+        coordinator = self._coordinator_with_space(group_mode=False, groups=())
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, added.append)
+        assert len(added[0]) == 1
+        assert isinstance(added[0][0], AjaxAlarmControlPanel)
+
+    @pytest.mark.asyncio
+    async def test_creates_space_panel_plus_per_group_panels_in_group_mode(self) -> None:
+        from custom_components.aegis_ajax.alarm_control_panel import async_setup_entry
+
+        groups = (
+            Group(id="g1", space_id="s1", name="Villa", security_state=SecurityState.ARMED),
+            Group(id="g2", space_id="s1", name="Apartment", security_state=SecurityState.DISARMED),
+        )
+        coordinator = self._coordinator_with_space(group_mode=True, groups=groups)
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, added.append)
+        entities = added[0]
+        # Expect: 1 whole-house + 2 group panels (Villa, Apartment)
+        assert len(entities) == 3
+        space_panels = [e for e in entities if isinstance(e, AjaxAlarmControlPanel)]
+        group_panels = [e for e in entities if isinstance(e, AjaxGroupAlarmControlPanel)]
+        assert len(space_panels) == 1
+        assert len(group_panels) == 2
+        assert {p._group_id for p in group_panels} == {"g1", "g2"}

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -266,6 +266,52 @@ class TestAsyncUpdateData:
         assert coordinator.spaces["s1"].monitoring_companies_loaded is True
 
     @pytest.mark.asyncio
+    async def test_update_data_preserves_cached_groups_between_snapshot_refreshes(
+        self,
+    ) -> None:
+        """list_spaces() doesn't return groups; the coordinator must keep the
+        previously cached groups + group_mode_enabled, otherwise per-group
+        alarm panels go unavailable on every poll between hourly snapshots.
+        """
+        from custom_components.aegis_ajax.api.models import Group
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._rooms_last_fetch = asyncio.get_running_loop().time()
+        cached_groups = (
+            Group(
+                id="g1",
+                space_id="s1",
+                name="Villa",
+                security_state=SecurityState.ARMED,
+                sorting_key="01",
+            ),
+            Group(
+                id="g2",
+                space_id="s1",
+                name="Apartment",
+                security_state=SecurityState.DISARMED,
+                sorting_key="02",
+            ),
+        )
+        coordinator.spaces["s1"] = replace(
+            _make_space("s1"),
+            groups=cached_groups,
+            group_mode_enabled=True,
+        )
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        assert coordinator.spaces["s1"].groups == cached_groups
+        assert coordinator.spaces["s1"].group_mode_enabled is True
+
+    @pytest.mark.asyncio
     async def test_update_data_raises_update_failed_on_error(self) -> None:
         from homeassistant.helpers.update_coordinator import UpdateFailed
 

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -507,3 +507,88 @@ class TestArmingCommands:
         api = SecurityApi.__new__(SecurityApi)
         api._client = MagicMock()
         assert callable(api.disarm_group)
+
+
+class TestGroupProtoIntegration:
+    """Real-proto regression tests for arm_group / disarm_group.
+
+    The class-level tests above mock the entire `*_request_pb2` module with
+    MagicMock, so a typo in the proto class name (e.g. ArmGroupRequest vs
+    ArmSpaceGroupRequest) silently passes. These tests use the real proto
+    module so any drift between security.py and the generated descriptors
+    surfaces immediately.
+    """
+
+    def test_arm_group_request_class_name(self) -> None:
+        from systems.ajax.api.mobile.v2.space.security.group import (
+            arm_group_request_pb2,
+        )
+
+        assert hasattr(arm_group_request_pb2, "ArmSpaceGroupRequest")
+        assert not hasattr(arm_group_request_pb2, "ArmGroupRequest")
+
+    def test_disarm_group_request_class_name(self) -> None:
+        from systems.ajax.api.mobile.v2.space.security.group import (
+            disarm_group_request_pb2,
+        )
+
+        assert hasattr(disarm_group_request_pb2, "DisarmSpaceGroupRequest")
+        assert not hasattr(disarm_group_request_pb2, "DisarmGroupRequest")
+
+    @pytest.mark.asyncio
+    async def test_arm_group_builds_real_proto(self) -> None:
+        """Exercise security.arm_group with the real proto, mocking only the stub."""
+        from systems.ajax.api.mobile.v2.space.security.group import (
+            arm_group_request_pb2,
+        )
+
+        api, _, _ = _make_security_api()
+
+        captured: dict[str, object] = {}
+        mock_response = MagicMock()
+        mock_response.HasField.return_value = False
+
+        async def fake_arm_group(request, metadata=None, timeout=None):  # noqa: ANN001, ANN202, ARG001
+            captured["request"] = request
+            return mock_response
+
+        mock_stub_instance = MagicMock()
+        mock_stub_instance.armGroup = fake_arm_group
+        mock_grpc_module = MagicMock(SpaceSecurityServiceStub=lambda _ch: mock_stub_instance)
+
+        with patch.dict("sys.modules", {_GRPC_MOD: mock_grpc_module}):
+            await api.arm_group("space-1", "group-2", ignore_alarms=True)
+
+        request = captured["request"]
+        assert isinstance(request, arm_group_request_pb2.ArmSpaceGroupRequest)
+        assert request.group_id == "group-2"
+        assert request.ignore_alarms is True
+        assert request.space_locator.space_id == "space-1"
+
+    @pytest.mark.asyncio
+    async def test_disarm_group_builds_real_proto(self) -> None:
+        from systems.ajax.api.mobile.v2.space.security.group import (
+            disarm_group_request_pb2,
+        )
+
+        api, _, _ = _make_security_api()
+
+        captured: dict[str, object] = {}
+        mock_response = MagicMock()
+        mock_response.HasField.return_value = False
+
+        async def fake_disarm_group(request, metadata=None, timeout=None):  # noqa: ANN001, ANN202, ARG001
+            captured["request"] = request
+            return mock_response
+
+        mock_stub_instance = MagicMock()
+        mock_stub_instance.disarmGroup = fake_disarm_group
+        mock_grpc_module = MagicMock(SpaceSecurityServiceStub=lambda _ch: mock_stub_instance)
+
+        with patch.dict("sys.modules", {_GRPC_MOD: mock_grpc_module}):
+            await api.disarm_group("space-1", "group-2")
+
+        request = captured["request"]
+        assert isinstance(request, disarm_group_request_pb2.DisarmSpaceGroupRequest)
+        assert request.group_id == "group-2"
+        assert request.space_locator.space_id == "space-1"

--- a/tests/unit/test_spaces.py
+++ b/tests/unit/test_spaces.py
@@ -6,18 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from google.protobuf.wrappers_pb2 import StringValue
-from systems.ajax.api.mobile.v2.common.space.security import (
-    space_security_mode_pb2,
-    space_security_pb2,
-)
-from systems.ajax.api.mobile.v2.common.space.security.group import (
-    group_mode_space_security_pb2,
-    group_pb2,
-    group_security_pb2,
-)
-from systems.ajax.api.mobile.v2.common.space.security.regular import (
-    regular_mode_space_security_pb2,
-)
 
 from custom_components.aegis_ajax.api.models import (
     MonitoringCompanyStatus,
@@ -102,12 +90,28 @@ class TestParseSpace:
 class TestParseGroups:
     """Parse group definitions + per-group security state from a SpaceSecurity proto."""
 
-    def _build_security(
+    def _build_security(  # noqa: ANN202
         self,
         groups: list[tuple[str, str, str]] | None = None,
         states: dict[str, int] | None = None,
         mode: str = "group_mode",
-    ) -> space_security_pb2.SpaceSecurity:
+    ):
+        # Imports inside the method so they don't pollute sys.modules with
+        # real proto packages at collection time — that breaks unrelated tests
+        # that patch.dict child modules of the same package.
+        from systems.ajax.api.mobile.v2.common.space.security import (  # noqa: PLC0415
+            space_security_mode_pb2,
+            space_security_pb2,
+        )
+        from systems.ajax.api.mobile.v2.common.space.security.group import (  # noqa: PLC0415
+            group_mode_space_security_pb2,
+            group_pb2,
+            group_security_pb2,
+        )
+        from systems.ajax.api.mobile.v2.common.space.security.regular import (  # noqa: PLC0415
+            regular_mode_space_security_pb2,
+        )
+
         proto_groups = [
             group_pb2.Group(id=gid, name=name, sorting_key=sort_key)
             for gid, name, sort_key in (groups or [])
@@ -319,13 +323,24 @@ class TestListRooms:
         locator_pb2 = MagicMock()
         locator_pb2.SpaceLocator = MagicMock(return_value="locator-marker")
 
-        with patch.dict(
-            "sys.modules",
-            {
-                _STREAM_SPACE_REQUEST: request_pb2,
-                _SPACE_GRPC: grpc_module,
-                _SPACE_LOCATOR: locator_pb2,
-            },
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    _STREAM_SPACE_REQUEST: request_pb2,
+                    _SPACE_GRPC: grpc_module,
+                    _SPACE_LOCATOR: locator_pb2,
+                },
+            ),
+            # The production code does `from systems.ajax...space import
+            # space_locator_pb2` which resolves via the parent's attribute
+            # if previously loaded. Patch that attribute too so the test is
+            # robust against earlier tests that triggered the real import.
+            patch(
+                "systems.ajax.api.mobile.v2.common.space.space_locator_pb2",
+                locator_pb2,
+                create=True,
+            ),
         ):
             rooms = await api.list_rooms("space-1")
 
@@ -469,13 +484,20 @@ class TestPressPanicButton:
         locator_pb2 = MagicMock()
         locator_pb2.SpaceLocator = MagicMock(return_value="locator-marker")
 
-        with patch.dict(
-            "sys.modules",
-            {
-                _PANIC_REQUEST: request_pb2,
-                _PANIC_GRPC: grpc_module,
-                _LOCATOR: locator_pb2,
-            },
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    _PANIC_REQUEST: request_pb2,
+                    _PANIC_GRPC: grpc_module,
+                    _LOCATOR: locator_pb2,
+                },
+            ),
+            patch(
+                "systems.ajax.api.mobile.v2.common.space.space_locator_pb2",
+                locator_pb2,
+                create=True,
+            ),
         ):
             await api.press_panic_button("space-1")
 


### PR DESCRIPTION
## Summary

Three bugs reported by @Cingar01 against v1.2.4-beta.1, plus the test infrastructure gap that let bug #1 ship.

1. **Proto class names**. `arm_group` / `disarm_group` referenced `ArmGroupRequest` / `DisarmGroupRequest` but the real classes are `ArmSpaceGroupRequest` / `DisarmSpaceGroupRequest`. Arming a group from HA failed with `module ... has no attribute 'ArmGroupRequest'`. Fixed.
2. **Per-group panels stuck `unavailable`**. The coordinator's poll wiped the cached `Space.groups` on every cycle (only the hourly snapshot path populated them; `list_spaces()` doesn't). `_group` returned `None`, panels went unavailable along with all state attributes. Coordinator now preserves `groups` and `group_mode_enabled` across polls, like it already does for `monitoring_companies`.
3. **Whole-house panel disappeared in group mode**. Setup created either the space-level panel OR per-group panels but never both, so users lost night mode (Ajax exposes night mode only space-wide — there is no `armGroupToNightMode` endpoint) and the pre-upgrade `aegis_ajax_alarm_<space>` entity from v1.2.3 was orphaned as `restored: true`. Setup now always creates the whole-house panel and additionally adds per-group panels when group mode is on.

## Tests

- New `TestGroupProtoIntegration` in `test_security.py` uses the real proto module and asserts the request type + class names. Would have caught bug #1 in v1.2.4-beta.1.
- New `test_update_data_preserves_cached_groups_between_snapshot_refreshes` in `test_coordinator.py` covers bug #2.
- New `TestAsyncSetupEntry` in `test_alarm_control_panel.py` covers bug #3 (1 panel without group mode, 1 + N panels with it).
- 938 tests passing, 81.82% coverage.

The new real-proto tests pull `space_locator_pb2` into `sys.modules` transitively, which exposed pre-existing fragility in two older `patch.dict("sys.modules", ...)`-style tests in `test_spaces.py`. Added a parallel `patch(parent_module.attr, mock, create=True)` so they're robust against earlier-imported parents. `tests/conftest.py` also pulls in `api._proto_path` so the proto search path is set before any module is collected.

## Test plan

- [x] `make check` clean (lint, format, typecheck, tests, dead code).
- [ ] Manual validation by @Cingar01 / @Picchios on the next beta (see #87 thread for setup notes). They should now see: whole-house panel armable to away/disarm/night, plus one per-zone panel each armable to away/disarm.

Refs #84
Refs #86