### PR TITLE
feat(system-health): in-UI diagnostics card

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -130,6 +130,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def notification_listener(self) -> AjaxNotificationListener | None:
         return self._notification_listener
 
+    @property
+    def is_hts_connected(self) -> bool:
+        """True if HTS has an active connection feeding hub-network sensors."""
+        return self._hts_client is not None and self._hts_task is not None
+
     async def _login_and_persist(self) -> None:
         """Login fresh and notify the on_session_persist callback.
 

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -64,6 +64,27 @@ class AjaxNotificationListener:
         # notification_id → time.monotonic() of first sighting; used to suppress
         # the second of the two FCM messages Ajax sends per event (#80).
         self._recent_notification_ids: dict[str, float] = {}
+        # Counters surfaced by system_health.py for in-UI diagnostics.
+        # Incremented inside `_on_notification` after the dedupe gate so
+        # only "real" pushes are counted; the dedupe-suppressed twin
+        # doesn't double-count.
+        self._pushes_received: int = 0
+        self._last_push_at: float | None = None
+
+    @property
+    def pushes_received(self) -> int:
+        """Total non-deduped push notifications received since startup."""
+        return self._pushes_received
+
+    @property
+    def last_push_at(self) -> float | None:
+        """`time.monotonic()` of the most recent non-deduped push, or None."""
+        return self._last_push_at
+
+    @property
+    def is_fcm_connected(self) -> bool:
+        """True if the FCM push client is alive."""
+        return self._push_client is not None
 
     async def async_start(self) -> None:
         """Register with FCM and start listening for push notifications."""
@@ -239,6 +260,11 @@ class AjaxNotificationListener:
                 NOTIFICATION_DEDUPE_WINDOW_SECONDS,
             )
             return
+
+        # Count only real (non-dedupe-suppressed) pushes. Surfaced in the
+        # System Health card so users can confirm push delivery is alive.
+        self._pushes_received += 1
+        self._last_push_at = time.monotonic()
 
         # Parse event from ENCODED_DATA using compiled protos
         if encoded_data:

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -69,6 +69,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Reach Ajax cloud (gRPC host)",
+            "configured_accounts": "Configured accounts",
+            "spaces": "Spaces (hubs)",
+            "hts_connected": "HTS streams connected",
+            "fcm_connected": "FCM push clients connected",
+            "pushes_received": "Pushes received",
+            "last_push": "Last push received",
+            "last_poll": "Last successful poll"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Force arm",

--- a/custom_components/aegis_ajax/system_health.py
+++ b/custom_components/aegis_ajax/system_health.py
@@ -1,0 +1,97 @@
+"""System Health card for Aegis for Ajax — in-UI diagnostics summary.
+
+Surfaces a one-line snapshot of cloud reachability, gRPC poll
+freshness, HTS stream state, and FCM push status under
+**Settings → System → Repairs → System Information**, so triage
+questions like "are my events arriving?" / "is the cloud reachable?"
+can be answered without log archaeology or downloading the full
+diagnostics JSON.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components import system_health
+from homeassistant.core import callback
+
+from custom_components.aegis_ajax.const import DOMAIN, GRPC_HOST
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+@callback
+def async_register(
+    hass: HomeAssistant,
+    register: system_health.SystemHealthRegistration,
+) -> None:
+    """Called by HA when the system_health component scans integrations."""
+    register.async_register_info(_system_health_info)
+
+
+async def _system_health_info(hass: HomeAssistant) -> dict[str, Any]:
+    """Build the System Health dict for the integration's row."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+    info: dict[str, Any] = {
+        "can_reach_server": system_health.async_check_can_reach_url(hass, f"https://{GRPC_HOST}"),
+        "configured_accounts": len(entries),
+    }
+    if not entries:
+        return info
+
+    spaces_total = 0
+    hts_connected = 0
+    fcm_connected = 0
+    pushes_total = 0
+    last_push_age_seconds: float | None = None
+    last_update_age_seconds: float | None = None
+
+    # `last_update_success_time` is wall-clock (datetime), while
+    # `last_push_at` is monotonic — keep them on their own clocks.
+    now_mono = time.monotonic()
+    now_wall = time.time()
+    for entry in entries:
+        coordinator = getattr(entry, "runtime_data", None)
+        if coordinator is None:
+            continue
+        spaces_total += len(coordinator.spaces)
+        if coordinator.is_hts_connected:
+            hts_connected += 1
+        last_update = coordinator.last_update_success_time
+        if last_update is not None and hasattr(last_update, "timestamp"):
+            age = now_wall - last_update.timestamp()
+            if age >= 0 and (last_update_age_seconds is None or age < last_update_age_seconds):
+                last_update_age_seconds = age
+        listener = coordinator.notification_listener
+        if listener is None:
+            continue
+        if listener.is_fcm_connected:
+            fcm_connected += 1
+        pushes_total += listener.pushes_received
+        if listener.last_push_at is not None:
+            age = now_mono - listener.last_push_at
+            if last_push_age_seconds is None or age < last_push_age_seconds:
+                last_push_age_seconds = age
+
+    info["spaces"] = spaces_total
+    info["hts_connected"] = f"{hts_connected}/{len(entries)}"
+    info["fcm_connected"] = f"{fcm_connected}/{len(entries)}"
+    info["pushes_received"] = pushes_total
+    info["last_push"] = _format_age(last_push_age_seconds)
+    info["last_poll"] = _format_age(last_update_age_seconds)
+    return info
+
+
+def _format_age(seconds: float | None) -> str:
+    """Render a duration as 'never' / '12s ago' / '4m ago' / '3h ago'."""
+    if seconds is None:
+        return "never"
+    if seconds < 60:
+        return f"{int(seconds)}s ago"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m ago"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h ago"
+    return f"{int(seconds // 86400)}d ago"

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -69,6 +69,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Acces al nuvol Ajax (host gRPC)",
+            "configured_accounts": "Comptes configurats",
+            "spaces": "Espais (hubs)",
+            "hts_connected": "Streams HTS connectats",
+            "fcm_connected": "Clients FCM connectats",
+            "pushes_received": "Pushes rebuts",
+            "last_push": "Ultim push rebut",
+            "last_poll": "Ultim sondeig correcte"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Forcar armat",

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -65,6 +65,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Dostupnost Ajax cloudu (gRPC host)",
+            "configured_accounts": "Nakonfigurovane ucty",
+            "spaces": "Prostory (huby)",
+            "hts_connected": "Pripojene HTS streamy",
+            "fcm_connected": "Pripojene FCM klienty",
+            "pushes_received": "Prijate push zpravy",
+            "last_push": "Posledni push prijat",
+            "last_poll": "Posledni uspesny dotaz"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Nucene zastrezeni",

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -65,6 +65,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Erreichbarkeit der Ajax-Cloud (gRPC-Host)",
+            "configured_accounts": "Konfigurierte Konten",
+            "spaces": "Bereiche (Hubs)",
+            "hts_connected": "HTS-Streams verbunden",
+            "fcm_connected": "FCM-Push-Clients verbunden",
+            "pushes_received": "Empfangene Pushes",
+            "last_push": "Letzter Push empfangen",
+            "last_poll": "Letzte erfolgreiche Abfrage"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Erzwungenes Scharfschalten",

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -69,6 +69,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Reach Ajax cloud (gRPC host)",
+            "configured_accounts": "Configured accounts",
+            "spaces": "Spaces (hubs)",
+            "hts_connected": "HTS streams connected",
+            "fcm_connected": "FCM push clients connected",
+            "pushes_received": "Pushes received",
+            "last_push": "Last push received",
+            "last_poll": "Last successful poll"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Force arm",

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -69,6 +69,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Acceso a la nube de Ajax (host gRPC)",
+            "configured_accounts": "Cuentas configuradas",
+            "spaces": "Espacios (hubs)",
+            "hts_connected": "Streams HTS conectados",
+            "fcm_connected": "Clientes FCM conectados",
+            "pushes_received": "Pushes recibidos",
+            "last_push": "Ultimo push recibido",
+            "last_poll": "Ultimo poll correcto"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Forzar armado",

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -69,6 +69,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Acces au cloud Ajax (hote gRPC)",
+            "configured_accounts": "Comptes configures",
+            "spaces": "Espaces (hubs)",
+            "hts_connected": "Streams HTS connectes",
+            "fcm_connected": "Clients FCM connectes",
+            "pushes_received": "Pushes recus",
+            "last_push": "Dernier push recu",
+            "last_poll": "Dernier sondage reussi"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Armement force",

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -65,6 +65,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Accesso al cloud Ajax (host gRPC)",
+            "configured_accounts": "Account configurati",
+            "spaces": "Spazi (hub)",
+            "hts_connected": "Stream HTS connessi",
+            "fcm_connected": "Client FCM connessi",
+            "pushes_received": "Push ricevuti",
+            "last_push": "Ultimo push ricevuto",
+            "last_poll": "Ultimo polling riuscito"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Inserimento forzato",

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -65,6 +65,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Bereik Ajax-cloud (gRPC-host)",
+            "configured_accounts": "Geconfigureerde accounts",
+            "spaces": "Ruimtes (hubs)",
+            "hts_connected": "HTS-streams verbonden",
+            "fcm_connected": "FCM-pushclients verbonden",
+            "pushes_received": "Ontvangen pushes",
+            "last_push": "Laatste push ontvangen",
+            "last_poll": "Laatste succesvolle poll"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Geforceerd inschakelen",

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -65,6 +65,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Dostepnosc chmury Ajax (host gRPC)",
+            "configured_accounts": "Skonfigurowane konta",
+            "spaces": "Przestrzenie (huby)",
+            "hts_connected": "Polaczone strumienie HTS",
+            "fcm_connected": "Polaczeni klienci FCM",
+            "pushes_received": "Otrzymane pushe",
+            "last_push": "Ostatni push",
+            "last_poll": "Ostatnie udane odpytanie"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Wymus uzbrojenie",

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -69,6 +69,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Acesso a nuvem Ajax (host gRPC)",
+            "configured_accounts": "Contas configuradas",
+            "spaces": "Espacos (hubs)",
+            "hts_connected": "Streams HTS conectados",
+            "fcm_connected": "Clientes FCM conectados",
+            "pushes_received": "Pushes recebidos",
+            "last_push": "Ultimo push recebido",
+            "last_poll": "Ultimo poll com sucesso"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Armar forcado",

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -69,6 +69,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Acesso a cloud Ajax (host gRPC)",
+            "configured_accounts": "Contas configuradas",
+            "spaces": "Espacos (hubs)",
+            "hts_connected": "Streams HTS ligados",
+            "fcm_connected": "Clientes FCM ligados",
+            "pushes_received": "Pushes recebidos",
+            "last_push": "Ultimo push recebido",
+            "last_poll": "Ultima sondagem com sucesso"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Armar forcado",

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -69,6 +69,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Acces la cloud-ul Ajax (host gRPC)",
+            "configured_accounts": "Conturi configurate",
+            "spaces": "Spatii (hub-uri)",
+            "hts_connected": "Stream-uri HTS conectate",
+            "fcm_connected": "Clienti FCM conectati",
+            "pushes_received": "Push-uri primite",
+            "last_push": "Ultimul push primit",
+            "last_poll": "Ultimul poll reusit"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Armare fortata",

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -65,6 +65,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Ajax bulutuna erisim (gRPC ana makinesi)",
+            "configured_accounts": "Yapilandirilmis hesaplar",
+            "spaces": "Alanlar (hub'lar)",
+            "hts_connected": "Bagli HTS akislari",
+            "fcm_connected": "Bagli FCM push istemcileri",
+            "pushes_received": "Alinan push'lar",
+            "last_push": "Son alinan push",
+            "last_poll": "Son basarili sorgu"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Zorla kurma",

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -65,6 +65,18 @@
             }
         }
     },
+    "system_health": {
+        "info": {
+            "can_reach_server": "Доступ до хмари Ajax (gRPC-хост)",
+            "configured_accounts": "Налаштовані акаунти",
+            "spaces": "Простори (хаби)",
+            "hts_connected": "Підключені HTS-потоки",
+            "fcm_connected": "Підключені FCM-клієнти",
+            "pushes_received": "Отримані push-повідомлення",
+            "last_push": "Останнє push-повідомлення",
+            "last_poll": "Останнє успішне опитування"
+        }
+    },
     "services": {
         "force_arm": {
             "name": "Примусова постановка на охорону",

--- a/tests/unit/test_system_health.py
+++ b/tests/unit/test_system_health.py
@@ -1,0 +1,121 @@
+"""Tests for the System Health card."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.aegis_ajax.system_health import (
+    _format_age,
+    _system_health_info,
+    async_register,
+)
+
+
+class TestFormatAge:
+    def test_none_renders_as_never(self) -> None:
+        assert _format_age(None) == "never"
+
+    def test_seconds(self) -> None:
+        assert _format_age(12) == "12s ago"
+
+    def test_minutes(self) -> None:
+        assert _format_age(125) == "2m ago"
+
+    def test_hours(self) -> None:
+        assert _format_age(7200) == "2h ago"
+
+    def test_days(self) -> None:
+        assert _format_age(2 * 86400) == "2d ago"
+
+
+class TestAsyncRegister:
+    def test_calls_register_async_register_info(self) -> None:
+        hass = MagicMock()
+        register = MagicMock()
+        async_register(hass, register)
+        register.async_register_info.assert_called_once()
+
+
+class TestSystemHealthInfo:
+    @staticmethod
+    def _make_hass(entries: list[MagicMock]) -> MagicMock:
+        hass = MagicMock()
+        hass.config_entries.async_entries.return_value = entries
+        return hass
+
+    @pytest.mark.asyncio
+    async def test_no_entries_only_returns_reach_check(self) -> None:
+        """With no configured entries, only the gRPC reach probe + count are returned."""
+        hass = self._make_hass([])
+        with patch(
+            "custom_components.aegis_ajax.system_health.system_health.async_check_can_reach_url",
+            new=MagicMock(return_value="reach-coro"),
+        ):
+            info = await _system_health_info(hass)
+        assert info["can_reach_server"] == "reach-coro"
+        assert info["configured_accounts"] == 0
+        # No per-entry metrics should be set when there are no entries
+        assert "spaces" not in info
+
+    @pytest.mark.asyncio
+    async def test_aggregates_across_entries(self) -> None:
+        """Two configured accounts: spaces / HTS / FCM / pushes are summed."""
+        coord_a = MagicMock()
+        coord_a.spaces = {"s1": MagicMock(), "s2": MagicMock()}
+        coord_a.is_hts_connected = True
+        coord_a.last_update_success_time = datetime.now(UTC) - timedelta(seconds=30)
+        listener_a = MagicMock()
+        listener_a.is_fcm_connected = True
+        listener_a.pushes_received = 17
+        listener_a.last_push_at = None  # never
+        coord_a.notification_listener = listener_a
+
+        coord_b = MagicMock()
+        coord_b.spaces = {"s3": MagicMock()}
+        coord_b.is_hts_connected = False
+        coord_b.last_update_success_time = None  # never polled successfully
+        listener_b = MagicMock()
+        listener_b.is_fcm_connected = False
+        listener_b.pushes_received = 3
+        listener_b.last_push_at = None
+        coord_b.notification_listener = listener_b
+
+        entry_a = MagicMock(runtime_data=coord_a)
+        entry_b = MagicMock(runtime_data=coord_b)
+        hass = self._make_hass([entry_a, entry_b])
+
+        with patch(
+            "custom_components.aegis_ajax.system_health.system_health.async_check_can_reach_url",
+            new=MagicMock(return_value="reach-coro"),
+        ):
+            info = await _system_health_info(hass)
+
+        assert info["configured_accounts"] == 2
+        assert info["spaces"] == 3
+        assert info["hts_connected"] == "1/2"
+        assert info["fcm_connected"] == "1/2"
+        assert info["pushes_received"] == 20
+        # last_push: both listeners report None
+        assert info["last_push"] == "never"
+        # last_poll: only coord_a has a real timestamp, ~30s old
+        assert info["last_poll"].endswith("s ago")
+
+    @pytest.mark.asyncio
+    async def test_skips_entries_without_runtime_data(self) -> None:
+        """A still-loading entry (no runtime_data) must not crash the card."""
+        entry = MagicMock(runtime_data=None)
+        hass = self._make_hass([entry])
+
+        with patch(
+            "custom_components.aegis_ajax.system_health.system_health.async_check_can_reach_url",
+            new=MagicMock(return_value="reach-coro"),
+        ):
+            info = await _system_health_info(hass)
+
+        assert info["configured_accounts"] == 1
+        assert info["spaces"] == 0
+        assert info["hts_connected"] == "0/1"
+        assert info["fcm_connected"] == "0/1"


### PR DESCRIPTION
## Summary

Third of four follow-ups from the *quality-of-life* audit. Adds a `system_health.py` module so HA's **Settings → System → Repairs → System Information** page renders a one-line snapshot for Aegis.

When users open issues with *"events stopped arriving"* / *"panel state stuck"*, the first triage question — *which* layer is dead, gRPC poll or HTS or FCM? — can now be answered with a screenshot rather than log archaeology or the full diagnostics download.

## Card content

| Field | Source |
|---|---|
| Reach Ajax cloud (gRPC host) | `system_health.async_check_can_reach_url(\"https://mobile-gw.prod.ajax.systems\")` |
| Configured accounts | `len(hass.config_entries.async_entries(DOMAIN))` |
| Spaces (hubs) | sum of `len(coordinator.spaces)` |
| HTS streams connected | `N/M` of coordinators with `_hts_client` + `_hts_task` alive |
| FCM push clients connected | `N/M` of listeners with `_push_client` alive |
| Pushes received | total count of *non-deduped* pushes since startup |
| Last push received | humanised age (`12s / 4m / 3h ago` / `never`) |
| Last successful poll | same humanisation, sourced from `last_update_success_time` |

## Wiring

- `notification.py` — counts only real (non-dedupe-suppressed) pushes via a new `_pushes_received` + `_last_push_at` pair, bumped after the dedupe gate. Three new public properties (`pushes_received`, `last_push_at`, `is_fcm_connected`).
- `coordinator.py` — new `is_hts_connected` property combining `_hts_client` + `_hts_task` checks.
- `system_health.py` — new module. Wall-clock vs monotonic clocks are tracked separately (`time.time()` for the datetime `last_update_success_time`, `time.monotonic()` for the monotonic listener counter) so neither value is corrupted by clock-source mismatch.
- Translations (`strings.json`, `en.json`, `es.json`) gain a `system_health.info` section labelling the eight rows.

## Out of scope

- Per-device state, per-space monitoring company details, full status maps stay on `diagnostics.py` JSON download. System Health is summary-by-design.
- Per-entry breakdown — currently aggregated. Multi-account installs see `1/2 HTS`, `2/2 FCM` etc rather than a row per entry. Could be expanded later if useful.

## Tests

- `test_system_health.py` — 9 tests covering `_format_age` (none / seconds / minutes / hours / days), `async_register` wiring, the no-entries fast path, multi-entry aggregation across HTS + FCM + pushes state, and graceful handling of still-loading entries (`runtime_data is None`).
- `make check` clean: **947 passing, coverage 81.98%**, lint / format / typecheck / dead-code green.
- Pre-push hook re-ran the full check inside a fresh Docker rebuild without volume mount.

## Test plan

- [x] Automated suite green.
- [ ] Manual: open Settings → System → Repairs → System Information on an HA install with Aegis configured (FCM + HTS both alive). Confirm the card shows `1/1` for HTS and FCM, the gRPC reach probe lights up green, and `last_poll` ticks up between visits.
- [ ] Manual: pull the FCM credentials from Options, restart, confirm the card now shows `0/1` for FCM and `last_push: never`.

Refs #91