### PR TITLE
feat(discovery): DHCP discovery for Ajax hubs on the local network

### DIFF
--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -10,9 +10,12 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import (
     SelectOptionDict,
     SelectSelector,
@@ -76,6 +79,32 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         self._password_hash: str = ""
         self._app_label: str = APPLICATION_LABEL
         self._request_id: str = ""
+
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
+        """Entry point when an Ajax hub is seen on the local network.
+
+        HA invokes this when a DHCP packet matches the manifest's `dhcp`
+        spec (Ajax Systems OUI 9C:75:6E). The flow doesn't have
+        credentials at discovery time — its only job is to surface
+        Aegis as a "Discovered" card with a hint so the user clicks
+        through into the credential prompt instead of having to search
+        for the integration by name.
+        """
+        # Per-MAC unique_id on the *flow* (not the eventual entry, which
+        # uses the email) so HA dedupes repeat DHCP packets and avoids
+        # showing two discovery cards for the same hub.
+        await self.async_set_unique_id(format_mac(discovery_info.macaddress))
+        self._abort_if_unique_id_configured()
+        # Once the user has at least one Aegis account configured we
+        # don't keep nagging on every hub renewal — additional spaces
+        # under the same account already appear automatically.
+        if self._async_current_entries(include_ignore=False):
+            return self.async_abort(reason="already_configured")
+        # Title placeholder is what HA renders on the "Discovered" card.
+        self.context["title_placeholders"] = {
+            "name": discovery_info.hostname or f"Ajax hub ({discovery_info.ip})"
+        }
+        return await self.async_step_user()
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -4,6 +4,9 @@
     "codeowners": ["@bvis"],
     "config_flow": true,
     "dependencies": ["media_source"],
+    "dhcp": [
+        {"macaddress": "9C756E*"}
+    ],
     "documentation": "https://github.com/bvis/aegis-hass",
     "integration_type": "hub",
     "iot_class": "cloud_push",

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -37,6 +37,69 @@ class TestConfigFlowInit:
         assert flow.VERSION == 2
 
 
+class TestAsyncStepDhcp:
+    @staticmethod
+    def _discovery(
+        ip: str = "192.168.1.42",
+        mac: str = "9c:75:6e:1b:60:c4",
+        hostname: str | None = None,
+    ) -> MagicMock:
+        info = MagicMock()
+        info.ip = ip
+        info.macaddress = mac
+        info.hostname = hostname
+        return info
+
+    @pytest.mark.asyncio
+    async def test_first_discovery_forwards_into_user_step(self) -> None:
+        flow = AjaxCobrandedConfigFlow()
+        flow.hass = MagicMock()
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+        flow._async_current_entries = MagicMock(return_value=[])
+        flow.async_step_user = AsyncMock(return_value={"type": "form"})
+        flow.context = {}
+
+        await flow.async_step_dhcp(self._discovery(hostname="ajax-hub-01"))
+
+        # Per-MAC unique_id deduplicates repeat DHCP packets
+        flow.async_set_unique_id.assert_awaited_once()
+        flow._abort_if_unique_id_configured.assert_called_once()
+        flow.async_step_user.assert_awaited_once()
+        assert flow.context["title_placeholders"] == {"name": "ajax-hub-01"}
+
+    @pytest.mark.asyncio
+    async def test_no_hostname_falls_back_to_ip_in_title(self) -> None:
+        flow = AjaxCobrandedConfigFlow()
+        flow.hass = MagicMock()
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+        flow._async_current_entries = MagicMock(return_value=[])
+        flow.async_step_user = AsyncMock(return_value={"type": "form"})
+        flow.context = {}
+
+        await flow.async_step_dhcp(self._discovery(hostname=None))
+
+        assert flow.context["title_placeholders"] == {"name": "Ajax hub (192.168.1.42)"}
+
+    @pytest.mark.asyncio
+    async def test_existing_entry_aborts_already_configured(self) -> None:
+        """A user with at least one Aegis account configured doesn't get nagged."""
+        flow = AjaxCobrandedConfigFlow()
+        flow.hass = MagicMock()
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+        flow._async_current_entries = MagicMock(return_value=[MagicMock()])
+        flow.async_abort = MagicMock(return_value={"type": "abort"})
+        flow.async_step_user = AsyncMock()
+        flow.context = {}
+
+        await flow.async_step_dhcp(self._discovery())
+
+        flow.async_abort.assert_called_once_with(reason="already_configured")
+        flow.async_step_user.assert_not_awaited()
+
+
 class TestAsyncStepUser:
     @pytest.mark.asyncio
     async def test_step_user_no_input_shows_form(self) -> None:


### PR DESCRIPTION
## Summary

Closes the last of the four quality-of-life follow-ups from the audit. When an Ajax hub is connected to the same LAN as Home Assistant, it now appears as a **Discovered** card under Settings → Devices & Services instead of forcing the user to search for the integration by name. Clicking the card forwards into the existing credential prompt.

## OUI capture

OUI captured from a real Hub Plus (`192.168.1.42 → 9c:75:6e:1b:60:c4` on the maintainer's LAN) and **verified via the IEEE registry as `Ajax Systems DMCC`**. Single OUI in this slice — additional OUIs from other hub families (Hub 2 / Hub Hybrid / Hub Mega / Hub Superior / Hub Fibra) can be captured by users via `arp -a` and added in one-line follow-up commits without changing the flow logic.

## Changes

- `manifest.json`: new `dhcp` array with `{\"macaddress\": \"9C756E*\"}`. HA inspects DHCP packets and triggers `async_step_dhcp` on every device whose MAC starts with that OUI.
- `config_flow.py`:
  - New `async_step_dhcp(discovery_info)` entry point.
  - Sets `format_mac(macaddress)` as the *flow's* `unique_id` (not the eventual entry's, which keeps using email) so HA dedupes repeat DHCP packets — hubs renew lease frequently and we don't want a discovery card per renewal.
  - Aborts with `already_configured` when at least one Aegis entry already exists. Once the user has set up an account, additional spaces under that account appear automatically; a discovery card on every renewal would be noise.
  - Sets `title_placeholders` to the DHCP hostname when present, or `Ajax hub (<ip>)` as the fallback for routers that don't expose hostnames.

## Tests

- `TestAsyncStepDhcp` in `test_config_flow.py` (3 cases):
  - First-time discovery deduplicates by MAC, flows into user step, title shows the DHCP hostname.
  - No DHCP hostname → IP-based fallback in the title.
  - At least one existing Aegis entry → `async_abort(reason=\"already_configured\")`, no user step.
- `make check` clean: **973 passing, 82.72% coverage**, lint / format / typecheck / dead-code green.
- Pre-push hook re-ran the full check inside a fresh Docker rebuild without volume mount.

## Out of scope, follow-ups welcome

- Capturing OUIs for other hub families (Hub 2 / Hybrid / Mega / Superior / Fibra) via `arp -a` from those models. Each is a one-line manifest addition; users can submit a tiny PR with their captured OUI.
- Capturing the DHCP `hostname` pattern Ajax hubs broadcast (would let us also fire on hostname matches — useful when MAC-based discovery is filtered by the router). Today the manifest fires on MAC alone.

## Test plan

- [x] Automated suite green.
- [ ] Manual: with this branch installed, restart HA and reboot the hub (or wait for DHCP lease renewal). Confirm the integration appears under Settings → Devices & Services as a Discovered card with the hub's hostname / IP in the title. Click Configure and confirm the credential prompt appears as if started from scratch.
- [ ] Manual: with the integration already configured, repeat the above. Confirm no Discovered card appears (deduplication works).

Closes #92