### PR TITLE
perf(startup): keep first refresh non-blocking by deferring HTS + FCM

### DIFF
--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -243,16 +243,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
-    # Start FCM push notifications if configured (credentials live in data since v2)
+    # Start FCM push notifications if configured (credentials live in data since v2).
+    # Run as a background task — FCM registration + push-client start is a
+    # multi-step network round-trip (Firebase + Ajax push registration) that
+    # would otherwise block setup for several seconds, extending HA's boot
+    # phase past the "integration taking too long" threshold (#112). Push
+    # delivery already tolerates a brief gap between setup and first push.
     def _get_fcm(key: str) -> str:
         return str(entry.data.get(key, entry.options.get(key, "")))
 
-    await coordinator.async_start_push_notifications(
-        fcm_project_id=_get_fcm("fcm_project_id"),
-        fcm_app_id=_get_fcm("fcm_app_id"),
-        fcm_api_key=_get_fcm("fcm_api_key"),
-        fcm_sender_id=_get_fcm("fcm_sender_id"),
-        entry_id=entry.entry_id,
+    entry.async_create_background_task(
+        hass,
+        coordinator.async_start_push_notifications(
+            fcm_project_id=_get_fcm("fcm_project_id"),
+            fcm_app_id=_get_fcm("fcm_app_id"),
+            fcm_api_key=_get_fcm("fcm_api_key"),
+            fcm_sender_id=_get_fcm("fcm_sender_id"),
+            entry_id=entry.entry_id,
+        ),
+        name=f"aegis_ajax_fcm_start_{entry.entry_id}",
     )
 
     # Schedule photo cleanup

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -366,7 +366,22 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed("Error fetching Ajax data") from err
 
     async def _start_hts(self) -> None:
-        """Start HTS connection for hub network data (graceful degradation)."""
+        """Start HTS in the background — never block the caller.
+
+        The HTS handshake is a TCP connect plus a custom application
+        handshake that takes a few seconds in the happy path and up to
+        20 s with the auth-handshake timeout from #74. Awaiting it
+        directly inside `_async_update_data` extended the integration's
+        first refresh past HA's "integration taking too long" boot
+        threshold (#112). Wrap the connect-then-listen lifecycle in a
+        single background task so the caller returns immediately and
+        the listener establishes (or fails and self-reconnects) without
+        blocking startup. Hub-network sensors stay `unavailable` for the
+        couple of seconds it takes to connect, then become available the
+        moment the connection succeeds.
+        """
+        if self._hts_task is not None and not self._hts_task.done():
+            return
         try:
             session = self._client.session
             token_hex = session.session_token
@@ -386,16 +401,24 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 device_id=session.device_id,
                 app_label=session.app_label,
             )
+        except Exception:
+            _LOGGER.debug("HTS pre-connect setup failed", exc_info=True)
+            self._hts_client = None
+            return
+        self._hts_task = asyncio.create_task(self._run_hts_lifecycle())
+        self._hts_task.add_done_callback(self._handle_hts_task_done)
+
+    async def _run_hts_lifecycle(self) -> None:
+        """Connect, log success, then drive the listen loop until disconnect."""
+        if self._hts_client is None:
+            return
+        try:
             result = await self._hts_client.connect()
             _LOGGER.info("HTS connected, %d hub(s)", len(result.hubs))
             self._clear_hts_chronic_failure()
-            self._hts_task = asyncio.create_task(
-                self._hts_client.listen(on_state_update=self._on_hts_update)
-            )
-            self._hts_task.add_done_callback(self._handle_hts_task_done)
+            await self._hts_client.listen(on_state_update=self._on_hts_update)
         except Exception:
             _LOGGER.debug("HTS connection failed (network sensors unavailable)", exc_info=True)
-            self._handle_hts_disconnect(reconnect=False)
             self._hts_client = None
 
     def _on_hts_update(self, hub_id: str, state: HubNetworkState) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -920,6 +921,53 @@ class TestStreamHandlers:
 
         assert coordinator.hub_network == {}
         coordinator.async_set_updated_data.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_start_hts_does_not_block_on_connect(self) -> None:
+        # Regression for #112 — `_start_hts()` used to `await connect()`
+        # before returning, extending HA's first-refresh past the boot
+        # threshold. The refactored version creates a background task
+        # for connect+listen and returns immediately.
+        coordinator = self._make_coordinator_with_stream()
+        coordinator._client.session.session_token = "abcdef"
+        coordinator._client.session.user_hex_id = "00112233"
+        coordinator._client.session.device_id = "device-1"
+        coordinator._client.session.app_label = "Ajax"
+
+        slow_connect_started = asyncio.Event()
+        slow_connect_release = asyncio.Event()
+
+        async def _slow_connect(self: object) -> object:
+            slow_connect_started.set()
+            await slow_connect_release.wait()
+            return MagicMock(hubs=[])
+
+        from custom_components.aegis_ajax.api.hts.client import HtsClient
+
+        with (
+            patch.object(HtsClient, "_ssl_ctx", create=True, new=object()),
+            patch.object(HtsClient, "connect", new=_slow_connect),
+            patch.object(HtsClient, "listen", new=AsyncMock()),
+        ):
+            await asyncio.wait_for(coordinator._start_hts(), timeout=1.0)
+            assert coordinator._hts_task is not None
+            await asyncio.wait_for(slow_connect_started.wait(), timeout=1.0)
+            slow_connect_release.set()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(coordinator._hts_task, timeout=2.0)
+
+    @pytest.mark.asyncio
+    async def test_start_hts_is_idempotent_when_task_already_running(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator._client.session.session_token = "abcdef"
+
+        existing_task = MagicMock(spec=asyncio.Task)
+        existing_task.done.return_value = False
+        coordinator._hts_task = existing_task
+
+        await coordinator._start_hts()
+
+        assert coordinator._hts_task is existing_task
 
     def test_handle_hts_task_done_clears_state(self) -> None:
         coordinator = self._make_coordinator_with_stream()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -9,6 +9,46 @@ import pytest
 
 class TestAsyncSetupEntry:
     @pytest.mark.asyncio
+    async def test_setup_entry_schedules_fcm_as_background_task(self) -> None:
+        # Regression for #112 — FCM startup must not block setup. The
+        # registration round-trip (Firebase + Ajax push token) takes
+        # several seconds; awaiting it here used to push HA past the
+        # "integration taking too long" boot threshold. Now scheduled
+        # via `entry.async_create_background_task` so setup returns
+        # immediately and FCM connects in the background.
+        from custom_components.aegis_ajax import async_setup_entry
+
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+        entry = MagicMock()
+        entry.entry_id = "entry-bg"
+        entry.data = {"email": "x@y", "password_hash": "h", "spaces": ["s1"]}
+        entry.options = {}
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.session = MagicMock()
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_start_push_notifications = MagicMock()  # not awaited directly
+
+        with (
+            patch("custom_components.aegis_ajax.AjaxGrpcClient", return_value=mock_client),
+            patch(
+                "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
+                return_value=mock_coordinator,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        # FCM startup should be scheduled, not awaited synchronously.
+        mock_coordinator.async_start_push_notifications.assert_called_once()
+        entry.async_create_background_task.assert_called_once()
+        kwargs = entry.async_create_background_task.call_args.kwargs
+        assert kwargs.get("name", "").startswith("aegis_ajax_fcm_start_")
+
+    @pytest.mark.asyncio
     async def test_setup_entry_creates_coordinator(self) -> None:
         from custom_components.aegis_ajax import async_setup_entry
 


### PR DESCRIPTION
## Summary
- The integration's first `_async_update_data` cycle was awaiting two multi-second listener startups inline (HTS handshake + FCM register/start), pushing HA's setup phase past the *"Something is blocking Home Assistant from wrapping up the start up phase"* threshold logged in #112 (~70 s end-to-end on a real install with FCM + HTS configured).
- Two changes that mirror the standard HA-premium pattern of "minimum viable first refresh, long-lived listeners on background tasks":
  - **HTS**: `_start_hts()` no longer awaits `connect()` before returning. Connect-then-listen lifecycle moves to a single background task (`_run_hts_lifecycle()`); pre-task setup keeps its try/except so SSL / construction errors don't corrupt the task pointer. Hub-network sensors stay `unavailable` for the few seconds the handshake takes, then become available the moment it succeeds. Self-reconnect on failure is unchanged.
  - **FCM**: `async_start_push_notifications()` is no longer awaited in `async_setup_entry`. Now scheduled via `entry.async_create_background_task` so the FCM round-trip (Firebase register → Ajax push token register → start `FcmPushClient`) doesn't block setup. Push delivery already tolerates a brief gap between setup and first push.

Closes #112.

## Test plan
- [x] `make check` (lint, format, typecheck, tests, dead-code) inside the dev image — 1080 passed, coverage 83.31%
- [x] `test_start_hts_does_not_block_on_connect` patches `HtsClient.connect` with a coroutine that suspends on an `Event.wait()` and verifies `_start_hts()` itself completes without that event being set — proves the connect runs in the task, not on the caller path
- [x] `test_setup_entry_schedules_fcm_as_background_task` asserts the FCM startup is dispatched through `entry.async_create_background_task` with the expected name prefix
- [ ] Smoke-test on real HA: confirm the *Something is blocking…* warning no longer fires for `aegis_ajax` after a restart, and that HTS + FCM still come up shortly after