### PR TITLE
perf(startup): warm-start devices from persisted snapshot cache

### DIFF
--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -239,6 +239,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
         space_ids=entry.data.get("spaces", []),
         poll_interval=entry.options.get("poll_interval", DEFAULT_POLL_INTERVAL),
         on_session_persist=_persist_session,
+        entry_id=entry.entry_id,
     )
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -566,9 +566,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         # Refresh the persisted cache so the next restart can warm-start
         # from real data instead of the previous boot's snapshot (#114).
-        # Sync callback can't await — schedule and forget.
+        # Debounced — bursts of stream snapshots coalesce into one write.
         if self._devices_cache is not None:
-            self.hass.async_create_task(self._devices_cache.async_save(self.devices))
+            self._devices_cache.async_schedule_save(self.devices)
 
     def _handle_status_update(self, device_id: str, status_name: str, data: dict[str, Any]) -> None:
         """Handle real-time status update from the persistent stream.

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -28,6 +28,7 @@ from custom_components.aegis_ajax.const import (
     MIN_POLL_INTERVAL,
     ConnectionStatus,
 )
+from custom_components.aegis_ajax.device_cache import DevicesCache
 from custom_components.aegis_ajax.repairs import (
     async_clear_hts_chronic_failure,
     async_clear_hub_offline,
@@ -88,6 +89,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         space_ids: list[str],
         poll_interval: int = DEFAULT_POLL_INTERVAL,
         on_session_persist: Callable[[str, str], None] | None = None,
+        entry_id: str = "",
     ) -> None:
         poll_interval = max(MIN_POLL_INTERVAL, min(MAX_POLL_INTERVAL, poll_interval))
         super().__init__(
@@ -136,6 +138,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Health card. HA's `DataUpdateCoordinator` only tracks the
         # success boolean, not when it last happened.
         self._last_update_success_time: datetime | None = None
+        # Persistent device-snapshot cache (#114) — restored on first
+        # refresh so platform setup doesn't have to await the gRPC
+        # `get_devices_snapshot` call. Tests construct the coordinator
+        # without an entry_id; in that mode the cache is disabled.
+        self._devices_cache: DevicesCache | None = (
+            DevicesCache(hass, entry_id) if entry_id else None
+        )
 
     @property
     def security_api(self) -> SecurityApi:
@@ -327,14 +336,35 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Start persistent device streams on first update (once only)
             if not self._streams_started:
                 self._streams_started = True
-                # Fetch initial device snapshot synchronously so entities
-                # are created with real data (avoids unavailable on reload)
-                initial_devices: dict[str, Device] = {}
-                for space_id in self.spaces:
-                    space_devices = await self._devices_api.get_devices_snapshot(space_id)
-                    for device in space_devices:
-                        initial_devices[device.id] = device
-                self.devices = initial_devices
+                # Try to skip the synchronous `get_devices_snapshot` call
+                # by warming `self.devices` from the persisted cache (#114).
+                # Streams (started below) deliver a fresh snapshot via
+                # `_handle_devices_snapshot` within seconds, replacing the
+                # cached values. On a fresh install or after a corrupt
+                # cache, fall back to the heavy path so platforms still
+                # see real data when they create entities.
+                cached_devices: dict[str, Device] | None = None
+                if self._devices_cache is not None:
+                    try:
+                        cached_devices = await self._devices_cache.async_load()
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.debug("Failed to load devices cache", exc_info=True)
+                if cached_devices:
+                    self.devices = cached_devices
+                else:
+                    # Fetch initial device snapshot synchronously so entities
+                    # are created with real data (avoids unavailable on reload)
+                    initial_devices: dict[str, Device] = {}
+                    for space_id in self.spaces:
+                        space_devices = await self._devices_api.get_devices_snapshot(space_id)
+                        for device in space_devices:
+                            initial_devices[device.id] = device
+                    self.devices = initial_devices
+                    if self._devices_cache is not None and self.devices:
+                        try:
+                            await self._devices_cache.async_save(self.devices)
+                        except Exception:  # noqa: BLE001
+                            _LOGGER.debug("Failed to persist devices cache", exc_info=True)
                 # Then start persistent streams for real-time updates
                 await self._start_device_streams()
                 # Start HTS for hub network data (non-blocking, graceful degradation)
@@ -534,6 +564,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         for device in devices:
             self.devices[device.id] = device
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+        # Refresh the persisted cache so the next restart can warm-start
+        # from real data instead of the previous boot's snapshot (#114).
+        # Sync callback can't await — schedule and forget.
+        if self._devices_cache is not None:
+            self.hass.async_create_task(self._devices_cache.async_save(self.devices))
 
     def _handle_status_update(self, device_id: str, status_name: str, data: dict[str, Any]) -> None:
         """Handle real-time status update from the persistent stream.

--- a/custom_components/aegis_ajax/device_cache.py
+++ b/custom_components/aegis_ajax/device_cache.py
@@ -29,11 +29,15 @@ def _storage_key(entry_id: str) -> str:
     return f"{DOMAIN}_devices_{entry_id}"
 
 
+_SAVE_DEBOUNCE_SECONDS = 30
+
+
 class DevicesCache:
     """Wraps a per-entry Store with serialization for `Device`."""
 
     def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
         self._store: Store[dict[str, Any]] = Store(hass, _STORAGE_VERSION, _storage_key(entry_id))
+        self._pending: dict[str, Device] = {}
 
     async def async_load(self) -> dict[str, Device] | None:
         raw = await self._store.async_load()
@@ -46,8 +50,19 @@ class DevicesCache:
             return None
 
     async def async_save(self, devices: dict[str, Device]) -> None:
-        payload = {"devices": [_serialize_device(d) for d in devices.values()]}
-        await self._store.async_save(payload)
+        await self._store.async_save(_build_payload(devices))
+
+    def async_schedule_save(self, devices: dict[str, Device]) -> None:
+        """Debounced save — coalesces bursts of stream snapshots into one
+        disk write every ~30s. Use this on hot paths; `async_save` for
+        the boot path where we want the first snapshot persisted now.
+        """
+        self._pending = devices
+        self._store.async_delay_save(lambda: _build_payload(self._pending), _SAVE_DEBOUNCE_SECONDS)
+
+
+def _build_payload(devices: dict[str, Device]) -> dict[str, Any]:
+    return {"devices": [_serialize_device(d) for d in devices.values()]}
 
 
 def _serialize_device(d: Device) -> dict[str, Any]:

--- a/custom_components/aegis_ajax/device_cache.py
+++ b/custom_components/aegis_ajax/device_cache.py
@@ -1,0 +1,101 @@
+"""Persistent cache of last-known device snapshot.
+
+Restored on coordinator startup so the first poll cycle does not have
+to await the gRPC `get_devices_snapshot` call before
+`async_forward_entry_setups` runs. Cuts the integration's contribution
+to HA's boot phase below the *"integration taking too long"* threshold
+on multi-account installs (see #114). The cache is best-effort: any
+deserialization failure falls back to "no cache" so the heavy path runs
+exactly as it does today.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.helpers.storage import Store
+
+from custom_components.aegis_ajax.api.models import BatteryInfo, Device
+from custom_components.aegis_ajax.const import DOMAIN, DeviceState
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_STORAGE_VERSION = 1
+
+
+def _storage_key(entry_id: str) -> str:
+    return f"{DOMAIN}_devices_{entry_id}"
+
+
+class DevicesCache:
+    """Wraps a per-entry Store with serialization for `Device`."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        self._store: Store[dict[str, Any]] = Store(hass, _STORAGE_VERSION, _storage_key(entry_id))
+
+    async def async_load(self) -> dict[str, Device] | None:
+        raw = await self._store.async_load()
+        if not raw:
+            return None
+        try:
+            entries = raw["devices"]
+            return {str(d["id"]): _deserialize_device(d) for d in entries}
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    async def async_save(self, devices: dict[str, Device]) -> None:
+        payload = {"devices": [_serialize_device(d) for d in devices.values()]}
+        await self._store.async_save(payload)
+
+
+def _serialize_device(d: Device) -> dict[str, Any]:
+    return {
+        "id": d.id,
+        "hub_id": d.hub_id,
+        "name": d.name,
+        "device_type": d.device_type,
+        "room_id": d.room_id,
+        "group_id": d.group_id,
+        "state": str(d.state),
+        "malfunctions": d.malfunctions,
+        "bypassed": d.bypassed,
+        "statuses": _serialize_statuses(d.statuses),
+        "battery": (
+            None if d.battery is None else {"level": d.battery.level, "is_low": d.battery.is_low}
+        ),
+    }
+
+
+def _deserialize_device(data: dict[str, Any]) -> Device:
+    battery = data.get("battery")
+    return Device(
+        id=str(data["id"]),
+        hub_id=str(data["hub_id"]),
+        name=str(data["name"]),
+        device_type=str(data["device_type"]),
+        room_id=data.get("room_id"),
+        group_id=data.get("group_id"),
+        state=DeviceState(str(data["state"])),
+        malfunctions=int(data.get("malfunctions", 0)),
+        bypassed=bool(data.get("bypassed", False)),
+        statuses=dict(data.get("statuses") or {}),
+        battery=(
+            None
+            if battery is None
+            else BatteryInfo(level=int(battery["level"]), is_low=bool(battery["is_low"]))
+        ),
+    )
+
+
+def _serialize_statuses(statuses: dict[str, Any]) -> dict[str, Any]:
+    """Drop non-JSON values (e.g. datetimes) — next snapshot repopulates them."""
+    safe: dict[str, Any] = {}
+    for key, value in statuses.items():
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError):
+            continue
+        safe[key] = value
+    return safe

--- a/docs/TODO-improvements.md
+++ b/docs/TODO-improvements.md
@@ -20,21 +20,27 @@ Prioritized list of remaining improvements based on HA platinum integration patt
 - ~~HA Repairs~~ (v1.2.4) — `hub_offline_24h`, `hts_chronic_failure`, `fcm_credentials_invalid` (with guided fix flow), `grpcio_version_mismatch` Repair cards (#89)
 - ~~System Health card~~ (v1.2.4) — gRPC reachability, HTS/FCM ratios, pushes received, last push / last poll ages under Settings → System (#91)
 - ~~DHCP discovery~~ (v1.2.4) — Ajax hubs on the LAN appear as Discovered cards via OUI `9C:75:6E` (#92)
-- ~~Tilt + Steam binary sensors~~ (v1.2.4) — `tilt` on DoorProtect Plus family (accelerometer), `steam` on FireProtect 2 smoke-chamber variants (steam-vs-smoke discriminator)
-- ~~Lock platform~~ (v1.2.5) — `lock.py` with `AjaxLock` for `smart_lock` / `smart_lock_yale` device types. State (locked / unlocked / unlatched) parsed from the `smart_lock` LockStatus oneof; `lock` / `unlock` / HA's `lock.open` (= unlatch) wired to `SwitchSmartLockService`
+- ~~Tilt + Steam binary sensors~~ (v1.2.4) — `tilt` on DoorProtect Plus family (accelerometer), `steam` on FireProtect 2 smoke-chamber variants (steam-vs-smoke discriminator) (#101)
+- ~~Lock platform~~ (v1.2.4) — `lock.py` with `AjaxLock` for `smart_lock` / `smart_lock_yale` device types. State (locked / unlocked / unlatched) parsed from the `smart_lock` LockStatus oneof; `lock` / `unlock` / HA's `lock.open` (= unlatch) wired to `SwitchSmartLockService` (#102)
+- ~~Device commands wired up~~ (v1.2.4) — `DevicesApi.send_command` no longer raises `NotImplementedError`; relays / sockets / wall switches act on the hub via `DeviceCommandDeviceOn` / `DeviceCommandDeviceOff`, dimmer brightness via `DeviceCommandBrightness`. Was a placeholder since v1.0. (#105)
+- ~~Switch state read-back~~ (v1.2.4) — `parse_device` now walks `LightHubDevice.spread_properties` for `RelayChannel` / `LightSwitchChannel` / `SocketBaseChannel` so `AjaxSwitch.is_on` reflects the actual hub state. Fixes the bistable Relay Jeweller symptom where the entity always read `False`. (#109)
+- ~~System Health diagnostics~~ (v1.2.4) — `last_update_success_time` exposed on the coordinator so the card stops rendering as `error: unknown` (#106); `Reach Ajax cloud (gRPC host)` derived from poll freshness instead of an HTTPS HEAD probe that always returned `unreachable` (#110)
+- ~~Non-blocking startup~~ (v1.2.4) — HTS connect-then-listen and FCM startup move to background tasks; first refresh no longer awaits multi-second listener startups so the integration drops out of HA's *"integration taking too long"* warning much sooner (#113, closes #112)
 
 ---
 
 ## Priority 1 — High impact, moderate effort
 
-### 1.1 Valve Platform (`valve.py`) — blocked
+### 1.1 Valve Platform (`valve.py`) — partially unblocked
 **Why:** WaterStop devices currently surface as a no-op (empty binary-sensor list). Native `valve` entity would let automations open/close the water shut-off valve.
 
-**Blockers — both need investigating in a real WaterStop install before this can ship:**
-1. The actual valve open/closed state lives in `LightHubDevice.properties.water_stop_channel.state` (an enum: STATE_OFF / STATE_ON), which is *not* part of the `LightDeviceStatus.statuses` oneof we currently parse. Surfacing it requires extending `parse_device` to walk the `properties` oneof per device type — a small architectural change touching every property-bearing entity.
-2. No `SwitchWaterStop`-style command service exists in the v3 protos we have. Without a way to actually toggle the valve, a `valve` entity would be read-only and provide little value over the existing `water_stop_valve_stuck` malfunction signal. Need to capture the wire calls the official mobile app makes when toggling a WaterStop to identify the right service.
+**Status after #109 (1.2.4-beta.9):** the `spread_properties` walker added for switch state already covers `WaterStopChannel.state` mechanically — extending it to populate a `valve_chN` key would be a one-liner. The remaining blocker is the **command path**: there is no `SwitchWaterStopService` in the v3 protos we have, so the entity would be read-only. Useful (status visibility + transition flag), but not the full valve UX.
 
-**Effort:** Unknown until both blockers are answered. The `water_stop_valve_stuck` Simple flag could be exposed as a `PROBLEM` binary sensor in the meantime — much smaller change, doesn't pre-empt the eventual `valve` design.
+**Suggested incremental ship:**
+1. Read-only `valve` entity — exposes `state` (STATE_OFF / STATE_ON), `is_transitioning`, and the `MALFUNCTION_IS_STUCK` flag as the existing `water_stop_valve_stuck` binary sensor. Lets automations *react* to the valve being closed even if HA can't toggle it.
+2. Wait for someone with a WaterStop to capture the wire calls the official mobile app makes when toggling, then add the command path.
+
+**Effort:** Low (1-2 h) for read-only ship; unknown for full bidirectional.
 
 ---
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1170,6 +1170,7 @@ class TestCachedSnapshotStart:
         cache_mock = MagicMock()
         cache_mock.async_load = AsyncMock(return_value=cached)
         cache_mock.async_save = AsyncMock()
+        cache_mock.async_schedule_save = MagicMock()
         coordinator._devices_cache = cache_mock
         coordinator._client.session.is_authenticated = True
         coordinator._spaces_api = MagicMock()
@@ -1217,7 +1218,8 @@ class TestCachedSnapshotStart:
     async def test_stream_snapshot_callback_persists_cache(self) -> None:
         # When the device stream delivers its initial snapshot via
         # `_handle_devices_snapshot`, that fresh data should overwrite the
-        # warm-started cache so the next boot reflects reality.
+        # warm-started cache so the next boot reflects reality. The save
+        # is debounced via `async_schedule_save` to coalesce bursts.
         coordinator = self._coordinator_with_cache(cached={"d1": _make_device("d1")})
         coordinator.async_set_updated_data = MagicMock()
 
@@ -1225,8 +1227,7 @@ class TestCachedSnapshotStart:
         coordinator._handle_devices_snapshot([fresh])
 
         assert coordinator.devices["d1"] == fresh
-        # Persistence is scheduled as a task (sync callback can't await)
-        coordinator.hass.async_create_task.assert_called_once()
+        coordinator._devices_cache.async_schedule_save.assert_called_once_with(coordinator.devices)
 
     @pytest.mark.asyncio
     async def test_no_cache_when_entry_id_missing(self) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1138,3 +1138,100 @@ class TestApplyPushSecurityState:
 
         assert coordinator.spaces["s1"].security_state == SecurityState.ARMED
         coordinator.async_set_updated_data.assert_called_once()
+
+
+class TestCachedSnapshotStart:
+    """First-refresh path now skips `get_devices_snapshot` when a cache is
+    available, returning cached devices immediately so platform setup
+    drops out of HA's *"integration taking too long"* boot warning. The
+    streams started in the same first refresh deliver a fresh snapshot
+    within seconds via `_handle_devices_snapshot`, replacing the cache.
+    Tracked in #114.
+    """
+
+    def _coordinator_with_cache(self, cached: dict[str, Device] | None) -> object:
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        hass = MagicMock()
+        client = MagicMock()
+        with patch(
+            "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+            return_value=None,
+        ):
+            coordinator = AjaxCobrandedCoordinator(
+                hass=hass,
+                client=client,
+                space_ids=["s1"],
+                poll_interval=30,
+                entry_id="entry-1",
+            )
+        coordinator.hass = hass
+        # Replace the real DevicesCache with an in-memory fake
+        cache_mock = MagicMock()
+        cache_mock.async_load = AsyncMock(return_value=cached)
+        cache_mock.async_save = AsyncMock()
+        coordinator._devices_cache = cache_mock
+        coordinator._client.session.is_authenticated = True
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(
+            return_value=[_make_device("fresh-d1")]
+        )
+        coordinator._hub_object_api = MagicMock()
+        coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
+        coordinator._start_device_streams = AsyncMock()
+        coordinator._start_hts = AsyncMock()
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_first_refresh_with_cache_skips_devices_snapshot(self) -> None:
+        cached = {"cached-d1": _make_device("cached-d1")}
+        coordinator = self._coordinator_with_cache(cached)
+
+        result = await coordinator._async_update_data()
+
+        # Cache wins: no synchronous gRPC snapshot call on the boot path
+        coordinator._devices_api.get_devices_snapshot.assert_not_called()
+        assert result["devices"] == cached
+        # Subsequent polls won't re-trigger the heavy path
+        assert coordinator._streams_started is True
+        # Streams + HTS are still kicked off (they were already non-blocking
+        # after #113; we just made sure we don't regress that)
+        coordinator._start_device_streams.assert_awaited_once()
+        coordinator._start_hts.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_first_refresh_without_cache_runs_heavy_path_and_persists(self) -> None:
+        coordinator = self._coordinator_with_cache(cached=None)
+
+        await coordinator._async_update_data()
+
+        coordinator._devices_api.get_devices_snapshot.assert_awaited()
+        assert "fresh-d1" in coordinator.devices
+        # Fresh snapshot is persisted so the next restart can warm-start
+        coordinator._devices_cache.async_save.assert_awaited_once_with(coordinator.devices)
+
+    @pytest.mark.asyncio
+    async def test_stream_snapshot_callback_persists_cache(self) -> None:
+        # When the device stream delivers its initial snapshot via
+        # `_handle_devices_snapshot`, that fresh data should overwrite the
+        # warm-started cache so the next boot reflects reality.
+        coordinator = self._coordinator_with_cache(cached={"d1": _make_device("d1")})
+        coordinator.async_set_updated_data = MagicMock()
+
+        fresh = replace(_make_device("d1"), name="Renamed")
+        coordinator._handle_devices_snapshot([fresh])
+
+        assert coordinator.devices["d1"] == fresh
+        # Persistence is scheduled as a task (sync callback can't await)
+        coordinator.hass.async_create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_cache_when_entry_id_missing(self) -> None:
+        # Tests construct the coordinator without an entry_id. We must keep
+        # working in that mode (no cache, heavy path always) so the existing
+        # ~1080-test suite doesn't need a giant rewrite.
+        coordinator = _make_coordinator()
+        assert coordinator._devices_cache is None

--- a/tests/unit/test_device_cache.py
+++ b/tests/unit/test_device_cache.py
@@ -1,0 +1,121 @@
+"""Tests for DevicesCache (the Store-backed cache from #114)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.aegis_ajax.api.models import BatteryInfo, Device
+from custom_components.aegis_ajax.const import DeviceState
+from custom_components.aegis_ajax.device_cache import (
+    DevicesCache,
+    _serialize_device,
+)
+
+
+def _make_device(device_id: str = "d1", **overrides: object) -> Device:
+    base = {
+        "id": device_id,
+        "hub_id": "hub-1",
+        "name": "Sensor",
+        "device_type": "door_protect",
+        "room_id": None,
+        "group_id": None,
+        "state": DeviceState.ONLINE,
+        "malfunctions": 0,
+        "bypassed": False,
+        "statuses": {},
+        "battery": None,
+    }
+    base.update(overrides)
+    return Device(**base)  # type: ignore[arg-type]
+
+
+class TestSerialization:
+    def test_roundtrip_minimal_device(self) -> None:
+        from custom_components.aegis_ajax.device_cache import _deserialize_device
+
+        d = _make_device("d1")
+        roundtripped = _deserialize_device(_serialize_device(d))
+        assert roundtripped == d
+
+    def test_roundtrip_device_with_battery_and_statuses(self) -> None:
+        from custom_components.aegis_ajax.device_cache import _deserialize_device
+
+        d = _make_device(
+            "d2",
+            battery=BatteryInfo(level=87, is_low=False),
+            statuses={"co_detected": False, "temperature": 21.5},
+            room_id="r1",
+            group_id="g1",
+            malfunctions=2,
+            bypassed=True,
+        )
+        roundtripped = _deserialize_device(_serialize_device(d))
+        assert roundtripped == d
+
+    def test_drops_non_json_status_values(self) -> None:
+        # `motion_detected_at` carries a `datetime`, which is not JSON-able.
+        # The cache is best-effort first-frame restoration, so we drop
+        # offending entries instead of inventing a wire format. The next
+        # snapshot repopulates them within seconds.
+        from custom_components.aegis_ajax.device_cache import _deserialize_device
+
+        d = _make_device(
+            "d3",
+            statuses={
+                "motion_detected": True,
+                "motion_detected_at": datetime(2026, 5, 8, 12, 0, tzinfo=UTC),
+            },
+        )
+        roundtripped = _deserialize_device(_serialize_device(d))
+        assert roundtripped.statuses == {"motion_detected": True}
+
+
+class TestDevicesCache:
+    @pytest.mark.asyncio
+    async def test_load_returns_none_when_store_empty(self) -> None:
+        cache = DevicesCache(MagicMock(), "entry-1")
+        cache._store.async_load = AsyncMock(return_value=None)
+        assert await cache.async_load() is None
+
+    @pytest.mark.asyncio
+    async def test_save_then_load_roundtrip(self) -> None:
+        # Replace the Store with an in-memory fake so we exercise the real
+        # serialize → save → load → deserialize path end-to-end.
+        cache = DevicesCache(MagicMock(), "entry-1")
+        store_state: dict[str, object] = {}
+
+        async def fake_save(value: object) -> None:
+            store_state["value"] = value
+
+        async def fake_load() -> object:
+            return store_state.get("value")
+
+        cache._store.async_save = fake_save  # type: ignore[method-assign]
+        cache._store.async_load = fake_load  # type: ignore[method-assign]
+
+        d = _make_device("d1", battery=BatteryInfo(level=42, is_low=True))
+        await cache.async_save({"d1": d})
+        loaded = await cache.async_load()
+        assert loaded == {"d1": d}
+
+    @pytest.mark.asyncio
+    async def test_load_returns_none_on_corrupt_payload(self) -> None:
+        # A schema bump or a manually-edited storage file should never crash
+        # the integration — fall back to `None` (no cache) so the heavy
+        # first-refresh path runs.
+        cache = DevicesCache(MagicMock(), "entry-1")
+        cache._store.async_load = AsyncMock(  # type: ignore[method-assign]
+            return_value={"devices": [{"not_a_device": True}]}
+        )
+        assert await cache.async_load() is None
+
+    @pytest.mark.asyncio
+    async def test_storage_key_is_per_entry(self) -> None:
+        # Two entries (e.g. multiple Ajax accounts) must not share a cache.
+        from custom_components.aegis_ajax.device_cache import _storage_key
+
+        assert _storage_key("entry-a") != _storage_key("entry-b")

--- a/tests/unit/test_device_cache.py
+++ b/tests/unit/test_device_cache.py
@@ -119,3 +119,26 @@ class TestDevicesCache:
         from custom_components.aegis_ajax.device_cache import _storage_key
 
         assert _storage_key("entry-a") != _storage_key("entry-b")
+
+    def test_schedule_save_debounces_through_store(self) -> None:
+        # `async_schedule_save` must hand a payload-builder + delay to
+        # the underlying Store so bursts of stream snapshots collapse
+        # into a single disk write.
+        from custom_components.aegis_ajax.device_cache import _SAVE_DEBOUNCE_SECONDS
+
+        cache = DevicesCache(MagicMock(), "entry-1")
+        cache._store.async_delay_save = MagicMock()  # type: ignore[method-assign]
+
+        d1 = _make_device("d1")
+        cache.async_schedule_save({"d1": d1})
+
+        cache._store.async_delay_save.assert_called_once()
+        args, _ = cache._store.async_delay_save.call_args
+        data_func, delay = args
+        assert delay == _SAVE_DEBOUNCE_SECONDS
+        # Builder is lazy: it reads from `_pending` at flush time, so a
+        # later snapshot replacing `_pending` is what gets written.
+        d2 = _make_device("d2")
+        cache.async_schedule_save({"d2": d2})
+        payload = data_func()
+        assert [entry["id"] for entry in payload["devices"]] == ["d2"]


### PR DESCRIPTION
## Summary

Follow-up to #112 / #113. After moving HTS + FCM startup off the boot path, the remaining contributor to HA's *"integration taking too long"* warning was the synchronous `get_devices_snapshot` loop inside the first `_async_update_data`. This change persists the last-known device snapshot to a per-entry `Store` and warm-starts `coordinator.devices` from it, so platform setup runs against cached data and the gRPC snapshot fetch drops off the boot path entirely. The persistent device streams started in the same refresh deliver fresh data via `_handle_devices_snapshot` within seconds, replacing cached values.

Approach corresponds to *option 1* in #114. Falls back to the existing heavy path on fresh install or if the cache fails to deserialize, so the worst case is unchanged.

## Changes

- New `custom_components/aegis_ajax/device_cache.py`: `DevicesCache` wrapping a per-entry `Store`, with serialize/deserialize for `Device` (handles `BatteryInfo`, `DeviceState` StrEnum, and drops non-JSON status values like `motion_detected_at` datetimes — the next snapshot repopulates them within seconds).
- `coordinator.py`: new `entry_id` parameter; first refresh tries `async_load()` and skips `get_devices_snapshot` on a hit; heavy path persists the fresh snapshot afterwards. `_handle_devices_snapshot` schedules a save on every stream-delivered snapshot so the cache stays current.
- `__init__.py`: passes `entry.entry_id` through to the coordinator.
- Tests: 4 new for `TestCachedSnapshotStart` (warm-start skips snapshot fetch, no-cache path persists, stream callback updates cache, no-entry_id path keeps cache disabled) + 7 new for `device_cache.py` (serialization roundtrip, non-JSON status drop, save→load roundtrip, corrupt-payload fallback, per-entry storage key).

## Trade-off

For the first poll cycle after restart, entity state reflects the *previous* boot's snapshot rather than live state — typically sub-second of staleness on a healthy install (until the device stream emits its initial snapshot), bounded by `get_devices_snapshot` latency on a slow one. HA's persisted entity state already does this for the very first frame, so the new cache only earns the time between HA boot completing and our first stream snapshot returning — which is exactly the time the issue targets.

## Test plan

- [x] `make check` (ruff, format, mypy, pytest, vulture) inside the dev image — 1091 passed (up from 1080), coverage 83.46%
- [x] CI parity verified by rebuilding `aegis-ajax-dev:ci-114` and running checks without volume mount
- [ ] Smoke-test on real HA: confirm boot phase no longer logs the *"integration taking too long"* warning after the first restart following install of this build, and that entity state reflects the prior snapshot for a brief moment before the stream catches up

Refs #114, #112, #113.