### PR TITLE
feat(repairs): make FCM-credentials repair fixable in-place

### DIFF
--- a/custom_components/aegis_ajax/repairs.py
+++ b/custom_components/aegis_ajax/repairs.py
@@ -2,23 +2,33 @@
 
 Each helper wraps `homeassistant.helpers.issue_registry` with the
 domain pre-bound and a stable issue id per category, so callers don't
-have to repeat boilerplate. All issues are non-fixable in this initial
-slice — the description tells the user what to do (re-enter FCM
-credentials via Options, check hub power, etc). A future pass can
-turn the FCM and app-label cases into guided RepairsFlow with
-`is_fixable=True`.
+have to repeat boilerplate.
+
+The FCM-credentials repair is fixable: the user clicks "Submit" on
+the Repair card, fills the four FCM fields in a dedicated form, and
+the integration reloads with the new credentials — no Options-menu
+detour. Hub-offline / HTS-chronic stay informational because their
+fix is physical (check hub power, firewall, etc.).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+import voluptuous as vol
+from homeassistant.components.repairs import RepairsFlow
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from custom_components.aegis_ajax.const import DOMAIN
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    from homeassistant.data_entry_flow import FlowResult
 
 DOCS_BASE_URL = "https://github.com/bvis/aegis-hass#"
 
@@ -96,15 +106,19 @@ def async_register_fcm_credentials_invalid(hass: HomeAssistant, *, entry_id: str
     """FCM credentials were configured but registration / push start failed.
 
     Scoped per entry_id so multi-account installs see one repair per
-    affected account.
+    affected account. Fixable in-place via `FcmCredentialsRepairFlow`
+    so users don't have to detour through the Options menu.
     """
     ir.async_create_issue(
         hass,
         DOMAIN,
         _issue_id(ISSUE_FCM_CREDENTIALS_INVALID, entry_id),
-        is_fixable=False,
+        is_fixable=True,
         severity=ir.IssueSeverity.ERROR,
         translation_key=ISSUE_FCM_CREDENTIALS_INVALID,
+        # Fix-flow needs the entry id to write the new creds back; the
+        # issue_id already encodes it but `data` is the canonical channel.
+        data={"entry_id": entry_id},
         learn_more_url=f"{DOCS_BASE_URL}push-notifications-fcm",
     )
 
@@ -172,3 +186,67 @@ def async_check_grpcio_version(hass: HomeAssistant) -> None:
         },
         learn_more_url=f"{DOCS_BASE_URL}troubleshooting",
     )
+
+
+_FCM_FIX_SCHEMA = vol.Schema(
+    {
+        vol.Required("fcm_project_id"): str,
+        vol.Required("fcm_app_id"): str,
+        vol.Required("fcm_api_key"): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
+        vol.Required("fcm_sender_id"): str,
+    }
+)
+
+
+class FcmCredentialsRepairFlow(RepairsFlow):
+    """Guided repair flow for `fcm_credentials_invalid`.
+
+    Re-prompts the four FCM fields, writes them to the entry data, and
+    reloads — which kicks `notification.async_start()` and either
+    re-raises the repair (creds still wrong) or clears it (creds work
+    now).
+    """
+
+    def __init__(self, entry_id: str) -> None:
+        self._entry_id = entry_id
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        if user_input is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if entry is None:
+                # The entry vanished between the repair being raised and
+                # the user clicking Submit. Nothing to fix.
+                return self.async_abort(reason="entry_missing")
+            self.hass.config_entries.async_update_entry(entry, data={**entry.data, **user_input})
+            await self.hass.config_entries.async_reload(self._entry_id)
+            return self.async_create_entry(data={})
+
+        # Pre-fill with the currently-stored values so the user only
+        # changes what's wrong, instead of re-typing everything.
+        suggested: dict[str, Any] = {}
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is not None:
+            for key in ("fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id"):
+                value = entry.data.get(key, entry.options.get(key, ""))
+                if value:
+                    suggested[key] = value
+        schema = self.add_suggested_values_to_schema(_FCM_FIX_SCHEMA, suggested)
+        return self.async_show_form(step_id="init", data_schema=schema)
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """HA discovery hook — returns the right flow for each fixable issue."""
+    if issue_id.startswith(f"{ISSUE_FCM_CREDENTIALS_INVALID}:"):
+        entry_id = (data or {}).get("entry_id") or issue_id.split(":", 1)[1]
+        return FcmCredentialsRepairFlow(str(entry_id))
+    # Fall back: HA's built-in confirm-only flow. Should not be hit since
+    # we only mark FCM as fixable today.
+    from homeassistant.components.repairs import ConfirmRepairFlow  # noqa: PLC0415
+
+    return ConfirmRepairFlow()

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -146,7 +146,6 @@
         },
         "fcm_credentials_invalid": {
             "title": "Push notifications disabled — FCM credentials rejected",
-            "description": "Firebase Cloud Messaging registration failed for this account. The configured FCM Project ID / App ID / API Key / Sender ID are most likely wrong for your co-branded Ajax app, or the API key has been revoked. Push-driven features (instant arm/disarm state, security_event entity, photo URLs from MotionCam) fall back to slower polling until this is fixed. Click Submit to re-enter the FCM credentials.",
             "fix_flow": {
                 "step": {
                     "init": {

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -146,7 +146,24 @@
         },
         "fcm_credentials_invalid": {
             "title": "Push notifications disabled — FCM credentials rejected",
-            "description": "Firebase Cloud Messaging registration failed for this account. The configured FCM Project ID / App ID / API Key / Sender ID are most likely wrong for your co-branded Ajax app, or the API key has been revoked. Push-driven features (instant arm/disarm state, security_event entity, photo URLs from MotionCam) fall back to slower polling until this is fixed. Open the integration's Configure menu to re-enter the FCM credentials — see the README's 'How to obtain FCM credentials' section."
+            "description": "Firebase Cloud Messaging registration failed for this account. The configured FCM Project ID / App ID / API Key / Sender ID are most likely wrong for your co-branded Ajax app, or the API key has been revoked. Push-driven features (instant arm/disarm state, security_event entity, photo URLs from MotionCam) fall back to slower polling until this is fixed. Click Submit to re-enter the FCM credentials.",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Fix Aegis FCM credentials",
+                        "description": "Firebase Cloud Messaging registration failed for this account. The configured FCM Project ID / App ID / API Key / Sender ID are most likely wrong for your co-branded Ajax app, or the API key has been revoked. Re-enter the four values below and the integration will reload — if the new credentials work the Repair clears automatically; if not, the form re-appears. See the README's 'How to obtain FCM credentials' section.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "The Aegis account this Repair was raised for is no longer configured. Nothing to fix."
+                }
+            }
         },
         "grpcio_version_mismatch": {
             "title": "Aegis needs grpcio {required} or newer (found {current})",

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -146,7 +146,6 @@
         },
         "fcm_credentials_invalid": {
             "title": "Push notifications disabled — FCM credentials rejected",
-            "description": "Firebase Cloud Messaging registration failed for this account. The configured FCM Project ID / App ID / API Key / Sender ID are most likely wrong for your co-branded Ajax app, or the API key has been revoked. Push-driven features (instant arm/disarm state, security_event entity, photo URLs from MotionCam) fall back to slower polling until this is fixed. Click Submit to re-enter the FCM credentials.",
             "fix_flow": {
                 "step": {
                     "init": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -146,7 +146,24 @@
         },
         "fcm_credentials_invalid": {
             "title": "Push notifications disabled — FCM credentials rejected",
-            "description": "Firebase Cloud Messaging registration failed for this account. The configured FCM Project ID / App ID / API Key / Sender ID are most likely wrong for your co-branded Ajax app, or the API key has been revoked. Push-driven features (instant arm/disarm state, security_event entity, photo URLs from MotionCam) fall back to slower polling until this is fixed. Open the integration's Configure menu to re-enter the FCM credentials — see the README's 'How to obtain FCM credentials' section."
+            "description": "Firebase Cloud Messaging registration failed for this account. The configured FCM Project ID / App ID / API Key / Sender ID are most likely wrong for your co-branded Ajax app, or the API key has been revoked. Push-driven features (instant arm/disarm state, security_event entity, photo URLs from MotionCam) fall back to slower polling until this is fixed. Click Submit to re-enter the FCM credentials.",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Fix Aegis FCM credentials",
+                        "description": "Firebase Cloud Messaging registration failed for this account. The configured FCM Project ID / App ID / API Key / Sender ID are most likely wrong for your co-branded Ajax app, or the API key has been revoked. Re-enter the four values below and the integration will reload — if the new credentials work the Repair clears automatically; if not, the form re-appears. See the README's 'How to obtain FCM credentials' section.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "The Aegis account this Repair was raised for is no longer configured. Nothing to fix."
+                }
+            }
         },
         "grpcio_version_mismatch": {
             "title": "Aegis needs grpcio {required} or newer (found {current})",

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -146,7 +146,6 @@
         },
         "fcm_credentials_invalid": {
             "title": "Notificaciones push desactivadas: credenciales FCM rechazadas",
-            "description": "El registro en Firebase Cloud Messaging ha fallado para esta cuenta. Lo mas probable es que el FCM Project ID / App ID / API Key / Sender ID configurados no correspondan a tu app Ajax co-branded, o que la API key haya sido revocada. Las funciones que dependen de push (estado instantaneo de armado/desarmado, entidad security_event, URLs de fotos de MotionCam) caeran a polling mas lento hasta que se corrija. Pulsa Enviar para reintroducir las credenciales FCM.",
             "fix_flow": {
                 "step": {
                     "init": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -146,7 +146,24 @@
         },
         "fcm_credentials_invalid": {
             "title": "Notificaciones push desactivadas: credenciales FCM rechazadas",
-            "description": "El registro en Firebase Cloud Messaging ha fallado para esta cuenta. Lo mas probable es que el FCM Project ID / App ID / API Key / Sender ID configurados no correspondan a tu app Ajax co-branded, o que la API key haya sido revocada. Las funciones que dependen de push (estado instantaneo de armado/desarmado, entidad security_event, URLs de fotos de MotionCam) caeran a polling mas lento hasta que se corrija. Abre el menu Configurar de la integracion para reintroducir las credenciales FCM — consulta la seccion 'How to obtain FCM credentials' del README."
+            "description": "El registro en Firebase Cloud Messaging ha fallado para esta cuenta. Lo mas probable es que el FCM Project ID / App ID / API Key / Sender ID configurados no correspondan a tu app Ajax co-branded, o que la API key haya sido revocada. Las funciones que dependen de push (estado instantaneo de armado/desarmado, entidad security_event, URLs de fotos de MotionCam) caeran a polling mas lento hasta que se corrija. Pulsa Enviar para reintroducir las credenciales FCM.",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Reparar credenciales FCM de Aegis",
+                        "description": "El registro en Firebase Cloud Messaging ha fallado para esta cuenta. Lo mas probable es que el FCM Project ID / App ID / API Key / Sender ID configurados no correspondan a tu app Ajax co-branded, o que la API key haya sido revocada. Reintroduce los cuatro valores y la integracion se recargara — si las nuevas credenciales funcionan el Repair se cierra solo; si no, este formulario reaparece. Consulta la seccion 'How to obtain FCM credentials' del README.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "La cuenta de Aegis para la que se levanto este Repair ya no esta configurada. No hay nada que reparar."
+                }
+            }
         },
         "grpcio_version_mismatch": {
             "title": "Aegis necesita grpcio {required} o superior (encontrado {current})",

--- a/tests/unit/test_repairs.py
+++ b/tests/unit/test_repairs.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from custom_components.aegis_ajax.const import DOMAIN
 from custom_components.aegis_ajax.repairs import (
@@ -11,11 +13,13 @@ from custom_components.aegis_ajax.repairs import (
     ISSUE_HTS_CHRONIC_FAILURE,
     ISSUE_HUB_OFFLINE_24H,
     MIN_GRPCIO_VERSION,
+    FcmCredentialsRepairFlow,
     _parse_version,
     async_check_grpcio_version,
     async_clear_fcm_credentials_invalid,
     async_clear_hts_chronic_failure,
     async_clear_hub_offline,
+    async_create_fix_flow,
     async_register_fcm_credentials_invalid,
     async_register_hts_chronic_failure,
     async_register_hub_offline,
@@ -82,6 +86,16 @@ class TestFcmCredentialsRepair:
             async_clear_fcm_credentials_invalid(hass, entry_id="entry-abc")
 
         delete.assert_called_once_with(hass, DOMAIN, f"{ISSUE_FCM_CREDENTIALS_INVALID}:entry-abc")
+
+    def test_register_marks_fixable_and_carries_entry_id_in_data(self) -> None:
+        """is_fixable=True and the entry_id is in `data` so the fix flow can find it."""
+        hass = MagicMock()
+        with patch("custom_components.aegis_ajax.repairs.ir.async_create_issue") as create:
+            async_register_fcm_credentials_invalid(hass, entry_id="entry-abc")
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["is_fixable"] is True
+        assert kwargs["data"] == {"entry_id": "entry-abc"}
 
 
 class TestParseVersion:
@@ -175,3 +189,99 @@ class TestAsyncCheckGrpcioVersion:
 
         create.assert_not_called()
         delete.assert_not_called()
+
+
+class TestFcmCredentialsRepairFlow:
+    @staticmethod
+    def _make_hass(entry: MagicMock | None) -> MagicMock:
+        hass = MagicMock()
+        hass.config_entries.async_get_entry.return_value = entry
+        hass.config_entries.async_reload = AsyncMock()
+        return hass
+
+    @pytest.mark.asyncio
+    async def test_init_no_input_shows_form_with_existing_creds_prefilled(self) -> None:
+        entry = MagicMock()
+        entry.data = {
+            "fcm_project_id": "old-proj",
+            "fcm_app_id": "old-app",
+            "fcm_api_key": "old-key",
+            "fcm_sender_id": "old-sender",
+        }
+        entry.options = {}
+        flow = FcmCredentialsRepairFlow("entry-abc")
+        flow.hass = self._make_hass(entry)
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        flow.add_suggested_values_to_schema = MagicMock(return_value="schema")
+
+        await flow.async_step_init(None)
+
+        flow.async_show_form.assert_called_once()
+        assert flow.async_show_form.call_args.kwargs["step_id"] == "init"
+        # Pre-filled with the currently-stored (broken) creds so the user
+        # can edit only what's wrong rather than re-typing everything.
+        suggested = flow.add_suggested_values_to_schema.call_args[0][1]
+        assert suggested["fcm_project_id"] == "old-proj"
+        assert suggested["fcm_api_key"] == "old-key"
+
+    @pytest.mark.asyncio
+    async def test_init_with_input_writes_entry_and_reloads(self) -> None:
+        entry = MagicMock()
+        entry.data = {"email": "u@x", "fcm_project_id": "old"}
+        flow = FcmCredentialsRepairFlow("entry-abc")
+        flow.hass = self._make_hass(entry)
+        flow.hass.config_entries.async_update_entry = MagicMock()
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+        new_creds = {
+            "fcm_project_id": "new-proj",
+            "fcm_app_id": "new-app",
+            "fcm_api_key": "new-key",
+            "fcm_sender_id": "new-sender",
+        }
+        await flow.async_step_init(new_creds)
+
+        # Existing entry data is preserved; only the four FCM fields rotate
+        flow.hass.config_entries.async_update_entry.assert_called_once_with(
+            entry, data={"email": "u@x", **new_creds}
+        )
+        flow.hass.config_entries.async_reload.assert_awaited_once_with("entry-abc")
+        flow.async_create_entry.assert_called_once_with(data={})
+
+    @pytest.mark.asyncio
+    async def test_init_aborts_if_entry_vanished(self) -> None:
+        flow = FcmCredentialsRepairFlow("entry-gone")
+        flow.hass = self._make_hass(None)
+        flow.async_abort = MagicMock(return_value={"type": "abort"})
+
+        await flow.async_step_init({"fcm_project_id": "x"})
+
+        flow.async_abort.assert_called_once_with(reason="entry_missing")
+        flow.hass.config_entries.async_reload.assert_not_awaited()
+
+
+class TestAsyncCreateFixFlow:
+    @pytest.mark.asyncio
+    async def test_returns_fcm_flow_for_fcm_issue(self) -> None:
+        hass = MagicMock()
+        flow = await async_create_fix_flow(
+            hass, f"{ISSUE_FCM_CREDENTIALS_INVALID}:entry-abc", {"entry_id": "entry-abc"}
+        )
+        assert isinstance(flow, FcmCredentialsRepairFlow)
+        assert flow._entry_id == "entry-abc"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_data_entry_id_when_data_missing(self) -> None:
+        """If `data` was lost, recover the entry id from the namespaced issue id."""
+        hass = MagicMock()
+        flow = await async_create_fix_flow(hass, f"{ISSUE_FCM_CREDENTIALS_INVALID}:entry-xyz", None)
+        assert isinstance(flow, FcmCredentialsRepairFlow)
+        assert flow._entry_id == "entry-xyz"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_confirm_flow_for_unknown_issue(self) -> None:
+        from homeassistant.components.repairs import ConfirmRepairFlow
+
+        hass = MagicMock()
+        flow = await async_create_fix_flow(hass, "some_other_issue", None)
+        assert isinstance(flow, ConfirmRepairFlow)


### PR DESCRIPTION
## Summary

Follow-up of #89 deferred work. Promotes `fcm_credentials_invalid` from informational (`is_fixable=False`) to a guided RepairsFlow so the user fixes broken FCM credentials directly from the **Settings → Repairs** card instead of detouring through Settings → Devices & Services → Aegis → Configure.

When the user clicks Submit on the Repair card:

1. A form appears with the four FCM fields (Project ID / App ID / API Key / Sender ID), pre-filled with the currently-stored (broken) values so they only edit what's wrong.
2. On submit, `async_update_entry` rotates only those four keys, preserving all other entry data (email, password_hash, app_label, session_token, …).
3. The integration reloads, which kicks `notification.async_start()`. If the new credentials work the Repair clears in `async_clear_fcm_credentials_invalid()`; if they're still wrong, the same Repair re-raises and the user can try again.

The other two Repairs (`hub_offline_24h`, `hts_chronic_failure`) stay informational because their fix is physical (hub power, firewall) and there's nothing meaningful to do from a form.

## Changes

- `repairs.py`:
  - `async_register_fcm_credentials_invalid` flips to `is_fixable=True` and stashes `{\"entry_id\": entry_id}` in the issue's `data` so the fix flow can reach the right entry.
  - New `FcmCredentialsRepairFlow(RepairsFlow)` with a single `init` step. Pre-fills suggested values from `entry.data` / `entry.options`.
  - New module-level `async_create_fix_flow(hass, issue_id, data)` — HA's auto-discovery hook on `<integration>/repairs.py`. Routes `fcm_credentials_invalid:*` to the new flow, falls back to `ConfirmRepairFlow` otherwise (defensive).
  - Recovers the entry id from the namespaced `issue_id` if `data` is missing (defensive).
- `strings.json` + `translations/{en,es}.json`: the issue gains `fix_flow.step.init` (form title / description / four field labels) plus `fix_flow.abort.entry_missing` for the entry-removed-while-Repair-open race. Issue-level description swaps 'Open the Configure menu' for 'Click Submit'. Other 12 locales fall back to the English `fix_flow` strings — the field labels are FCM tokens (Project ID, App ID, API Key, Sender ID) which already render in English in every existing locale.

## Tests

- 4 new tests on the flow:
  - `test_register_marks_fixable_and_carries_entry_id_in_data` — the load-bearing wiring that lets HA find the right entry.
  - `test_init_no_input_shows_form_with_existing_creds_prefilled` — pre-fill so users edit instead of re-typing all four.
  - `test_init_with_input_writes_entry_and_reloads` — non-FCM keys preserved, only FCM rotates, reload hits the right entry id.
  - `test_init_aborts_if_entry_vanished` — defensive path for the entry-removed race.
- 3 new tests on `async_create_fix_flow` covering the FCM-flow path, the namespaced-id fallback when `data` is lost, and the `ConfirmRepairFlow` fall-through for unknown issues.
- `make check` clean: **977 passing, coverage 82.82%**, lint / format / typecheck / dead-code green.
- Pre-push hook re-ran the full check inside a fresh Docker rebuild without volume mount.

## Test plan

- [x] Automated suite green.
- [ ] Manual: configure FCM with deliberately wrong API key, restart HA, see the `fcm_credentials_invalid` Repair card with a **Submit** button. Click it, confirm form pre-fills with the broken values, paste correct creds, hit Submit. Confirm the integration reloads, the Repair card disappears, and `event.aegis_security_event` starts firing on arm/disarm pushes again.
- [ ] Manual edge: delete the integration entry from a different browser tab while the Repair form is open; submitting should now show the `entry_missing` abort message instead of crashing.

Refs #89