### PR TITLE
fix(switch): parse channel state from LightHubDevice.spread_properties

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -315,6 +315,61 @@ class DevicesApi:
         return result
 
     @staticmethod
+    def _parse_spread_properties(hub_dev: Any) -> dict[str, Any]:  # noqa: ANN401
+        """Walk `LightHubDevice.spread_properties` for switch / dimmer state.
+
+        The on/off state of relays, sockets, and light switches lives in
+        the repeated `spread_properties` field — *not* in the
+        `LightDeviceStatus.statuses` oneof we already parse — and one
+        entry surfaces per physical channel. Multi-gang devices like
+        `light_switch_two_gang` therefore appear as 2 entries each
+        carrying a `LightSwitchChannel` with id 1 / 2.
+
+        Output keys mirror what `AjaxSwitch` / `AjaxLight` already read
+        (`switch_ch{N}`, `brightness_ch{N}`) so a Device parsed from a
+        snapshot now drives those entities directly. Without this, the
+        switch entity always read False regardless of the actual hub
+        state — the symptom @EpicManeuver reported in #104 for a
+        bistable Relay Jeweller.
+        """
+        result: dict[str, Any] = {}
+        spread = getattr(hub_dev, "spread_properties", None)
+        if not spread:
+            return result
+        for entry in spread:
+            which = entry.WhichOneof("properties") if hasattr(entry, "WhichOneof") else None
+            if which == "channel":
+                # RelayChannel — `channel_id` is a plain int (1..4),
+                # `is_channel_on` is a real bool.
+                ch = entry.channel
+                channel_id = int(ch.channel_id) if hasattr(ch, "channel_id") else 1
+                if channel_id <= 0:
+                    continue
+                result[f"switch_ch{channel_id}"] = bool(ch.is_channel_on)
+            elif which == "light_switch_channel":
+                # LightSwitchChannel — `id` and `state` are ChannelId and
+                # State enums (1=OFF, 2=ON). Optional `brightness.level`
+                # carries the dimmer percentage 0..100.
+                lsc = entry.light_switch_channel
+                channel_id = int(lsc.id) if hasattr(lsc, "id") else 1
+                if channel_id <= 0:
+                    continue
+                state_int = int(lsc.state) if hasattr(lsc, "state") else 0
+                result[f"switch_ch{channel_id}"] = state_int == 2  # STATE_ON
+                if lsc.HasField("brightness"):
+                    result[f"brightness_ch{channel_id}"] = int(lsc.brightness.level)
+            elif which == "socket_base_channel":
+                # SocketBaseChannel — same shape as light_switch_channel
+                # for our purposes.
+                sbc = entry.socket_base_channel
+                channel_id = int(sbc.id) if hasattr(sbc, "id") else 1
+                if channel_id <= 0:
+                    continue
+                state_int = int(sbc.state) if hasattr(sbc, "state") else 0
+                result[f"switch_ch{channel_id}"] = state_int == 2  # STATE_ON
+        return result
+
+    @staticmethod
     def parse_device(proto_light_device: Any) -> Device | None:  # noqa: ANN401
         device_kind = proto_light_device.WhichOneof("device")
         if device_kind != "hub_device":
@@ -327,6 +382,9 @@ class DevicesApi:
 
         device_type = common.object_type.WhichOneof("type") or "unknown"
 
+        statuses = DevicesApi._parse_statuses(profile.statuses)
+        statuses.update(DevicesApi._parse_spread_properties(hub_dev))
+
         return Device(
             id=profile.id,
             hub_id=common.hub_id,
@@ -337,7 +395,7 @@ class DevicesApi:
             state=DevicesApi._parse_device_state(profile.states),
             malfunctions=profile.malfunctions,
             bypassed=profile.bypassed,
-            statuses=DevicesApi._parse_statuses(profile.statuses),
+            statuses=statuses,
             battery=DevicesApi._parse_battery(profile.statuses),
         )
 

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -72,6 +72,133 @@ class TestParseDevice:
         assert result is None
 
 
+class TestSpreadPropertiesParser:
+    """Cover the `LightHubDevice.spread_properties` walk for switch state.
+
+    Built around real proto messages — `MagicMock` would silently
+    accept attribute reads and let the tests pass even if the parser
+    grabbed the wrong field name (the same MagicMock-hides-bug pattern
+    that masked the System Health regression in #106).
+    """
+
+    def test_relay_channel_on_populates_switch_ch1(self) -> None:
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            relay_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.channel.CopyFrom(
+            relay_channel_pb2.RelayChannel(
+                channel_id=1,
+                is_channel_on=True,
+                is_transitioning=False,
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"switch_ch1": True}
+
+    def test_relay_channel_off_populates_switch_ch1_false(self) -> None:
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            relay_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.channel.CopyFrom(relay_channel_pb2.RelayChannel(channel_id=1, is_channel_on=False))
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"switch_ch1": False}
+
+    def test_light_switch_two_gang_populates_both_channels(self) -> None:
+        # `light_switch_two_gang` exposes 2 channels via 2 entries in
+        # spread_properties — the only place per-channel state lives.
+        # Regression for the symptom @EpicManeuver hit in #104.
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            light_switch_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        e1 = hub_dev.spread_properties.add()
+        e1.light_switch_channel.CopyFrom(
+            light_switch_channel_pb2.LightSwitchChannel(
+                id=light_switch_channel_pb2.LightSwitchChannel.CHANNEL_ID_1,
+                state=light_switch_channel_pb2.LightSwitchChannel.STATE_ON,
+            )
+        )
+        e2 = hub_dev.spread_properties.add()
+        e2.light_switch_channel.CopyFrom(
+            light_switch_channel_pb2.LightSwitchChannel(
+                id=light_switch_channel_pb2.LightSwitchChannel.CHANNEL_ID_2,
+                state=light_switch_channel_pb2.LightSwitchChannel.STATE_OFF,
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"switch_ch1": True, "switch_ch2": False}
+
+    def test_light_switch_dimmer_brightness_extracted(self) -> None:
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            light_switch_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.light_switch_channel.CopyFrom(
+            light_switch_channel_pb2.LightSwitchChannel(
+                id=light_switch_channel_pb2.LightSwitchChannel.CHANNEL_ID_1,
+                state=light_switch_channel_pb2.LightSwitchChannel.STATE_ON,
+                brightness=light_switch_channel_pb2.LightSwitchChannel.Brightness(level=42),
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"switch_ch1": True, "brightness_ch1": 42}
+
+    def test_socket_base_channel_on(self) -> None:
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            socket_base_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.socket_base_channel.CopyFrom(
+            socket_base_channel_pb2.SocketBaseChannel(
+                id=socket_base_channel_pb2.SocketBaseChannel.CHANNEL_ID_1,
+                state=socket_base_channel_pb2.SocketBaseChannel.STATE_ON,
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"switch_ch1": True}
+
+    def test_unrelated_spread_properties_ignored(self) -> None:
+        # photo_on_demand, billing_company, fire_zones, etc. share the
+        # same oneof but aren't channel-bearing — the parser should leave
+        # them alone instead of throwing.
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.photo_on_demand.SetInParent()
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {}
+
+    def test_no_spread_properties_returns_empty(self) -> None:
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {}
+
+
 class TestDeviceStateParser:
     def test_empty_states_returns_online(self) -> None:
         result = DevicesApi._parse_device_state([])


### PR DESCRIPTION
## Summary
- The on/off state of relays, sockets and light switches lives in `LightHubDevice.spread_properties` (repeated, one entry per channel) — the parser only walked `LightDeviceStatus.statuses`, so `device.statuses["switch_chN"]` was never populated and `AjaxSwitch.is_on` always read `False` regardless of the actual hub state. Same path covers `LightSwitchChannel.brightness.level` for the dimmer.
- Symptom @EpicManeuver hit in #104: a relay in **Pulse** mode looked correct because the hub auto-resets to off after the pulse (matching our permanently-False reading), but in **Bistable** mode the bug was visible — toggle worked at the hub yet HA snapped back to off, and toggling from off-displayed-but-on-real did nothing visible.
- New `_parse_spread_properties(hub_dev)` translates each entry to the existing `switch_chN` / `brightness_chN` keys: `channel` → `RelayChannel`, `light_switch_channel` → `LightSwitchChannel` (multi-gang devices arrive as multiple entries — both populate), `socket_base_channel` → `SocketBaseChannel`.
- Real-time updates already flow through `parse_device` on each `snapshot_update`, so a hub-side state change propagates to HA in the same hop.

Tests use real proto messages on purpose — `MagicMock` would silently accept any attribute access and mask field-name drift. Same MagicMock-hides-bug class that masked the System Health regression in #106.

Refs #104.

## Test plan
- [x] `make check` (lint, format, typecheck, tests, dead-code) inside the dev image — 1075 passed, coverage 83.19%
- [x] 7 new parametric tests over `_parse_spread_properties` cover relay on/off, multi-gang light switch, dimmer brightness, socket base channel, unrelated `properties` oneof cases ignored, empty `spread_properties`
- [ ] Smoke-test on real HA: confirm a Bistable Relay Jeweller's `switch.*` state in HA matches the physical state after toggling from the Ajax app, and the LightSwitch Dimmer's brightness slider reflects the actual level