### PR TITLE
fix(system-health): expose last_update_success_time so the diagnostics row renders

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -6,11 +6,12 @@ import asyncio
 import contextlib
 import logging
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from custom_components.aegis_ajax.api.devices import DevicesApi
 from custom_components.aegis_ajax.api.hts.client import HtsClient
@@ -130,6 +131,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # `hts_chronic_failure` Repair surfaced after 30 min of
         # sustained reconnect failures.
         self._hts_first_failure_at: float | None = None
+        # Wall-clock timestamp of the last successful `_async_update_data`
+        # return, exposed as `last_update_success_time` for the System
+        # Health card. HA's `DataUpdateCoordinator` only tracks the
+        # success boolean, not when it last happened.
+        self._last_update_success_time: datetime | None = None
 
     @property
     def security_api(self) -> SecurityApi:
@@ -159,6 +165,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def is_hts_connected(self) -> bool:
         """True if HTS has an active connection feeding hub-network sensors."""
         return self._hts_client is not None and self._hts_task is not None
+
+    @property
+    def last_update_success_time(self) -> datetime | None:
+        """UTC datetime of the last successful poll, or None if never polled."""
+        return self._last_update_success_time
 
     async def _login_and_persist(self) -> None:
         """Login fresh and notify the on_session_persist callback.
@@ -328,6 +339,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self._start_device_streams()
                 # Start HTS for hub network data (non-blocking, graceful degradation)
                 await self._start_hts()
+                self._last_update_success_time = dt_util.utcnow()
                 return {"spaces": self.spaces, "devices": self.devices}
 
             # Skip device snapshot if all persistent streams are alive
@@ -346,6 +358,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self._hts_client is None:
                 await self._start_hts()
 
+            self._last_update_success_time = dt_util.utcnow()
             return {"spaces": self.spaces, "devices": self.devices}
         except ConfigEntryAuthFailed:
             raise

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -106,6 +106,15 @@ class TestCoordinatorInit:
         coordinator = _make_coordinator()
         assert coordinator.rooms == {}
 
+    def test_last_update_success_time_initially_none(self) -> None:
+        # Regression for #74 follow-up — the System Health card calls
+        # `coordinator.last_update_success_time` and HA renders the row as
+        # "error: unknown" if the attribute raises. The real
+        # `DataUpdateCoordinator` doesn't expose this attribute, so the
+        # subclass has to provide it — verify the default before any poll.
+        coordinator = _make_coordinator()
+        assert coordinator.last_update_success_time is None
+
 
 class TestRoomsRefresh:
     @pytest.mark.asyncio
@@ -199,6 +208,43 @@ class TestAsyncUpdateData:
         assert "devices" in result
         assert "s1" in result["spaces"]
         assert "d1" in result["devices"]
+
+    @pytest.mark.asyncio
+    async def test_update_data_sets_last_success_timestamp(self) -> None:
+        # Regression for #74 follow-up — the System Health card reads
+        # `last_update_success_time` to render the "last poll" age. Before
+        # this fix the attribute didn't exist and the entire row blew up
+        # with "error: unknown" instead of showing diagnostic data.
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+
+        space = _make_space("s1")
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[space])
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        assert coordinator.last_update_success_time is None
+        await coordinator._async_update_data()
+        first_ts = coordinator.last_update_success_time
+        assert first_ts is not None
+
+        await coordinator._async_update_data()
+        assert coordinator.last_update_success_time >= first_ts
+
+    @pytest.mark.asyncio
+    async def test_update_data_does_not_set_timestamp_on_failure(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(Exception):  # noqa: B017 - wrapped as UpdateFailed
+            await coordinator._async_update_data()
+        assert coordinator.last_update_success_time is None
 
     @pytest.mark.asyncio
     async def test_update_data_logs_in_when_not_authenticated(self) -> None:


### PR DESCRIPTION
## Summary
- The System Health card shipped in `1.2.4-beta.3` (#91) reads `coordinator.last_update_success_time` to render the "last poll" age. That attribute doesn't exist on HA's `DataUpdateCoordinator` base class — only the `last_update_success` boolean does — so every access raised `AttributeError`. HA's system_health framework catches the exception generically and renders the integration's row as `error: unknown` instead of the diagnostics fields.
- @Hansontech190 hit this on `1.2.4-beta.6` while triaging #74; the screenshot in [issue #74's latest comment](https://github.com/bvis/aegis-hass/issues/74#issuecomment-4395387560) shows the broken row.
- The previous unit tests "covered" this by setting `coord.last_update_success_time = ...` directly on a `MagicMock`, which silently created the attribute and let the assertion pass even though the real coordinator never had it. New regression tests in `test_coordinator.py` construct the real coordinator (no MagicMock) and assert: attribute exists; returns `None` pre-poll; advances after a successful poll; stays untouched on failure.

The fix is minimal — `AjaxCobrandedCoordinator` now exposes a `last_update_success_time` property backed by `dt_util.utcnow()` set at the two success-return sites in `_async_update_data`. Failure paths leave it untouched, so "last poll: 2h ago" really means 2h since the last successful poll, not since the last attempt.

Refs #74.

## Test plan
- [x] `make check` (lint, format, typecheck, tests, dead-code) inside the dev image — 1068 passed, coverage 83.13%
- [x] Regression test confirms `coordinator.last_update_success_time` exists on the real class (would have caught this bug)
- [ ] Smoke-test on real HA: open the System Health card and confirm the row renders the diagnostic fields (gRPC reachability, HTS streams, FCM clients, pushes received, last push, last poll) instead of `error: unknown`