### PR TITLE
fix(hts): keep listen loop alive on unknown TLV escape sequences

### DIFF
--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -538,7 +538,21 @@ class HtsClient:
 
     async def _handle_update(self, msg: HtsMessage) -> None:
         """Parse an UPDATES message and update hub state."""
-        params = tlv_decode(msg.payload)
+        # Belt-and-suspenders for #108: even with the lenient
+        # `tlv_unescape_param` (preserves unknown 0x06 0xNN pairs), a
+        # future parser bug or a truly garbled payload should not kill
+        # the listen loop and silently take down hub-network sensors
+        # for hours. Drop the offending message, log payload hex for
+        # post-mortem, and let the next update flow normally.
+        try:
+            params = tlv_decode(msg.payload)
+        except Exception:
+            _LOGGER.debug(
+                "Failed to decode UPDATES payload (first 80 bytes: %s) — dropping message",
+                msg.payload[:80].hex(),
+                exc_info=True,
+            )
+            return
         if not params:
             return
 

--- a/custom_components/aegis_ajax/api/hts/messages.py
+++ b/custom_components/aegis_ajax/api/hts/messages.py
@@ -16,9 +16,12 @@ Header layout (all big-endian):
 
 from __future__ import annotations
 
+import logging
 import struct
 from dataclasses import dataclass, field
 from enum import IntEnum
+
+_LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # TLV helpers
@@ -53,27 +56,46 @@ def tlv_escape_param(param: bytes) -> bytes:
 def tlv_unescape_param(data: bytes) -> bytes:
     """Unescape a single TLV parameter value.
 
-    Reverses:
+    Reverses the two known escape sequences:
       0x06 0x35 -> 0x05
       0x06 0x36 -> 0x06
+
+    Lenient on unknown sequences (#108): a `0x06 <other>` pair is
+    preserved as two literal bytes rather than raising. The strict
+    behaviour used to bubble a `ValueError` up through `tlv_decode`,
+    out of `_handle_update`, into `_run_hts_lifecycle`'s broad except,
+    which terminated the listen loop and left hub-network sensors
+    permanently `unavailable` for affected installs (@uddinr captured
+    `0x06 0x6A` from real firmware traffic). If the unknown pair turns
+    out to be a third escape code we don't yet know about, the worst
+    case is a slightly wrong byte in one field rather than the whole
+    HTS surface being dead. An orphan `0x06` at the end of the segment
+    is treated the same way (preserved as a literal 0x06).
     """
     out = bytearray()
     i = 0
     while i < len(data):
         b = data[i]
         if b == _ESC:
-            i += 1
-            if i >= len(data):
-                raise ValueError("Truncated escape sequence at end of TLV param")
-            nxt = data[i]
+            if i + 1 >= len(data):
+                _LOGGER.debug("Orphan 0x06 at end of TLV param; preserving literal")
+                out.append(_ESC)
+                break
+            nxt = data[i + 1]
             if nxt == _ESC_DELIM:
                 out.append(_DELIM)
-            elif nxt == _ESC_ESC:
+                i += 2
+                continue
+            if nxt == _ESC_ESC:
                 out.append(_ESC)
-            else:
-                raise ValueError(f"Unknown escape sequence 0x06 0x{nxt:02X}")
-        else:
-            out.append(b)
+                i += 2
+                continue
+            _LOGGER.debug("Unknown escape 0x06 0x%02X; preserving literal", nxt)
+            out.append(_ESC)
+            out.append(nxt)
+            i += 2
+            continue
+        out.append(b)
         i += 1
     return bytes(out)
 

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -323,6 +323,43 @@ class TestHandleUpdate:
         assert state.wifi_connected is True
         assert state.primary_connection == "wifi"
         client._on_state_update.assert_called_once_with("12345678", state)
+
+    @pytest.mark.asyncio
+    async def test_malformed_payload_drops_message_without_raising(self) -> None:
+        # Regression for #108: @uddinr's hub firmware emitted a payload
+        # containing 0x06 0x6A inside a TLV segment which our escape
+        # table didn't recognise. The lenient `tlv_unescape_param`
+        # already preserves unknown pairs, but as belt-and-suspenders
+        # `_handle_update` swallows any tlv_decode exception so a
+        # future parser bug or a truly garbled payload does not bubble
+        # out, kill the listen loop, and leave hub-network sensors
+        # permanently unavailable.
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        client._on_state_update = MagicMock()
+
+        # Force a tlv_decode failure with a payload that will reach an
+        # exception path even with the lenient unescape (mock the
+        # decoder so we don't have to construct an artificial wire-
+        # format that survives the lenient parser).
+        with patch(
+            "custom_components.aegis_ajax.api.hts.client.tlv_decode",
+            side_effect=ValueError("synthetic decode failure"),
+        ):
+            msg = HtsMessage(
+                sender=0x12345678,
+                receiver=client._sender_id,
+                seq_num=1,
+                link=10,
+                flags=0,
+                msg_type=MsgType.UPDATES,
+                payload=b"\x05\x06\x6a\x05",
+            )
+            # Must not raise — the listen loop depends on this
+            await client._handle_update(msg)
+
+        # No state update fired — message was correctly dropped
+        client._on_state_update.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_unknown_hub_update_requests_refresh_once(self) -> None:

--- a/tests/unit/hts/test_messages.py
+++ b/tests/unit/hts/test_messages.py
@@ -60,13 +60,34 @@ class TestTlvUnescape:
     def test_unescape_esc(self) -> None:
         assert tlv_unescape_param(b"\x06\x36") == b"\x06"
 
-    def test_truncated_escape_raises(self) -> None:
-        with pytest.raises(ValueError, match="Truncated escape"):
-            tlv_unescape_param(b"\x06")
+    def test_truncated_escape_preserved(self) -> None:
+        # Lenient (#108): an orphan 0x06 at the end of a segment used to
+        # raise and kill the HTS listen loop on the very next update.
+        # Treat the byte as literal data so the message decodes and the
+        # network sensors keep working.
+        assert tlv_unescape_param(b"\x06") == b"\x06"
 
-    def test_unknown_escape_raises(self) -> None:
-        with pytest.raises(ValueError, match="Unknown escape"):
-            tlv_unescape_param(b"\x06\x01")
+    def test_unknown_escape_preserved(self) -> None:
+        # Lenient (#108): @uddinr's hub firmware emits 0x06 0x6A inside
+        # a TLV segment which our escape table doesn't recognise. Strict
+        # ValueError used to propagate and shut down the listen loop —
+        # network sensors stayed unavailable forever. Preserve both
+        # bytes literally so the rest of the message decodes; if it
+        # turns out 0x6A is actually a third escape code we don't know
+        # about, the worst case is a slightly wrong byte in one field
+        # rather than the entire HTS surface being permanently dead.
+        assert tlv_unescape_param(b"\x06\x6a") == b"\x06\x6a"
+        assert tlv_unescape_param(b"\x06\x01") == b"\x06\x01"
+
+    def test_unknown_escape_preserved_in_context(self) -> None:
+        # Surrounding bytes pass through unchanged — only the unknown
+        # escape pair is preserved as-is.
+        assert tlv_unescape_param(b"AB\x06\x6aCD") == b"AB\x06\x6aCD"
+
+    def test_known_escape_still_works_after_lenient_fallback(self) -> None:
+        # Regression: don't accidentally make 0x06 0x35 / 0x06 0x36
+        # also literal — those still mean what they always meant.
+        assert tlv_unescape_param(b"\x06\x35\x06\x6a\x06\x36") == b"\x05\x06\x6a\x06"
 
     def test_empty(self) -> None:
         assert tlv_unescape_param(b"") == b""


### PR DESCRIPTION
## Summary

Fixes #108. @uddinr's HTS lifecycle was terminating on every reconnect because his hub firmware emits `0x06 0x6A` inside a TLV segment which our escape table doesn't recognise. The strict `tlv_unescape_param` raised `ValueError`, the exception bubbled out of `tlv_decode`, out of `_handle_update`, into `_run_hts_lifecycle`'s broad except — killing the listen task and leaving every hub-network sensor (Ethernet, Wi-Fi, GSM, mains power) permanently `unavailable` even though the lifecycle "succeeds" in reconnecting (the very next update hits the same bad message).

## Changes

- **`tlv_unescape_param` is now lenient.** A `0x06 <unknown>` pair is preserved as two literal bytes with a debug log. An orphan `0x06` at the end of a segment is preserved the same way. The two known escapes (`0x06 0x35` -> `0x05`, `0x06 0x36` -> `0x06`) keep working unchanged.
- **`_handle_update` catches any future `tlv_decode` exception**, logs the offending payload hex, and drops the message. Belt-and-suspenders: even if the lenient parser one day proves not enough, the listen loop survives.

## Why lenient over strict

If `0x6A` turns out to be a third escape code we don't yet know about, the worst case is a slightly wrong byte in one field rather than the whole HTS surface being permanently dead. Strict-by-default isn't worth the cost when the failure mode silently takes down hub-network sensors for hours.

The unknown pair will surface in DEBUG logs (`Unknown escape 0x06 0xNN; preserving literal`) — if a real user reports a wrong value we can revisit and add the third case.

## Test plan

- [x] 5 new unit tests cover lenient unescape behaviours + listen-loop survival on a malformed payload (regression)
- [x] `make check` inside the dev image — **1118 passed**, coverage **83.83%**
- [ ] CI parity — Docker Hub registry incident is preventing fresh image rebuilds locally; relying on GHA CI for parity
- [ ] Real-HA validation: needs @uddinr's confirmation on the next beta cut. Symptom on his side should change from "HTS streams: 0/1, Reach: unreachable" to "HTS streams: 1/1" within seconds of restart.

Refs #108.