### PR TITLE
feat(valve): read-only valve platform for WaterStop devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ If a specific group of sensors stops working:
 ## Roadmap
 
 - [ ] Video stream support (VideoEdge, RTSP)
-- [ ] Valve platform — bidirectional control. Read-only `valve` entity ships in `1.2.5`; full open / close still waits on capturing the official app's command-side calls (no `SwitchWaterStopService` in the v3 protos)
+- [ ] Valve platform — bidirectional control. Read-only `valve` entity ships in `1.3.0`; full open / close still waits on capturing the official app's command-side calls (no `SwitchWaterStopService` in the v3 protos)
 - [ ] Firmware update platform
 - [ ] Number/Select platforms for device settings (sensitivity, brightness)
 - [ ] SpaceControl (keyfob) event support

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 - **Switches**: Relays, wall switches, sockets (multi-channel support) — turn on/off via `DeviceCommandDeviceOn` / `DeviceCommandDeviceOff` gRPC services
 - **Lights**: Dimmers with absolute brightness control via `DeviceCommandBrightness`
 - **Locks**: Ajax SmartLock and LockBridge (Yale) — lock, unlock, and unlatch (HA's `lock.open`) via `SwitchSmartLockService`
+- **Valves** (read-only): Ajax WaterStop and WaterStop Fibra surface as native `valve.*` entities reflecting `WaterStopChannel.state` (open / closed), `is_transitioning`, and a `stuck` attribute pulled from the channel-level `MALFUNCTION_IS_STUCK`. Bidirectional control waits on capturing the official app's command-side calls — file an issue with a packet capture if you have a WaterStop and we'll wire the open / close path
 - **Cameras**: MotionCam Photo on Demand — capture photos and view them in HA (PhOD models only)
 - **Photo Storage**: Captured photos saved to `/media/ajax_photos/` with timestamp overlay, configurable retention
 - **Media Browser**: Browse captured photos per device via HA Media Browser
@@ -339,7 +340,7 @@ If a specific group of sensors stops working:
 ## Roadmap
 
 - [ ] Video stream support (VideoEdge, RTSP)
-- [ ] Valve platform (WaterStop) — read-only `valve` entity is unblocked (the `spread_properties` walker added in `1.2.4` already exposes `WaterStopChannel.state`); full bidirectional control still waits on capturing the official app's command-side calls
+- [ ] Valve platform — bidirectional control. Read-only `valve` entity ships in `1.2.5`; full open / close still waits on capturing the official app's command-side calls (no `SwitchWaterStopService` in the v3 protos)
 - [ ] Firmware update platform
 - [ ] Number/Select platforms for device settings (sensitivity, brightness)
 - [ ] SpaceControl (keyfob) event support

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -36,6 +36,7 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.LIGHT,
     Platform.LOCK,
+    Platform.VALVE,
 ]
 
 type AjaxCobrandedConfigEntry = ConfigEntry[AjaxCobrandedCoordinator]

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -367,6 +367,33 @@ class DevicesApi:
                     continue
                 state_int = int(sbc.state) if hasattr(sbc, "state") else 0
                 result[f"switch_ch{channel_id}"] = state_int == 2  # STATE_ON
+            elif which == "water_stop_channel":
+                # WaterStopChannel — feeds the read-only `valve` entity (#117).
+                # State enum is distinct from the relay/switch family:
+                # 0=UNSPECIFIED, 1=UNKNOWN, 2=OFF, 3=ON. We only emit
+                # `valve_chN` for ON/OFF; UNKNOWN / UNSPECIFIED leave the
+                # key absent so the entity renders as `unknown` rather
+                # than fabricating a closed/open reading on a comms hiccup.
+                # `STATE_ON` = water flowing (valve open) follows the same
+                # convention as the relay parser above; if real-hardware
+                # testing reveals the WaterStop firmware uses the inverted
+                # mapping, flip the comparison here.
+                wsc = entry.water_stop_channel
+                channel_id = int(wsc.id) if hasattr(wsc, "id") else 1
+                if channel_id <= 0:
+                    continue
+                state_int = int(wsc.state) if hasattr(wsc, "state") else 0
+                if state_int == 3:  # STATE_ON
+                    result[f"valve_ch{channel_id}"] = True
+                elif state_int == 2:  # STATE_OFF
+                    result[f"valve_ch{channel_id}"] = False
+                if getattr(wsc, "is_transitioning", False):
+                    result[f"valve_ch{channel_id}_transitioning"] = True
+                # MALFUNCTION_IS_STUCK = 2 in the channel-level enum
+                # (distinct from the Simple-flag `water_stop_valve_stuck`
+                # parsed off `LightDeviceStatus.statuses`).
+                if 2 in [int(m) for m in getattr(wsc, "malfunctions", [])]:
+                    result[f"valve_ch{channel_id}_stuck"] = True
         return result
 
     @staticmethod

--- a/custom_components/aegis_ajax/valve.py
+++ b/custom_components/aegis_ajax/valve.py
@@ -1,0 +1,119 @@
+"""Valve entities for Ajax WaterStop devices (read-only — #117).
+
+Read-only on purpose: the v3 protos we have don't expose a
+`SwitchWaterStopService`, so the integration cannot toggle the valve
+from HA. Surfacing OPEN / CLOSE features would just attach buttons that
+silently fail. The entity therefore declares `supported_features = 0`
+and `reports_position = False`; automations can still react to the
+valve closing (leak event) via the standard `valve.closed` state
+trigger.
+
+When someone with a WaterStop captures the wire calls the official
+mobile app makes when toggling, extending this entity with an
+`async_open_valve` / `async_close_valve` pair is straightforward.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.valve import (
+    ValveDeviceClass,
+    ValveEntity,
+    ValveEntityFeature,
+)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from custom_components.aegis_ajax.api.models import Device
+
+_LOGGER = logging.getLogger(__name__)
+
+# Ajax catalog ships two WaterStop buckets — `water_stop` (Jeweller, the
+# default wireless variant) and `water_stop_base` (Fibra, wired). Same
+# `WaterStopChannel` payload, same parser path, same entity surface.
+VALVE_DEVICE_TYPES: frozenset[str] = frozenset({"water_stop", "water_stop_base"})
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: AjaxCobrandedCoordinator = entry.runtime_data
+    entities: list[AjaxValve] = []
+    for device_id, device in coordinator.devices.items():
+        if device.device_type in VALVE_DEVICE_TYPES:
+            entities.append(AjaxValve(coordinator=coordinator, device_id=device_id))
+    async_add_entities(entities)
+
+
+class AjaxValve(CoordinatorEntity[AjaxCobrandedCoordinator], ValveEntity):
+    """Read-only valve entity backed by `WaterStopChannel.state`."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_device_class = ValveDeviceClass.WATER
+    _attr_supported_features = ValveEntityFeature(0)
+    _attr_reports_position = False
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._attr_unique_id = f"aegis_ajax_{device_id}_valve"
+        device = coordinator.devices.get(device_id)
+        if device:
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
+
+    @property
+    def _device(self) -> Device | None:
+        return self.coordinator.devices.get(self._device_id)
+
+    @property
+    def available(self) -> bool:
+        device = self._device
+        return device is not None and device.is_online
+
+    @property
+    def is_closed(self) -> bool | None:
+        device = self._device
+        if device is None:
+            return None
+        # Parser leaves `valve_ch1` absent on STATE_UNKNOWN / UNSPECIFIED
+        # — propagate as `unknown` instead of guessing.
+        state = device.statuses.get("valve_ch1")
+        if state is None:
+            return None
+        return not bool(state)
+
+    @property
+    def is_closing(self) -> bool:
+        device = self._device
+        if device is None:
+            return False
+        if not device.statuses.get("valve_ch1_transitioning"):
+            return False
+        # In transit + currently open → on its way to closed.
+        return bool(device.statuses.get("valve_ch1"))
+
+    @property
+    def is_opening(self) -> bool:
+        device = self._device
+        if device is None:
+            return False
+        if not device.statuses.get("valve_ch1_transitioning"):
+            return False
+        return not bool(device.statuses.get("valve_ch1"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        device = self._device
+        if device is None:
+            return {}
+        return {"stuck": bool(device.statuses.get("valve_ch1_stuck"))}

--- a/docs/TODO-improvements.md
+++ b/docs/TODO-improvements.md
@@ -27,21 +27,18 @@ Prioritized list of remaining improvements based on HA platinum integration patt
 - ~~System Health diagnostics~~ (v1.2.4) — `last_update_success_time` exposed on the coordinator so the card stops rendering as `error: unknown` (#106); `Reach Ajax cloud (gRPC host)` derived from poll freshness instead of an HTTPS HEAD probe that always returned `unreachable` (#110)
 - ~~Non-blocking startup~~ (v1.2.4) — HTS connect-then-listen and FCM startup move to background tasks; first refresh no longer awaits multi-second listener startups so the integration drops out of HA's *"integration taking too long"* warning much sooner (#113, closes #112)
 - ~~Cached-snapshot warm start~~ (v1.2.4) — first `_async_update_data` warm-starts `coordinator.devices` from a per-entry `Store`-backed cache and skips the synchronous `get_devices_snapshot` loop on subsequent boots; persistent streams deliver fresh data within seconds. Cache writes from the stream callback go through `Store.async_delay_save` (30 s window) to coalesce bursts. Real-HA measurement: ~10 s shaved off HA total boot, ~9 s off aegis_ajax setup-to-platforms-online (#116, closes #114)
+- ~~Valve platform (read-only)~~ (v1.2.5) — `WaterStopChannel.state` / `is_transitioning` / `MALFUNCTION_IS_STUCK` surfaced via the existing `spread_properties` walker as `valve_chN` / `_transitioning` / `_stuck` keys; new `valve.py` exposes them as native HA `valve.*` entities for `water_stop` and `water_stop_base` device types. Bidirectional control still waits on capturing the official app's command-side calls (no `SwitchWaterStopService` in v3 protos) (#117)
 
 ---
 
 ## Priority 1 — High impact, moderate effort
 
-### 1.1 Valve Platform (`valve.py`) — partially unblocked
-**Why:** WaterStop devices currently surface as a no-op (empty binary-sensor list). Native `valve` entity would let automations open/close the water shut-off valve.
+### 1.1 Valve Platform (`valve.py`) — bidirectional control
+**Why:** Read-only valve entity shipped in `1.2.5` (#117). The remaining gap is **opening / closing the valve from HA** — automations can react to the valve being closed by a leak, but can't trigger the shut-off themselves nor reopen after a false-positive.
 
-**Status after #109 (1.2.4):** the `spread_properties` walker added for switch state already covers `WaterStopChannel.state` mechanically — extending it to populate a `valve_chN` key would be a one-liner. The remaining blocker is the **command path**: there is no `SwitchWaterStopService` in the v3 protos we have, so the entity would be read-only. Useful (status visibility + transition flag), but not the full valve UX.
+**Status:** Blocked on protocol capture. There is no `SwitchWaterStopService` in the v3 protos we have. Need someone with a WaterStop to run the rig (Frida + mitmproxy on the official mobile app) and capture the gRPC call the app makes when toggling the valve from its UI.
 
-**Suggested incremental ship:**
-1. Read-only `valve` entity — exposes `state` (STATE_OFF / STATE_ON), `is_transitioning`, and the `MALFUNCTION_IS_STUCK` flag as the existing `water_stop_valve_stuck` binary sensor. Lets automations *react* to the valve being closed even if HA can't toggle it.
-2. Wait for someone with a WaterStop to capture the wire calls the official mobile app makes when toggling, then add the command path.
-
-**Effort:** Low (1-2 h) for read-only ship; unknown for full bidirectional.
+**Effort:** Unknown — likely 2-3 h once the wire shape is in hand.
 
 ---
 

--- a/docs/TODO-improvements.md
+++ b/docs/TODO-improvements.md
@@ -27,14 +27,14 @@ Prioritized list of remaining improvements based on HA platinum integration patt
 - ~~System Health diagnostics~~ (v1.2.4) — `last_update_success_time` exposed on the coordinator so the card stops rendering as `error: unknown` (#106); `Reach Ajax cloud (gRPC host)` derived from poll freshness instead of an HTTPS HEAD probe that always returned `unreachable` (#110)
 - ~~Non-blocking startup~~ (v1.2.4) — HTS connect-then-listen and FCM startup move to background tasks; first refresh no longer awaits multi-second listener startups so the integration drops out of HA's *"integration taking too long"* warning much sooner (#113, closes #112)
 - ~~Cached-snapshot warm start~~ (v1.2.4) — first `_async_update_data` warm-starts `coordinator.devices` from a per-entry `Store`-backed cache and skips the synchronous `get_devices_snapshot` loop on subsequent boots; persistent streams deliver fresh data within seconds. Cache writes from the stream callback go through `Store.async_delay_save` (30 s window) to coalesce bursts. Real-HA measurement: ~10 s shaved off HA total boot, ~9 s off aegis_ajax setup-to-platforms-online (#116, closes #114)
-- ~~Valve platform (read-only)~~ (v1.2.5) — `WaterStopChannel.state` / `is_transitioning` / `MALFUNCTION_IS_STUCK` surfaced via the existing `spread_properties` walker as `valve_chN` / `_transitioning` / `_stuck` keys; new `valve.py` exposes them as native HA `valve.*` entities for `water_stop` and `water_stop_base` device types. Bidirectional control still waits on capturing the official app's command-side calls (no `SwitchWaterStopService` in v3 protos) (#117)
+- ~~Valve platform (read-only)~~ (v1.3.0) — `WaterStopChannel.state` / `is_transitioning` / `MALFUNCTION_IS_STUCK` surfaced via the existing `spread_properties` walker as `valve_chN` / `_transitioning` / `_stuck` keys; new `valve.py` exposes them as native HA `valve.*` entities for `water_stop` and `water_stop_base` device types. Bidirectional control still waits on capturing the official app's command-side calls (no `SwitchWaterStopService` in v3 protos) (#117)
 
 ---
 
 ## Priority 1 — High impact, moderate effort
 
 ### 1.1 Valve Platform (`valve.py`) — bidirectional control
-**Why:** Read-only valve entity shipped in `1.2.5` (#117). The remaining gap is **opening / closing the valve from HA** — automations can react to the valve being closed by a leak, but can't trigger the shut-off themselves nor reopen after a false-positive.
+**Why:** Read-only valve entity shipped in `1.3.0` (#117). The remaining gap is **opening / closing the valve from HA** — automations can react to the valve being closed by a leak, but can't trigger the shut-off themselves nor reopen after a false-positive.
 
 **Status:** Blocked on protocol capture. There is no `SwitchWaterStopService` in the v3 protos we have. Need someone with a WaterStop to run the rig (Frida + mitmproxy on the official mobile app) and capture the gRPC call the app makes when toggling the valve from its UI.
 

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -198,6 +198,114 @@ class TestSpreadPropertiesParser:
         result = DevicesApi._parse_spread_properties(hub_dev)
         assert result == {}
 
+    def test_water_stop_channel_state_on_populates_valve_ch1_open(self) -> None:
+        # Read-only valve path (#117). `STATE_ON` means the channel is
+        # energised — water flowing — so the entity should report `open`.
+        # If real-hardware testing later proves the WaterStop firmware
+        # uses the inverted convention, this is the line to flip.
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            water_stop_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.water_stop_channel.CopyFrom(
+            water_stop_channel_pb2.WaterStopChannel(
+                id=water_stop_channel_pb2.WaterStopChannel.CHANNEL_ID_1,
+                state=water_stop_channel_pb2.WaterStopChannel.STATE_ON,
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"valve_ch1": True}
+
+    def test_water_stop_channel_state_off_populates_valve_ch1_closed(self) -> None:
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            water_stop_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.water_stop_channel.CopyFrom(
+            water_stop_channel_pb2.WaterStopChannel(
+                id=water_stop_channel_pb2.WaterStopChannel.CHANNEL_ID_1,
+                state=water_stop_channel_pb2.WaterStopChannel.STATE_OFF,
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"valve_ch1": False}
+
+    def test_water_stop_unknown_state_omits_valve_key(self) -> None:
+        # `STATE_UNKNOWN` / `STATE_UNSPECIFIED` mean the hub didn't report
+        # state (sensor reset, comms hiccup) — better to leave the key
+        # absent than to fabricate a closed/open reading. The valve entity
+        # then renders as `unknown` rather than wrong.
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            water_stop_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.water_stop_channel.CopyFrom(
+            water_stop_channel_pb2.WaterStopChannel(
+                id=water_stop_channel_pb2.WaterStopChannel.CHANNEL_ID_1,
+                state=water_stop_channel_pb2.WaterStopChannel.STATE_UNKNOWN,
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert "valve_ch1" not in result
+
+    def test_water_stop_is_transitioning_flag(self) -> None:
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            water_stop_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.water_stop_channel.CopyFrom(
+            water_stop_channel_pb2.WaterStopChannel(
+                id=water_stop_channel_pb2.WaterStopChannel.CHANNEL_ID_1,
+                state=water_stop_channel_pb2.WaterStopChannel.STATE_OFF,
+                is_transitioning=True,
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result["valve_ch1_transitioning"] is True
+
+    def test_water_stop_malfunction_is_stuck_exposed(self) -> None:
+        # Distinct from the existing `water_stop_valve_stuck` Simple-flag
+        # binary sensor parsed off `LightDeviceStatus.statuses`: this one
+        # comes from the channel-level `malfunctions` repeated enum, which
+        # is what the WaterStop firmware actually sets when the motor
+        # can't seat the valve. The entity surfaces it as an attribute.
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            water_stop_channel_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.water_stop_channel.CopyFrom(
+            water_stop_channel_pb2.WaterStopChannel(
+                id=water_stop_channel_pb2.WaterStopChannel.CHANNEL_ID_1,
+                state=water_stop_channel_pb2.WaterStopChannel.STATE_ON,
+                malfunctions=[
+                    water_stop_channel_pb2.WaterStopChannel.MALFUNCTION_BATTERY_LOW_ERROR,
+                    water_stop_channel_pb2.WaterStopChannel.MALFUNCTION_IS_STUCK,
+                ],
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result["valve_ch1_stuck"] is True
+
 
 class TestDeviceStateParser:
     def test_empty_states_returns_online(self) -> None:

--- a/tests/unit/test_valve.py
+++ b/tests/unit/test_valve.py
@@ -1,0 +1,215 @@
+"""Tests for the valve platform (Ajax WaterStop, read-only — #117)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.aegis_ajax.api.models import Device, Space
+from custom_components.aegis_ajax.const import (
+    ConnectionStatus,
+    DeviceState,
+    SecurityState,
+)
+from custom_components.aegis_ajax.valve import VALVE_DEVICE_TYPES, AjaxValve
+
+
+def _make_device(device_type: str = "water_stop", **status_overrides: Any) -> Device:  # noqa: ANN401
+    return Device(
+        id="valve-1",
+        hub_id="hub-1",
+        name="Kitchen WaterStop",
+        device_type=device_type,
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses=dict(status_overrides),
+        battery=None,
+    )
+
+
+def _make_coordinator(device: Device) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.devices = {device.id: device}
+    coordinator.rooms = {}
+    coordinator.spaces = {
+        "space-A": Space(
+            id="space-A",
+            hub_id=device.hub_id,
+            name="Home",
+            security_state=SecurityState.DISARMED,
+            connection_status=ConnectionStatus.ONLINE,
+            malfunctions_count=0,
+            monitoring_companies=(),
+            monitoring_companies_loaded=True,
+            groups=(),
+            group_mode_enabled=False,
+        )
+    }
+    return coordinator
+
+
+class TestValveDeviceTypes:
+    def test_water_stop_in_valve_types(self) -> None:
+        assert "water_stop" in VALVE_DEVICE_TYPES
+
+    def test_water_stop_base_in_valve_types(self) -> None:
+        # `water_stop_base` is the Fibra (wired) sibling — same channel
+        # status shape, same parser path, must surface a valve entity too.
+        assert "water_stop_base" in VALVE_DEVICE_TYPES
+
+
+class TestAjaxValveState:
+    def test_is_closed_true_when_valve_ch1_false(self) -> None:
+        # Parser emits `valve_ch1=False` on `STATE_OFF` (water stopped).
+        device = _make_device(valve_ch1=False)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert valve.is_closed is True
+
+    def test_is_closed_false_when_valve_ch1_true(self) -> None:
+        # `valve_ch1=True` means STATE_ON — water flowing — valve open.
+        device = _make_device(valve_ch1=True)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert valve.is_closed is False
+
+    def test_is_closed_unknown_when_key_absent(self) -> None:
+        # `STATE_UNKNOWN` / `STATE_UNSPECIFIED` leave the key absent —
+        # the entity must render as `unknown` rather than guess closed.
+        device = _make_device()  # no valve_ch1 key
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert valve.is_closed is None
+
+
+class TestAjaxValveTransitioning:
+    def test_is_closing_when_open_and_transitioning(self) -> None:
+        # Valve is currently open (STATE_ON) and motor is moving — must
+        # be on its way to closed. Read-only, so no async_close call,
+        # but the entity flag still drives the right HA card animation.
+        device = _make_device(valve_ch1=True, valve_ch1_transitioning=True)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert valve.is_closing is True
+        assert valve.is_opening is False
+
+    def test_is_opening_when_closed_and_transitioning(self) -> None:
+        device = _make_device(valve_ch1=False, valve_ch1_transitioning=True)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert valve.is_opening is True
+        assert valve.is_closing is False
+
+    def test_neither_when_not_transitioning(self) -> None:
+        device = _make_device(valve_ch1=False, valve_ch1_transitioning=False)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert valve.is_opening is False
+        assert valve.is_closing is False
+
+
+class TestAjaxValveAttributes:
+    def test_stuck_attribute_exposed(self) -> None:
+        device = _make_device(valve_ch1=False, valve_ch1_stuck=True)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert (valve.extra_state_attributes or {}).get("stuck") is True
+
+    def test_stuck_false_when_absent(self) -> None:
+        device = _make_device(valve_ch1=True)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert (valve.extra_state_attributes or {}).get("stuck") is False
+
+
+class TestAjaxValveDeviceMissing:
+    """If the coordinator drops the device between polls (rare — only on
+    a snapshot that excludes it), every property must degrade gracefully
+    instead of raising on `None.statuses`.
+    """
+
+    def _orphaned_valve(self) -> AjaxValve:
+        device = _make_device(valve_ch1=True)
+        coordinator = _make_coordinator(device)
+        valve = AjaxValve(coordinator=coordinator, device_id=device.id)
+        coordinator.devices = {}  # device gone
+        return valve
+
+    def test_is_closed_none(self) -> None:
+        assert self._orphaned_valve().is_closed is None
+
+    def test_is_closing_false(self) -> None:
+        assert self._orphaned_valve().is_closing is False
+
+    def test_is_opening_false(self) -> None:
+        assert self._orphaned_valve().is_opening is False
+
+    def test_extra_state_attributes_empty(self) -> None:
+        assert self._orphaned_valve().extra_state_attributes == {}
+
+
+class TestAjaxValveAvailability:
+    def test_unavailable_when_device_offline(self) -> None:
+        device = Device(
+            id="valve-1",
+            hub_id="hub-1",
+            name="Kitchen WaterStop",
+            device_type="water_stop",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.OFFLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={"valve_ch1": True},
+            battery=None,
+        )
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert valve.available is False
+
+
+class TestAjaxValveSupportedFeatures:
+    def test_no_supported_features(self) -> None:
+        # Read-only path: no `SwitchWaterStopService` in v3 protos, so
+        # exposing OPEN/CLOSE features would surface controls that fail
+        # silently. Keep features at 0 until the command path is captured.
+        device = _make_device(valve_ch1=True)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert int(valve.supported_features) == 0
+
+    def test_reports_position_disabled(self) -> None:
+        # WaterStop is binary, not positional. HA renders a position bar
+        # if `reports_position` is True — must stay False.
+        device = _make_device(valve_ch1=True)
+        valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
+        assert valve.reports_position is False
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_one_entity_per_water_stop() -> None:
+    from homeassistant.const import Platform
+
+    from custom_components.aegis_ajax.valve import async_setup_entry
+
+    devices = {
+        "v1": _make_device("water_stop", valve_ch1=True),
+        "v2": _make_device("water_stop_base", valve_ch1=False),
+        "x1": _make_device("door_protect"),  # not a valve — must be skipped
+    }
+    devices["v2"] = devices["v2"].__class__(  # noqa: SLF001  (frozen dataclass replace shorthand)
+        **{**devices["v2"].__dict__, "id": "v2"}
+    )
+    devices["x1"] = devices["x1"].__class__(**{**devices["x1"].__dict__, "id": "x1"})
+
+    coordinator = MagicMock()
+    coordinator.devices = devices
+    coordinator.rooms = {}
+    coordinator.spaces = {}
+
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    added: list[Any] = []
+
+    def add_entities(items: list[Any]) -> None:
+        added.extend(items)
+
+    await async_setup_entry(MagicMock(), entry, add_entities)
+    assert {e.unique_id for e in added} == {"aegis_ajax_v1_valve", "aegis_ajax_v2_valve"}
+    assert all(isinstance(e, AjaxValve) for e in added)
+    assert Platform.VALVE  # sanity: HA does ship the constant we'll register against


### PR DESCRIPTION
## Summary

Surfaces Ajax WaterStop and WaterStop Fibra (`water_stop`, `water_stop_base`) as native HA `valve.*` entities by extending the existing `spread_properties` walker shipped in 1.2.4 (#109).

- New `water_stop_channel` branch in `_parse_spread_properties` emits `valve_chN`, `valve_chN_transitioning`, `valve_chN_stuck` (mirrors the existing `switch_chN` / `brightness_chN` pattern)
- New `valve.py` with `AjaxValve` (CoordinatorEntity + ValveEntity) reads those keys and reports `open` / `closed`, `is_opening` / `is_closing`, and `stuck` as an attribute
- `Platform.VALVE` wired into `__init__.py` PLATFORMS

## Why read-only

There is no `SwitchWaterStopService` in the v3 protos we have. Surfacing OPEN / CLOSE features would attach buttons that silently fail — `supported_features = 0` and `reports_position = False` keep the card honest. Bidirectional control follows once someone with a WaterStop captures the official app's command-side gRPC call.

## State mapping

`STATE_ON` → valve open / water flowing (matching the relay parser convention in the same walker). Documented inline so a real-hardware report can flip the comparison with a one-line patch. `STATE_UNKNOWN` / `STATE_UNSPECIFIED` leave `valve_chN` absent so the entity renders as `unknown` rather than fabricating a closed reading.

## Test plan

- [x] `make check` (ruff, format, mypy, pytest, vulture) inside the dev image — **1115 passed** (up from 1092), coverage **83.78%**, `valve.py` at **100%**
- [x] CI parity verified by rebuilding `aegis-ajax-dev:ci-117` and running checks without volume mount
- [ ] Hardware validation: pending. Maintainer doesn't have a WaterStop. The proto path is end-to-end unit-tested with synthetic `WaterStopChannel` instances; community feedback on the `STATE_ON`=open assumption is the only remaining gap

Refs #117.