### PR TITLE
feat(lock): SmartLock / LockBridge platform with lock + unlatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 - **Sensors**: Battery level, temperature, humidity, CO2, signal strength, GSM type (2G/3G/4G), Wi-Fi signal level, Wi-Fi SSID, Wi-Fi IP, IMEI, Ethernet IP/gateway/DNS, cellular signal/network, connection type
 - **Switches**: Relays, wall switches, sockets (multi-channel support)
 - **Lights**: Dimmers with brightness control
+- **Locks**: Ajax SmartLock and LockBridge (Yale) — lock, unlock, and unlatch (HA's `lock.open`) via `SwitchSmartLockService`
 - **Cameras**: MotionCam Photo on Demand — capture photos and view them in HA (PhOD models only)
 - **Photo Storage**: Captured photos saved to `/media/ajax_photos/` with timestamp overlay, configurable retention
 - **Media Browser**: Browse captured photos per device via HA Media Browser
@@ -153,6 +154,7 @@ You can type any custom label during setup if yours is not listed.
 | Water Leak | LeaksProtect | Leak detected, tamper, battery |
 | Relays/Switches | Relay, WallSwitch, Socket, LightSwitch | On/off per channel |
 | Lights | LightSwitch Dimmer | Brightness control |
+| Locks | SmartLock, LockBridge (Yale) | Lock, unlock, unlatch (HA `lock.open` → momentary unlatch). State surfaces locked / unlocked / unlatched |
 | Keypads | Keypad, KeypadPlus, KeypadCombi, KeypadTouchscreen | Battery, tamper, temperature, signal, NFC status |
 | Sirens | HomeSiren, HomeSiren S, HomeSiren Fibra, HomeSiren G3, StreetSiren, StreetSiren S, StreetSiren Plus, StreetSiren Plus Fibra/G3, StreetSiren Fibra, StreetSiren Double Deck (& S / Fibra) | Battery, tamper, signal |
 | Range extenders | ReX, ReX 2, ReX 2 Fire | Battery, signal |

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -35,6 +35,7 @@ PLATFORMS = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.LIGHT,
+    Platform.LOCK,
 ]
 
 type AjaxCobrandedConfigEntry = ConfigEntry[AjaxCobrandedCoordinator]

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -16,6 +16,11 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+
+class SmartLockError(Exception):
+    """Raised when a SwitchSmartLockService call fails."""
+
+
 _STREAM_LIGHT_DEVICES = (
     "/systems.ajax.api.ecosystem.v3.mobilegwsvc.service"
     ".stream_light_devices.StreamLightDevicesService/execute"
@@ -32,6 +37,20 @@ _DEVICE_BRIGHTNESS = (
     "/systems.ajax.api.ecosystem.v3.mobilegwsvc.service"
     ".device_command_brightness.DeviceCommandBrightnessService/execute"
 )
+
+# SmartLockStatus.LockStatus → human-readable state used by the lock entity.
+# Mirrors `proto/.../space/smartlock/smart_lock_pb2`.
+_SMART_LOCK_STATE_MAP: dict[int, str] = {
+    0: "unknown",
+    1: "unlocked",
+    2: "locked",
+    3: "unlatched",
+}
+
+# SwitchSmartLockRequest.Action enum — UNLOCK=1, LOCK=2, UNLATCH=3.
+SMART_LOCK_ACTION_LOCK = 2
+SMART_LOCK_ACTION_UNLOCK = 1
+SMART_LOCK_ACTION_UNLATCH = 3
 
 
 def _encode_string_field(field_number: int, value: str) -> bytes:
@@ -260,6 +279,12 @@ class DevicesApi:
                     if hasattr(status, "wifi_signal_level_status")
                     else 0
                 )
+            elif which == "smart_lock":
+                # The status oneof carries the LockStatus enum directly (not a
+                # sub-message), so `status.smart_lock` is already the int value.
+                result["smart_lock_state"] = _SMART_LOCK_STATE_MAP.get(
+                    int(status.smart_lock), "unknown"
+                )
         return result
 
     @staticmethod
@@ -451,6 +476,10 @@ class DevicesApi:
                                             )
                                         elif status_name == "wifi_signal_level_status":
                                             payload["value"] = int(status.wifi_signal_level_status)
+                                        elif status_name == "smart_lock":
+                                            payload["value"] = _SMART_LOCK_STATE_MAP.get(
+                                                int(status.smart_lock), "unknown"
+                                            )
 
                                         on_status_update(
                                             device_id,
@@ -492,6 +521,31 @@ class DevicesApi:
             f"Device commands not yet implemented (action={command.action}, "
             f"device={command.device_id})"
         )
+
+    async def switch_smart_lock(self, space_id: str, smart_lock_id: str, action: int) -> None:
+        """Lock / unlock / unlatch a SmartLock or LockBridge.
+
+        action: 1=UNLOCK, 2=LOCK, 3=UNLATCH (constants exported as
+        SMART_LOCK_ACTION_*). Raises SmartLockError on a failure response.
+        """
+        from v3.mobilegwsvc.service.switch_smart_lock import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.SwitchSmartLockServiceStub(channel)
+        request = request_pb2.SwitchSmartLockRequest(
+            space_id=space_id,
+            smart_lock_id=smart_lock_id,
+            action=action,
+        )
+        response = await stub.execute(request, metadata=metadata, timeout=15)
+        if response.HasField("failure"):
+            error_type = response.failure.WhichOneof("error") or "unknown"
+            raise SmartLockError(error_type)
+        _LOGGER.debug("SmartLock %s in space %s: action=%s OK", smart_lock_id, space_id, action)
 
     async def capture_photo(self, hub_id: str, device_id: str, device_type: str) -> str | None:
         """Capture a photo using v2 PhotoOnDemandService.

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -64,6 +64,7 @@ _STATUS_KEY_MAP: dict[str, str] = {
     "vibration_detected": "vibration",
     "wire_input_status": "wire_input_alert",
     "transmitter_status": "wire_input_alert",
+    "smart_lock": "smart_lock_state",
 }
 
 # Statuses whose snapshot parser writes more than the single mapped key.

--- a/custom_components/aegis_ajax/lock.py
+++ b/custom_components/aegis_ajax/lock.py
@@ -1,0 +1,125 @@
+"""Lock entities for Ajax SmartLock / LockBridge devices."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.lock import LockEntity, LockEntityFeature
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.aegis_ajax.api.devices import (
+    SMART_LOCK_ACTION_LOCK,
+    SMART_LOCK_ACTION_UNLATCH,
+    SMART_LOCK_ACTION_UNLOCK,
+    SmartLockError,
+)
+from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from custom_components.aegis_ajax.api.models import Device
+
+_LOGGER = logging.getLogger(__name__)
+
+# Ajax catalog ships two SmartLock device-type buckets — `smart_lock` for
+# generic LockBridge integrations and `smart_lock_yale` for Yale-branded
+# locks. Both expose the same status oneof and are controlled by the same
+# SwitchSmartLockService, so they share a single entity class.
+LOCK_DEVICE_TYPES: frozenset[str] = frozenset({"smart_lock", "smart_lock_yale"})
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: AjaxCobrandedCoordinator = entry.runtime_data
+    entities: list[AjaxLock] = []
+    for device_id, device in coordinator.devices.items():
+        if device.device_type in LOCK_DEVICE_TYPES:
+            entities.append(AjaxLock(coordinator=coordinator, device_id=device_id))
+    async_add_entities(entities)
+
+
+class AjaxLock(CoordinatorEntity[AjaxCobrandedCoordinator], LockEntity):
+    """Lock entity backed by the Ajax SmartLock status + SwitchSmartLockService."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    # OPEN maps to UNLATCH on the Ajax side — pull the latch without keeping
+    # the door deadbolted, e.g. for delivery drop-offs.
+    _attr_supported_features = LockEntityFeature.OPEN
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._attr_unique_id = f"aegis_ajax_{device_id}_lock"
+        device = coordinator.devices.get(device_id)
+        if device:
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
+
+    @property
+    def _device(self) -> Device | None:
+        return self.coordinator.devices.get(self._device_id)
+
+    def _resolve_space_id(self) -> str | None:
+        device = self._device
+        if device is None:
+            return None
+        for space in self.coordinator.spaces.values():
+            if space.hub_id == device.hub_id:
+                return space.id
+        return None
+
+    @property
+    def available(self) -> bool:
+        device = self._device
+        return device is not None and device.is_online
+
+    @property
+    def is_locked(self) -> bool | None:
+        device = self._device
+        if device is None:
+            return None
+        state = device.statuses.get("smart_lock_state")
+        if state == "locked":
+            return True
+        if state in ("unlocked", "unlatched"):
+            return False
+        return None
+
+    @property
+    def is_open(self) -> bool | None:
+        device = self._device
+        if device is None:
+            return None
+        return device.statuses.get("smart_lock_state") == "unlatched"
+
+    async def _send_action(self, action: int) -> None:
+        space_id = self._resolve_space_id()
+        if space_id is None:
+            _LOGGER.error(
+                "Cannot resolve space for SmartLock %s — no matching hub in coordinator",
+                self._device_id,
+            )
+            return
+        try:
+            await self.coordinator.devices_api.switch_smart_lock(
+                space_id=space_id, smart_lock_id=self._device_id, action=action
+            )
+        except SmartLockError as exc:
+            _LOGGER.error("SmartLock %s action %s failed: %s", self._device_id, action, exc)
+            return
+        await self.coordinator.async_request_refresh()
+
+    async def async_lock(self, **kwargs: object) -> None:
+        await self._send_action(SMART_LOCK_ACTION_LOCK)
+
+    async def async_unlock(self, **kwargs: object) -> None:
+        await self._send_action(SMART_LOCK_ACTION_UNLOCK)
+
+    async def async_open(self, **kwargs: object) -> None:
+        await self._send_action(SMART_LOCK_ACTION_UNLATCH)

--- a/docs/TODO-improvements.md
+++ b/docs/TODO-improvements.md
@@ -21,31 +21,20 @@ Prioritized list of remaining improvements based on HA platinum integration patt
 - ~~System Health card~~ (v1.2.4) — gRPC reachability, HTS/FCM ratios, pushes received, last push / last poll ages under Settings → System (#91)
 - ~~DHCP discovery~~ (v1.2.4) — Ajax hubs on the LAN appear as Discovered cards via OUI `9C:75:6E` (#92)
 - ~~Tilt + Steam binary sensors~~ (v1.2.4) — `tilt` on DoorProtect Plus family (accelerometer), `steam` on FireProtect 2 smoke-chamber variants (steam-vs-smoke discriminator)
+- ~~Lock platform~~ (v1.2.5) — `lock.py` with `AjaxLock` for `smart_lock` / `smart_lock_yale` device types. State (locked / unlocked / unlatched) parsed from the `smart_lock` LockStatus oneof; `lock` / `unlock` / HA's `lock.open` (= unlatch) wired to `SwitchSmartLockService`
 
 ---
 
 ## Priority 1 — High impact, moderate effort
 
-### 1.1 Lock Platform (`lock.py`)
-**Why:** Users with LockBridge (Yale smart lock) expect a lock entity.
+### 1.1 Valve Platform (`valve.py`) — blocked
+**Why:** WaterStop devices currently surface as a no-op (empty binary-sensor list). Native `valve` entity would let automations open/close the water shut-off valve.
 
-**Implementation:**
-1. Create `lock.py` with `AjaxLock` entity
-2. Parse `smart_lock` status from `LightDeviceStatus` (field 66)
-3. Commands via `SwitchSmartLockService` gRPC (proto exists: `switch_smart_lock/`)
-4. States: locked, unlocked, locking, unlocking, jammed
+**Blockers — both need investigating in a real WaterStop install before this can ship:**
+1. The actual valve open/closed state lives in `LightHubDevice.properties.water_stop_channel.state` (an enum: STATE_OFF / STATE_ON), which is *not* part of the `LightDeviceStatus.statuses` oneof we currently parse. Surfacing it requires extending `parse_device` to walk the `properties` oneof per device type — a small architectural change touching every property-bearing entity.
+2. No `SwitchWaterStop`-style command service exists in the v3 protos we have. Without a way to actually toggle the valve, a `valve` entity would be read-only and provide little value over the existing `water_stop_valve_stuck` malfunction signal. Need to capture the wire calls the official mobile app makes when toggling a WaterStop to identify the right service.
 
-**Effort:** Medium (3-4 hours). Need to compile switch_smart_lock protos.
-
-### 1.2 Valve Platform (`valve.py`)
-**Why:** WaterStop devices should be controlled as native HA valves, not switches.
-
-**Implementation:**
-1. Create `valve.py` with `AjaxWaterStopValve` entity
-2. Parse `water_stop_valve_stuck` status
-3. Commands need investigation — may be via device command service
-
-**Effort:** Medium (2-3 hours).
+**Effort:** Unknown until both blockers are answered. The `water_stop_valve_stuck` Simple flag could be exposed as a `PROBLEM` binary sensor in the meantime — much smaller change, doesn't pre-empt the eventual `valve` design.
 
 ---
 

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -178,6 +178,17 @@ class TestStatusParser:
         result = DevicesApi._parse_statuses([status])
         assert result.get("high_temperature") is True
 
+    @pytest.mark.parametrize(
+        "value,expected",
+        [(0, "unknown"), (1, "unlocked"), (2, "locked"), (3, "unlatched"), (99, "unknown")],
+    )
+    def test_smart_lock_status(self, value: int, expected: str) -> None:
+        status = MagicMock()
+        status.WhichOneof.return_value = "smart_lock"
+        status.smart_lock = value
+        result = DevicesApi._parse_statuses([status])
+        assert result.get("smart_lock_state") == expected
+
     def test_signal_strength(self) -> None:
         status = MagicMock()
         status.WhichOneof.return_value = "signal_strength"

--- a/tests/unit/test_lock.py
+++ b/tests/unit/test_lock.py
@@ -1,0 +1,189 @@
+"""Tests for the lock platform (Ajax SmartLock / LockBridge)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.aegis_ajax.api.devices import (
+    SMART_LOCK_ACTION_LOCK,
+    SMART_LOCK_ACTION_UNLATCH,
+    SMART_LOCK_ACTION_UNLOCK,
+    SmartLockError,
+)
+from custom_components.aegis_ajax.api.models import Device, Space
+from custom_components.aegis_ajax.const import (
+    ConnectionStatus,
+    DeviceState,
+    SecurityState,
+)
+from custom_components.aegis_ajax.lock import LOCK_DEVICE_TYPES, AjaxLock
+
+
+def _make_device(device_type: str, smart_lock_state: str | None = None) -> Device:
+    statuses: dict = {}
+    if smart_lock_state is not None:
+        statuses["smart_lock_state"] = smart_lock_state
+    return Device(
+        id="lock-1",
+        hub_id="hub-1",
+        name="Front Door Lock",
+        device_type=device_type,
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses=statuses,
+        battery=None,
+    )
+
+
+def _make_coordinator(device: Device) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.devices = {device.id: device}
+    coordinator.rooms = {}
+    coordinator.spaces = {
+        "space-A": Space(
+            id="space-A",
+            hub_id=device.hub_id,
+            name="Home",
+            security_state=SecurityState.DISARMED,
+            connection_status=ConnectionStatus.ONLINE,
+            malfunctions_count=0,
+            monitoring_companies=(),
+            monitoring_companies_loaded=True,
+            groups=(),
+            group_mode_enabled=False,
+        )
+    }
+    coordinator.devices_api = MagicMock()
+    coordinator.devices_api.switch_smart_lock = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+class TestLockDeviceTypes:
+    def test_smart_lock_in_lock_types(self) -> None:
+        assert "smart_lock" in LOCK_DEVICE_TYPES
+
+    def test_smart_lock_yale_in_lock_types(self) -> None:
+        assert "smart_lock_yale" in LOCK_DEVICE_TYPES
+
+
+class TestAjaxLockState:
+    @pytest.mark.parametrize("device_type", ["smart_lock", "smart_lock_yale"])
+    def test_is_locked_true(self, device_type: str) -> None:
+        device = _make_device(device_type, "locked")
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+        assert lock.is_locked is True
+
+    @pytest.mark.parametrize("state", ["unlocked", "unlatched"])
+    def test_is_locked_false(self, state: str) -> None:
+        device = _make_device("smart_lock", state)
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+        assert lock.is_locked is False
+
+    def test_is_locked_unknown_when_state_missing(self) -> None:
+        device = _make_device("smart_lock", smart_lock_state=None)
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+        assert lock.is_locked is None
+
+    def test_is_open_unlatched(self) -> None:
+        device = _make_device("smart_lock", "unlatched")
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+        assert lock.is_open is True
+
+    def test_is_open_false_when_locked(self) -> None:
+        device = _make_device("smart_lock", "locked")
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+        assert lock.is_open is False
+
+    def test_unavailable_when_offline(self) -> None:
+        device = Device(
+            id="lock-1",
+            hub_id="hub-1",
+            name="Front Door Lock",
+            device_type="smart_lock",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.OFFLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+        assert lock.available is False
+
+
+class TestAjaxLockCommands:
+    @pytest.mark.asyncio
+    async def test_async_lock_invokes_lock_action(self) -> None:
+        device = _make_device("smart_lock", "unlocked")
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+
+        await lock.async_lock()
+
+        coordinator.devices_api.switch_smart_lock.assert_awaited_once_with(
+            space_id="space-A", smart_lock_id="lock-1", action=SMART_LOCK_ACTION_LOCK
+        )
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_unlock_invokes_unlock_action(self) -> None:
+        device = _make_device("smart_lock", "locked")
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+
+        await lock.async_unlock()
+
+        coordinator.devices_api.switch_smart_lock.assert_awaited_once_with(
+            space_id="space-A", smart_lock_id="lock-1", action=SMART_LOCK_ACTION_UNLOCK
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_open_invokes_unlatch_action(self) -> None:
+        device = _make_device("smart_lock", "locked")
+        coordinator = _make_coordinator(device)
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+
+        await lock.async_open()
+
+        coordinator.devices_api.switch_smart_lock.assert_awaited_once_with(
+            space_id="space-A", smart_lock_id="lock-1", action=SMART_LOCK_ACTION_UNLATCH
+        )
+
+    @pytest.mark.asyncio
+    async def test_command_swallows_smart_lock_error(self) -> None:
+        # We surface the failure through logs rather than raising — the
+        # entity should not crash HA's service call pipeline. The next poll
+        # corrects the displayed state.
+        device = _make_device("smart_lock", "locked")
+        coordinator = _make_coordinator(device)
+        coordinator.devices_api.switch_smart_lock.side_effect = SmartLockError("smart_lock_offline")
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+
+        await lock.async_unlock()  # must not raise
+
+        coordinator.async_request_refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_command_no_op_when_space_unresolvable(self) -> None:
+        device = _make_device("smart_lock", "locked")
+        coordinator = _make_coordinator(device)
+        coordinator.spaces = {}  # no space matches the hub_id
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+
+        await lock.async_lock()
+
+        coordinator.devices_api.switch_smart_lock.assert_not_called()
+        coordinator.async_request_refresh.assert_not_called()


### PR DESCRIPTION
## Summary
- New `lock` platform exposing Ajax SmartLock and Yale LockBridge as native HA `lock.*` entities.
- Status (locked / unlocked / unlatched) parsed from the v3 `LightDeviceStatus.smart_lock` LockStatus oneof; real-time updates flow through the same status-update path as every other entity.
- Commands wired to the existing `SwitchSmartLockService.execute` gRPC endpoint with three actions: `LOCK`, `UNLOCK`, and `UNLATCH`. HA's `lock.open` is mapped to `UNLATCH` so it pulls the latch without keeping the bolt thrown — same semantics as the Ajax mobile app.
- `Platform.LOCK` added to the integration's `PLATFORMS` list.

Drops the `lock.py` item from `docs/TODO-improvements.md` Priority 1 and rewrites the `valve.py` entry with the actual blockers (state lives in `LightHubDevice.properties.water_stop_channel`, not in the streamed statuses we parse, and no command service exists in the current protos).

## Test plan
- [x] `make check` (lint, format, typecheck, tests, dead-code) inside the dev image — 1046 passed, coverage 83.01%
- [x] `make check` against the no-volume CI image — same result
- [ ] Smoke-test on real HA: confirm a SmartLock / LockBridge device exposes a `lock.*` entity with the correct state and that `lock` / `unlock` / `lock.open` (unlatch) round-trip through the hub