### PR TITLE
docs(fcm): clarify iOS users must extract credentials from the Android APK

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,8 @@ The required fields (configured in the integration's Options flow, stored secure
 
 Three of the four values are plain strings in the app's `res/values/strings.xml`: `project_id`, `gcm_defaultSenderId` and `google_app_id`. The fourth, `google_api_key`, is **not** in `strings.xml` (the value there is a placeholder); it ships inside `lib/<arch>/libnative-lib.so` bundled with the APK.
 
+> **iOS users:** the iOS Ajax app ships these values in `GoogleService-Info.plist` inside the signed `.ipa` bundle, which is encrypted and cannot be inspected without a jailbroken device. In practice, even if you use the Ajax app on iPhone day-to-day, **extract the credentials from the Android APK** — the Firebase project is the same on both platforms (same `project_id`, `google_app_id`, `gcm_defaultSenderId` and `google_api_key`), so values pulled from the Android build work for FCM push delivery on a Home Assistant install regardless of which OS you personally use.
+
 If FCM credentials are not configured, the integration will still work using the persistent gRPC stream for real-time updates. FCM adds an additional push notification channel for faster event delivery and enables Photo on Demand URL retrieval.
 
 ## Translations


### PR DESCRIPTION
## Summary
- Adds an explicit iOS callout to the README's *How to obtain FCM credentials* section.
- The honest answer for iOS users — whose `.ipa` bundle ships `GoogleService-Info.plist` inside an encrypted, signed app bundle — is that they cannot extract the credentials from their phone's app at all without a jailbroken device. The practical guidance is to use the Android APK regardless of which OS they personally use day-to-day, since the Firebase project is identical on both platforms.

Motivated by a follow-up question on issue #46.

## Test plan
- [x] Markdown renders cleanly (callout uses standard `>` blockquote, no fancy formatting)