### PR TITLE
feat(commands): wire DeviceCommand* gRPC services so switches and dimmer act

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 - **Binary Sensors**: Door open/close, motion detection, smoke, steam (FireProtect 2 chamber discriminator), leak, tamper, CO, heat, glass break, vibration, tilt (DoorProtect Plus accelerometer), CRA monitoring status, cellular connection, lid tamper, external contact alert (wired reed switches on DoorProtect/Hub Hybrid inputs), external contact fault, MultiTransmitter wired-input alert with alarm category, anti-masking, interference detection, ethernet link, Wi-Fi link, mains power
 - **Hub Network**: Real-time hub network data — ethernet/wifi/gsm connection status, Wi-Fi SSID and signal strength, IP addressing, cellular signal strength and network type, power supply status
 - **Sensors**: Battery level, temperature, humidity, CO2, signal strength, GSM type (2G/3G/4G), Wi-Fi signal level, Wi-Fi SSID, Wi-Fi IP, IMEI, Ethernet IP/gateway/DNS, cellular signal/network, connection type
-- **Switches**: Relays, wall switches, sockets (multi-channel support)
-- **Lights**: Dimmers with brightness control
+- **Switches**: Relays, wall switches, sockets (multi-channel support) — turn on/off via `DeviceCommandDeviceOn` / `DeviceCommandDeviceOff` gRPC services
+- **Lights**: Dimmers with absolute brightness control via `DeviceCommandBrightness`
 - **Locks**: Ajax SmartLock and LockBridge (Yale) — lock, unlock, and unlatch (HA's `lock.open`) via `SwitchSmartLockService`
 - **Cameras**: MotionCam Photo on Demand — capture photos and view them in HA (PhOD models only)
 - **Photo Storage**: Captured photos saved to `/media/ajax_photos/` with timestamp overlay, configurable retention

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -21,6 +21,10 @@ class SmartLockError(Exception):
     """Raised when a SwitchSmartLockService call fails."""
 
 
+class DeviceCommandError(Exception):
+    """Raised when a DeviceCommand* gRPC call fails or is not supported."""
+
+
 _STREAM_LIGHT_DEVICES = (
     "/systems.ajax.api.ecosystem.v3.mobilegwsvc.service"
     ".stream_light_devices.StreamLightDevicesService/execute"
@@ -51,6 +55,29 @@ _SMART_LOCK_STATE_MAP: dict[int, str] = {
 SMART_LOCK_ACTION_LOCK = 2
 SMART_LOCK_ACTION_UNLOCK = 1
 SMART_LOCK_ACTION_UNLATCH = 3
+
+
+def _build_object_type(device_type: str) -> Any:  # noqa: ANN401
+    """Construct an `ObjectType` v2 proto with the matching `type` oneof set.
+
+    `DeviceCommandDevice{On,Off,Brightness}Request.device_type` is an
+    `ObjectType` message whose `type` oneof is selected per device family
+    (relay / wall_switch / socket_* / light_switch_* / etc.). Each inner
+    case is an empty marker message — `SetInParent()` marks the oneof
+    case as present without setting any fields. The accepted strings
+    mirror the WhichOneof("type") return values that `parse_device`
+    already produces from the snapshot, so a `Device.device_type` round-
+    trips back into a valid request without further mapping.
+    """
+    from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels import (  # noqa: PLC0415
+        object_type_pb2,
+    )
+
+    obj = object_type_pb2.ObjectType()
+    if not hasattr(obj, device_type):
+        raise DeviceCommandError(f"Unsupported device type for command: {device_type}")
+    getattr(obj, device_type).SetInParent()
+    return obj
 
 
 def _encode_string_field(field_number: int, value: str) -> bytes:
@@ -517,9 +544,96 @@ class DevicesApi:
         return task
 
     async def send_command(self, command: DeviceCommand) -> None:
-        raise NotImplementedError(
-            f"Device commands not yet implemented (action={command.action}, "
-            f"device={command.device_id})"
+        """Dispatch a device command to the right v3 DeviceCommand* service.
+
+        action="on" / "off" → DeviceCommandDeviceOn / Off (relays, sockets,
+        wall/light switches), action="brightness" → DeviceCommandBrightness
+        (LightSwitch Dimmer). Raises DeviceCommandError on unsupported
+        action / device_type or on a gRPC failure response.
+        """
+        if command.action == "on":
+            await self._device_on(command)
+        elif command.action == "off":
+            await self._device_off(command)
+        elif command.action == "brightness":
+            await self._device_brightness(command)
+        else:
+            raise DeviceCommandError(f"Unknown device command action: {command.action}")
+
+    async def _device_on(self, command: DeviceCommand) -> None:
+        from v3.mobilegwsvc.service.device_command_device_on import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.DeviceCommandDeviceOnServiceStub(channel)
+        request = request_pb2.DeviceCommandDeviceOnRequest(
+            hub_id=command.hub_id,
+            device_id=command.device_id,
+            device_type=_build_object_type(command.device_type),
+            channels=command.channels or [1],
+        )
+        response = await stub.execute(request, metadata=metadata, timeout=15)
+        if response.HasField("failure"):
+            error = response.failure.WhichOneof("error") or "unknown"
+            raise DeviceCommandError(f"on: {error}")
+        _LOGGER.debug("Device %s on (channels=%s) OK", command.device_id, command.channels)
+
+    async def _device_off(self, command: DeviceCommand) -> None:
+        from v3.mobilegwsvc.service.device_command_device_off import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.DeviceCommandDeviceOffServiceStub(channel)
+        request = request_pb2.DeviceCommandDeviceOffRequest(
+            hub_id=command.hub_id,
+            device_id=command.device_id,
+            device_type=_build_object_type(command.device_type),
+            channels=command.channels or [1],
+        )
+        response = await stub.execute(request, metadata=metadata, timeout=15)
+        if response.HasField("failure"):
+            error = response.failure.WhichOneof("error") or "unknown"
+            raise DeviceCommandError(f"off: {error}")
+        _LOGGER.debug("Device %s off (channels=%s) OK", command.device_id, command.channels)
+
+    async def _device_brightness(self, command: DeviceCommand) -> None:
+        from v3.mobilegwsvc.service.device_command_brightness import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        if command.brightness is None:
+            raise DeviceCommandError("brightness command requires a brightness value")
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.DeviceCommandBrightnessServiceStub(channel)
+        # BRIGHTNESS_TYPE_ABSOLUTE=2 — the percentage we send is the new
+        # absolute target, not a delta. HA's brightness slider is always
+        # absolute, so this matches user intent.
+        request = request_pb2.DeviceCommandBrightnessRequest(
+            hub_id=command.hub_id,
+            device_id=command.device_id,
+            device_type=_build_object_type(command.device_type),
+            brightness_in_percentage=command.brightness,
+            channels=command.channels or [1],
+            brightness_type=2,
+        )
+        response = await stub.execute(request, metadata=metadata, timeout=15)
+        if response.HasField("failure"):
+            error = response.failure.WhichOneof("error") or "unknown"
+            raise DeviceCommandError(f"brightness: {error}")
+        _LOGGER.debug(
+            "Device %s brightness=%s%% (channels=%s) OK",
+            command.device_id,
+            command.brightness,
+            command.channels,
         )
 
     async def switch_smart_lock(self, space_id: str, smart_lock_id: str, action: int) -> None:

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -412,26 +412,45 @@ class TestDevicesApiInit:
 
 
 class TestSendCommand:
+    """Dispatcher behaviour for `DevicesApi.send_command`.
+
+    These tests mock out the per-action coroutines on the instance so we
+    only assert the action-string → method routing. The actual gRPC
+    serialisation is covered by the dedicated tests below.
+    """
+
     @pytest.mark.asyncio
-    async def test_send_command_on_raises_not_implemented(self) -> None:
-        client = MagicMock()
-        api = DevicesApi(client)
+    async def test_send_command_dispatches_on(self) -> None:
+        api = DevicesApi(MagicMock())
+        api._device_on = AsyncMock()
+        api._device_off = AsyncMock()
+        api._device_brightness = AsyncMock()
         cmd = DeviceCommand.on(hub_id="h1", device_id="d1", device_type="relay", channels=[1])
-        with pytest.raises(NotImplementedError):
-            await api.send_command(cmd)
+
+        await api.send_command(cmd)
+
+        api._device_on.assert_awaited_once_with(cmd)
+        api._device_off.assert_not_called()
+        api._device_brightness.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_send_command_off_raises_not_implemented(self) -> None:
-        client = MagicMock()
-        api = DevicesApi(client)
+    async def test_send_command_dispatches_off(self) -> None:
+        api = DevicesApi(MagicMock())
+        api._device_on = AsyncMock()
+        api._device_off = AsyncMock()
+        api._device_brightness = AsyncMock()
         cmd = DeviceCommand.off(hub_id="h1", device_id="d1", device_type="relay", channels=[1])
-        with pytest.raises(NotImplementedError):
-            await api.send_command(cmd)
+
+        await api.send_command(cmd)
+
+        api._device_off.assert_awaited_once_with(cmd)
 
     @pytest.mark.asyncio
-    async def test_send_command_brightness_raises_not_implemented(self) -> None:
-        client = MagicMock()
-        api = DevicesApi(client)
+    async def test_send_command_dispatches_brightness(self) -> None:
+        api = DevicesApi(MagicMock())
+        api._device_on = AsyncMock()
+        api._device_off = AsyncMock()
+        api._device_brightness = AsyncMock()
         cmd = DeviceCommand.set_brightness(
             hub_id="h1",
             device_id="d1",
@@ -439,7 +458,208 @@ class TestSendCommand:
             brightness=50,
             channels=[1],
         )
-        with pytest.raises(NotImplementedError):
+
+        await api.send_command(cmd)
+
+        api._device_brightness.assert_awaited_once_with(cmd)
+
+    @pytest.mark.asyncio
+    async def test_send_command_unknown_action_raises(self) -> None:
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        api = DevicesApi(MagicMock())
+        cmd = DeviceCommand(
+            action="bogus",
+            hub_id="h1",
+            device_id="d1",
+            device_type="relay",
+            channels=[1],
+        )
+        with pytest.raises(DeviceCommandError):
+            await api.send_command(cmd)
+
+
+class TestBuildObjectType:
+    """`_build_object_type` must mark the right ObjectType.type oneof case."""
+
+    @pytest.mark.parametrize(
+        "device_type",
+        [
+            "relay",
+            "relay_fibra_base",
+            "wall_switch",
+            "socket",
+            "socket_b",
+            "socket_g",
+            "socket_outlet_type_e",
+            "socket_outlet_type_f",
+            "socket_type_g_plus",
+            "light_switch",
+            "light_switch_one_gang",
+            "light_switch_two_gang",
+            "light_switch_dimmer",
+        ],
+    )
+    def test_known_device_type_sets_oneof(self, device_type: str) -> None:
+        from custom_components.aegis_ajax.api.devices import _build_object_type
+
+        obj = _build_object_type(device_type)
+
+        assert obj.WhichOneof("type") == device_type
+
+    def test_unknown_device_type_raises(self) -> None:
+        from custom_components.aegis_ajax.api.devices import (
+            DeviceCommandError,
+            _build_object_type,
+        )
+
+        with pytest.raises(DeviceCommandError):
+            _build_object_type("not_a_real_device")
+
+
+class TestDeviceCommandRoundTrip:
+    """Cover the gRPC stub interaction for the three command actions.
+
+    We patch the lazy-imported `endpoint_pb2_grpc` module's stub class so
+    each call returns a controllable response message. The test then
+    asserts on the actual request that hit the stub, catching any drift
+    between `DeviceCommand` and the proto wire format.
+    """
+
+    def _make_api(self) -> DevicesApi:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        return DevicesApi(client)
+
+    @pytest.mark.asyncio
+    async def test_device_on_sends_correct_request(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_device_on import (
+            endpoint_pb2_grpc,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        success_response = response_pb2.DeviceCommandDeviceOnResponse(
+            success=common_response_pb2.Success()
+        )
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                async def _execute(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return success_response
+
+                self.execute = AsyncMock(side_effect=_execute)
+
+        with patch.object(endpoint_pb2_grpc, "DeviceCommandDeviceOnServiceStub", _StubFactory):
+            await api.send_command(
+                DeviceCommand.on(
+                    hub_id="hub-1",
+                    device_id="dev-1",
+                    device_type="relay",
+                    channels=[1],
+                )
+            )
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert request.hub_id == "hub-1"
+        assert request.device_id == "dev-1"
+        assert request.device_type.WhichOneof("type") == "relay"
+        assert list(request.channels) == [1]
+
+    @pytest.mark.asyncio
+    async def test_device_off_failure_raises(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_device_off import (
+            endpoint_pb2_grpc,
+            response_pb2,
+        )
+
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        api = self._make_api()
+        failure_response = response_pb2.DeviceCommandDeviceOffResponse(
+            failure=response_pb2.DeviceCommandDeviceOffResponse.Failure(
+                hub_offline=common_response_pb2.Error(),
+            )
+        )
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.execute = AsyncMock(return_value=failure_response)
+
+        with (
+            patch.object(endpoint_pb2_grpc, "DeviceCommandDeviceOffServiceStub", _StubFactory),
+            pytest.raises(DeviceCommandError, match="hub_offline"),
+        ):
+            await api.send_command(
+                DeviceCommand.off(
+                    hub_id="hub-1",
+                    device_id="dev-1",
+                    device_type="socket",
+                    channels=[1],
+                )
+            )
+
+    @pytest.mark.asyncio
+    async def test_brightness_sends_absolute_percentage(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_brightness import (
+            endpoint_pb2_grpc,
+            request_pb2,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        success_response = response_pb2.DeviceCommandBrightnessResponse(
+            success=common_response_pb2.Success()
+        )
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                async def _execute(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return success_response
+
+                self.execute = AsyncMock(side_effect=_execute)
+
+        with patch.object(endpoint_pb2_grpc, "DeviceCommandBrightnessServiceStub", _StubFactory):
+            await api.send_command(
+                DeviceCommand.set_brightness(
+                    hub_id="hub-1",
+                    device_id="dev-1",
+                    device_type="light_switch_dimmer",
+                    brightness=42,
+                    channels=[1],
+                )
+            )
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert request.brightness_in_percentage == 42
+        absolute = request_pb2.DeviceCommandBrightnessRequest.BRIGHTNESS_TYPE_ABSOLUTE
+        assert request.brightness_type == absolute
+        assert request.device_type.WhichOneof("type") == "light_switch_dimmer"
+
+    @pytest.mark.asyncio
+    async def test_brightness_without_value_raises(self) -> None:
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        api = self._make_api()
+        cmd = DeviceCommand(
+            action="brightness",
+            hub_id="h1",
+            device_id="d1",
+            device_type="light_switch_dimmer",
+            channels=[1],
+            brightness=None,
+        )
+        with pytest.raises(DeviceCommandError, match="brightness"):
             await api.send_command(cmd)
 
 


### PR DESCRIPTION
## Summary
- Replaces the long-standing `NotImplementedError` placeholder in `DevicesApi.send_command` with real gRPC dispatch:
  - `action="on"` → `DeviceCommandDeviceOnService.execute`
  - `action="off"` → `DeviceCommandDeviceOffService.execute`
  - `action="brightness"` → `DeviceCommandBrightnessService.execute` (absolute percentage, matches HA's slider semantics)
- New `_build_object_type` helper constructs the v2 `ObjectType` proto using `SetInParent()` on the matching empty marker oneof, so `Device.device_type` strings (`relay`, `wall_switch`, `socket_*`, `light_switch_*`…) round-trip from `parse_device` back into a valid command without a separate mapping table.
- Failure responses surface as `DeviceCommandError(<error_oneof_name>)`, which HA shows as a proper service-call error instead of the opaque `NotImplementedError` users saw before.

Until now, `AjaxSwitch` and the brightness path in `AjaxLight` were registering entities and exposing controls in the UI, but every press returned `Device commands not yet implemented (action=on, device=<id>)` — that's what @EpicManeuver hit on a Relay Jeweller in #104. The same gap broke every wall switch, socket, light switch, and the dimmer's brightness control.

Closes #104.

## Test plan
- [x] `make check` (lint, format, typecheck, tests, dead-code) inside the dev image — 1065 passed, coverage 83.10%
- [x] `make check` against the no-volume CI image — same result
- [x] Action dispatcher routes on/off/brightness to the right private method; unknown action raises `DeviceCommandError`
- [x] `_build_object_type` parametrized over the supported device-type strings; unknown types raise `DeviceCommandError`
- [x] Round-trip tests patch the lazy-imported gRPC stub class and assert the captured request shape (hub_id, device_id, `device_type.WhichOneof("type")`, channels, brightness percentage, `BRIGHTNESS_TYPE_ABSOLUTE`)
- [x] Failure path test for `device_off` with `hub_offline` raises `DeviceCommandError("off: hub_offline")`
- [ ] Smoke-test on real HA: confirm `switch.turn_on` on a Relay Jeweller / WallSwitch / Socket actually toggles the device, and that the dimmer brightness slider takes effect on a LightSwitch Dimmer