### PR TITLE
docs: refresh README + TODO for 1.2.4 QoL features

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 - **Real-time updates**: Persistent gRPC stream for instant sensor state changes (< 1 second latency)
 - **Push notifications**: FCM integration for immediate event delivery
 - **2FA support** (TOTP)
+- **Reauth flow**: when the Ajax session is rejected (password rotated, 2FA newly enabled, server-side logout), HA shows the orange "Reconfigure" banner with a guided password prompt — entity ids, areas, automations and history survive untouched
+- **HA Repairs**: diagnosable conditions surface as cards under **Settings → Repairs** instead of being buried in `home-assistant.log` — hub offline > 24h, sustained HTS reconnect failure, FCM credentials rejected (with one-click fix flow), or grpcio version below the floor on Home Assistant OS
+- **System Health card**: one-line snapshot under **Settings → System → Repairs → System Information** with gRPC reachability, HTS / FCM connection ratios, last push / last poll ages — replaces log archaeology as the first triage step
+- **DHCP discovery**: Ajax hubs on the same LAN appear as a "Discovered" card in **Settings → Devices & Services**, no need to search by name
 - **MDI icons** for all entity types
 - **Automation Blueprints**: Ready-to-use automation templates (see below)
 
@@ -334,9 +338,9 @@ If a specific group of sensors stops working:
 - [ ] Smart lock support (LockBridge)
 - [ ] Valve platform (WaterStop)
 - [ ] Firmware update platform
-- [ ] DHCP discovery for hub auto-detection
 - [ ] Number/Select platforms for device settings (sensitivity, brightness)
 - [ ] SpaceControl (keyfob) event support
+- [ ] "Unknown app label" Repair card (#99)
 
 ## Push Notifications (Optional)
 

--- a/docs/TODO-improvements.md
+++ b/docs/TODO-improvements.md
@@ -15,6 +15,11 @@ Prioritized list of remaining improvements based on HA platinum integration patt
 - ~~Automation blueprints~~ (v1.0.0) — 8 blueprints (security events, intrusion, tamper, remind arm, battery, connectivity, door-while-armed, TTS)
 - ~~Rebrand~~ (v1.0.0) — Aegis for Ajax identity
 - ~~Binary sensors~~ (partial) — glass_break, vibration, external_contact
+- ~~Per-group `alarm_control_panel` for Group/Zone Mode~~ (v1.2.4) — one panel per Ajax security group + whole-house panel for night mode (#84, #86)
+- ~~Reauth flow~~ (v1.2.4) — `ConfigEntryAuthFailed` + `async_step_reauth` so HA shows the Reconfigure banner instead of failing silently (#90)
+- ~~HA Repairs~~ (v1.2.4) — `hub_offline_24h`, `hts_chronic_failure`, `fcm_credentials_invalid` (with guided fix flow), `grpcio_version_mismatch` Repair cards (#89)
+- ~~System Health card~~ (v1.2.4) — gRPC reachability, HTS/FCM ratios, pushes received, last push / last poll ages under Settings → System (#91)
+- ~~DHCP discovery~~ (v1.2.4) — Ajax hubs on the LAN appear as Discovered cards via OUI `9C:75:6E` (#92)
 
 ---
 
@@ -59,19 +64,17 @@ Prioritized list of remaining improvements based on HA platinum integration patt
 
 **Effort:** Medium (3 hours). Need to parse firmware proto fields.
 
-### 2.2 DHCP Discovery
-**Why:** Automatic hub detection on the local network without manual setup.
-
-**Implementation:** Add `dhcp` entries to `manifest.json` with Ajax hub MAC prefixes, implement `async_step_dhcp` in config_flow.
-
-**Note:** Only helps if the hub is on the same network as HA.
-
-**Effort:** Low (1 hour).
-
-### 2.3 Persistent Notification Service
+### 2.2 Persistent Notification Service
 **Why:** Show alarm events as HA persistent notifications with configurable filters.
 
 **Effort:** Medium (2 hours).
+
+### 2.3 Unknown App Label Repair (#99)
+**Why:** When the user configures a label the Ajax backend rejects, the integration today surfaces UNAUTHENTICATED / PERMISSION_DENIED gRPC errors with no clear remediation. A Repair card with a fix flow (the same `KNOWN_APP_LABELS` dropdown the config flow uses) would replace stack traces with a one-click fix.
+
+**Implementation:** Capture the gRPC error shape backend returns for unknown labels (vs. wrong credentials), introduce `UnknownAppLabelError(AuthenticationError)` subclass, branch in coordinator's auth-failure path, add `UnknownAppLabelRepairFlow`. Same pattern as the FCM fix flow shipped in #96.
+
+**Effort:** Medium (3-4 hours, gated on capturing the discriminating error shape).
 
 ---
 


### PR DESCRIPTION
## Summary

The Features list in the README and the Completed section of \`docs/TODO-improvements.md\` were stale relative to the 1.2.4-beta line. This brings them in sync with what's actually shipping in the channel today.

## Changes

- **README.md**:
  - Features list gains five bullets covering the HA-platform additions: Reauth flow, HA Repairs (4 cards including the FCM guided fix flow), System Health card, DHCP discovery.
  - Roadmap drops \"DHCP discovery for hub auto-detection\" (now done) and adds the remaining \"Unknown app label Repair\" follow-up under #99.
- **docs/TODO-improvements.md**:
  - Completed section gains five entries (per-group panels for Group/Zone Mode, Reauth, Repairs, System Health, DHCP).
  - Priority 2 loses \"DHCP Discovery\" (shipped) and gains \"Unknown App Label Repair\" with the same implementation sketch noted in #99's body.

No code changes. Unit suite, coverage, hassfest unaffected.