### PR TITLE
fix(system-health): derive 'Reach Ajax cloud' from poll freshness

### DIFF
--- a/custom_components/aegis_ajax/system_health.py
+++ b/custom_components/aegis_ajax/system_health.py
@@ -13,13 +13,19 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components import system_health
 from homeassistant.core import callback
 
-from custom_components.aegis_ajax.const import DOMAIN, GRPC_HOST
+from custom_components.aegis_ajax.const import DOMAIN
 
 if TYPE_CHECKING:
+    from homeassistant.components import system_health
     from homeassistant.core import HomeAssistant
+
+# Maximum age (seconds) a successful poll can have before the card
+# downgrades reachability to "unreachable". Defaults to 10 min, well
+# above the 5-min default poll interval but tight enough that a
+# genuine cloud outage shows up before users notice missing entities.
+_REACHABILITY_STALE_AFTER = 600.0
 
 
 @callback
@@ -34,11 +40,9 @@ def async_register(
 async def _system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Build the System Health dict for the integration's row."""
     entries = hass.config_entries.async_entries(DOMAIN)
-    info: dict[str, Any] = {
-        "can_reach_server": system_health.async_check_can_reach_url(hass, f"https://{GRPC_HOST}"),
-        "configured_accounts": len(entries),
-    }
+    info: dict[str, Any] = {"configured_accounts": len(entries)}
     if not entries:
+        info["can_reach_server"] = "no accounts configured"
         return info
 
     spaces_total = 0
@@ -74,6 +78,21 @@ async def _system_health_info(hass: HomeAssistant) -> dict[str, Any]:
             age = now_mono - listener.last_push_at
             if last_push_age_seconds is None or age < last_push_age_seconds:
                 last_push_age_seconds = age
+
+    # Derive reachability from the actual gRPC poll path we already use,
+    # not from a separate HTTPS HEAD probe. The gRPC host doesn't
+    # respond to plain HTTPS GET / HEAD, so `async_check_can_reach_url`
+    # always returned "unreachable" even when polling worked perfectly
+    # (surfaced once #106 made the rest of the card render). If any
+    # account polled successfully in the last 10 min the cloud *is*
+    # reachable from the integration's perspective, regardless of what
+    # an external HTTP probe would say.
+    if last_update_age_seconds is None:
+        info["can_reach_server"] = "never polled"
+    elif last_update_age_seconds <= _REACHABILITY_STALE_AFTER:
+        info["can_reach_server"] = "reachable"
+    else:
+        info["can_reach_server"] = "unreachable"
 
     info["spaces"] = spaces_total
     info["hts_connected"] = f"{hts_connected}/{len(entries)}"

--- a/tests/unit/test_system_health.py
+++ b/tests/unit/test_system_health.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -47,17 +47,12 @@ class TestSystemHealthInfo:
         return hass
 
     @pytest.mark.asyncio
-    async def test_no_entries_only_returns_reach_check(self) -> None:
-        """With no configured entries, only the gRPC reach probe + count are returned."""
+    async def test_no_entries_marks_no_accounts(self) -> None:
+        """With no configured entries, reachability falls back to a sentinel."""
         hass = self._make_hass([])
-        with patch(
-            "custom_components.aegis_ajax.system_health.system_health.async_check_can_reach_url",
-            new=MagicMock(return_value="reach-coro"),
-        ):
-            info = await _system_health_info(hass)
-        assert info["can_reach_server"] == "reach-coro"
+        info = await _system_health_info(hass)
+        assert info["can_reach_server"] == "no accounts configured"
         assert info["configured_accounts"] == 0
-        # No per-entry metrics should be set when there are no entries
         assert "spaces" not in info
 
     @pytest.mark.asyncio
@@ -87,11 +82,7 @@ class TestSystemHealthInfo:
         entry_b = MagicMock(runtime_data=coord_b)
         hass = self._make_hass([entry_a, entry_b])
 
-        with patch(
-            "custom_components.aegis_ajax.system_health.system_health.async_check_can_reach_url",
-            new=MagicMock(return_value="reach-coro"),
-        ):
-            info = await _system_health_info(hass)
+        info = await _system_health_info(hass)
 
         assert info["configured_accounts"] == 2
         assert info["spaces"] == 3
@@ -102,20 +93,53 @@ class TestSystemHealthInfo:
         assert info["last_push"] == "never"
         # last_poll: only coord_a has a real timestamp, ~30s old
         assert info["last_poll"].endswith("s ago")
+        # Reachability derived from poll freshness: any account polled
+        # within the staleness window means we're reachable.
+        assert info["can_reach_server"] == "reachable"
+
+    @pytest.mark.asyncio
+    async def test_can_reach_server_unreachable_when_polls_stale(self) -> None:
+        """A stale `last_update_success_time` (>10 min) flips the reach line."""
+        coord = MagicMock()
+        coord.spaces = {"s1": MagicMock()}
+        coord.is_hts_connected = False
+        coord.last_update_success_time = datetime.now(UTC) - timedelta(minutes=30)
+        listener = MagicMock()
+        listener.is_fcm_connected = False
+        listener.pushes_received = 0
+        listener.last_push_at = None
+        coord.notification_listener = listener
+
+        hass = self._make_hass([MagicMock(runtime_data=coord)])
+        info = await _system_health_info(hass)
+        assert info["can_reach_server"] == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_can_reach_server_never_polled(self) -> None:
+        """A fresh-install state with `last_update_success_time=None` says so explicitly."""
+        coord = MagicMock()
+        coord.spaces = {}
+        coord.is_hts_connected = False
+        coord.last_update_success_time = None
+        listener = MagicMock()
+        listener.is_fcm_connected = False
+        listener.pushes_received = 0
+        listener.last_push_at = None
+        coord.notification_listener = listener
+
+        hass = self._make_hass([MagicMock(runtime_data=coord)])
+        info = await _system_health_info(hass)
+        assert info["can_reach_server"] == "never polled"
 
     @pytest.mark.asyncio
     async def test_skips_entries_without_runtime_data(self) -> None:
         """A still-loading entry (no runtime_data) must not crash the card."""
         entry = MagicMock(runtime_data=None)
         hass = self._make_hass([entry])
-
-        with patch(
-            "custom_components.aegis_ajax.system_health.system_health.async_check_can_reach_url",
-            new=MagicMock(return_value="reach-coro"),
-        ):
-            info = await _system_health_info(hass)
+        info = await _system_health_info(hass)
 
         assert info["configured_accounts"] == 1
         assert info["spaces"] == 0
         assert info["hts_connected"] == "0/1"
         assert info["fcm_connected"] == "0/1"
+        assert info["can_reach_server"] == "never polled"


### PR DESCRIPTION
## Summary
- The card's reachability row used `system_health.async_check_can_reach_url` to probe the gRPC host with plain HTTPS HEAD/GET — but the Ajax gRPC endpoint doesn't respond to plain HTTPS, so the probe always returned **unreachable** even when the integration was polling the same host successfully through the gRPC channel.
- The bug only became visible after #106 made the rest of the card render. @Hansontech190's screenshot in [#74](https://github.com/bvis/aegis-hass/issues/74#issuecomment-4395387560) shows `Reach Ajax cloud (gRPC host): unreachable` (red) directly above `Last successful poll: 3m ago` — clearly contradictory.
- Fix removes the external HTTP probe and derives the value from data the card already gathers. If any account polled successfully within `600 s` (well above the 5-min default poll interval, tight enough that a real cloud outage shows up before users notice missing entities), the cloud *is* reachable from the integration's perspective:
  - `reachable` — at least one account polled within the window
  - `unreachable` — every account's last successful poll is older
  - `never polled` — fresh setup, no cycle completed yet
  - `no accounts configured` — empty install

Refs #74, #106.

## Test plan
- [x] `make check` (lint, format, typecheck, tests, dead-code) inside the dev image — 1070 passed, coverage 83.15%
- [x] Three new test cases cover the fresh-install / stale-poll / never-polled paths; existing aggregate test asserts the new `reachable` value
- [ ] Smoke-test on real HA: confirm the card now shows `Reach Ajax cloud: reachable` on a healthy install (matching `Last successful poll: Xm ago`)