### PR TITLE
feat(doorbell): MotionCam Video Doorbell + ring events

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -150,6 +150,13 @@ _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
     "motion_cam_s_phod": ["motion_detected", "tamper"],
     "motion_cam_s_phod_am": ["motion_detected", "tamper"],
     "motion_cam_superior_phod": ["motion_detected", "tamper"],
+    # MotionCam Video family — streaming cameras (Video Doorbell, Indoor,
+    # Base). Same on-device sensors as PhOD MotionCams; the video stream
+    # itself is a separate concern (#119, see RingButtonPressed in
+    # `VIDEO_EVENT_TAG_MAP` for the doorbell ring path).
+    "motion_cam_video_base": ["motion_detected", "tamper"],
+    "motion_cam_video_doorbell": ["motion_detected", "tamper"],
+    "motion_cam_video_indoor": ["motion_detected", "tamper"],
     "combi_protect": ["motion_detected", "glass_break", "tamper"],
     "combi_protect_s": ["motion_detected", "glass_break", "tamper"],
     "combi_protect_fibra": ["motion_detected", "glass_break", "tamper"],

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -246,6 +246,10 @@ HUB_EVENT_TAG_MAP: dict[str, str] = {
     "motion_detected": "motion",
     # Door
     "door_opened": "door_open",
+    # Doorbell — Wireless DoorBell SKU (#119). The MotionCam Video
+    # Doorbell fires its own ring through `VideoEventQualifier` instead;
+    # see `VIDEO_EVENT_TAG_MAP` below.
+    "ring_button_pressed": "doorbell_pressed",
 }
 
 # Map SpaceEventTag oneof field names to simplified HA event types. Used in
@@ -270,7 +274,25 @@ SPACE_EVENT_TAG_MAP: dict[str, str] = {
     "space_panic_button_pressed": "panic",
 }
 
+# Map VideoEventTag oneof field names to simplified HA event types. The
+# MotionCam Video Doorbell (and any other Ajax video device) fires its
+# events through `VideoEventQualifier` — distinct from the hub-level
+# `HubEventQualifier` we already parse. Pass 4 of
+# `_extract_event_with_compiled_protos` walks this. Only the events that
+# have a HA-meaningful destination are mapped; the long tail of
+# storage/temporary-access/firmware-update tags from `VideoEventTag` is
+# intentionally left unmapped (we'd just be inflating `ALL_EVENT_TYPES`
+# for events nobody automates on). Add more entries here when a real
+# automation use case shows up.
+VIDEO_EVENT_TAG_MAP: dict[str, str] = {
+    "ring_button_pressed": "doorbell_pressed",
+    "motion_detected": "motion",
+    "human_detected": "motion",
+}
+
 
 ALL_EVENT_TYPES: list[str] = sorted(
-    set(HUB_EVENT_TAG_MAP.values()) | set(SPACE_EVENT_TAG_MAP.values())
+    set(HUB_EVENT_TAG_MAP.values())
+    | set(SPACE_EVENT_TAG_MAP.values())
+    | set(VIDEO_EVENT_TAG_MAP.values())
 )

--- a/custom_components/aegis_ajax/logbook.py
+++ b/custom_components/aegis_ajax/logbook.py
@@ -25,6 +25,7 @@ _EVENT_DESCRIPTIONS: dict[str, str] = {
     "connection_lost": "Connection lost ({device_name})",
     "disarm": "Disarmed (via {device_name})",
     "disarm_night": "Night mode disarmed (via {device_name})",
+    "doorbell_pressed": "Doorbell pressed ({device_name})",
     "door_open": "Door opened (via {device_name})",
     "fire": "Fire detected ({device_name})",
     "flood": "Flood detected ({device_name})",

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -17,6 +17,7 @@ from custom_components.aegis_ajax.const import (
     HUB_EVENT_TAG_MAP,
     RAW_TAG_TO_SECURITY_STATE,
     SPACE_EVENT_TAG_MAP,
+    VIDEO_EVENT_TAG_MAP,
 )
 from custom_components.aegis_ajax.repairs import (
     async_clear_fcm_credentials_invalid,
@@ -432,6 +433,9 @@ class AjaxNotificationListener:
         from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (  # noqa: PLC0415, E501
             qualifier_pb2 as space_qualifier_pb2,
         )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.video import (  # noqa: PLC0415, E501
+            qualifier_pb2 as video_qualifier_pb2,
+        )
 
         candidates = self._find_embedded_messages(raw)
 
@@ -472,6 +476,27 @@ class AjaxNotificationListener:
                         return event_type, data
             except Exception:
                 continue
+
+        # Pass 3 — VideoEventQualifier (#119: MotionCam Video Doorbell ring,
+        # plus motion / human detected from video devices). The video tag
+        # set is disjoint from HubEventTag so its own qualifier is needed.
+        for candidate in candidates:
+            try:
+                video_q = video_qualifier_pb2.VideoEventQualifier()
+                video_q.ParseFromString(candidate)
+            except Exception:
+                continue
+            if not video_q.HasField("tag"):
+                continue
+            tag_field = video_q.tag.WhichOneof("event_tag_case")
+            if tag_field and tag_field in VIDEO_EVENT_TAG_MAP:
+                event_type = VIDEO_EVENT_TAG_MAP[tag_field]
+                data = {"raw_tag": tag_field}
+                if video_q.HasField("transition"):
+                    trans_field = video_q.transition.WhichOneof("transition")
+                    if trans_field:
+                        data["transition"] = trans_field
+                return event_type, data
         return None
 
     @staticmethod

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -13,12 +13,16 @@
             "2fa": {
                 "title": "Two-Factor Authentication",
                 "description": "Enter the 6-digit code from your authenticator app.",
-                "data": {"totp_code": "TOTP Code"}
+                "data": {
+                    "totp_code": "TOTP Code"
+                }
             },
             "select_spaces": {
                 "title": "Select Spaces",
                 "description": "Choose which spaces (hubs) to add.",
-                "data": {"spaces": "Spaces"}
+                "data": {
+                    "spaces": "Spaces"
+                }
             },
             "reconfigure": {
                 "title": "Reconfigure Aegis for Ajax",
@@ -32,17 +36,23 @@
             "reconfigure_2fa": {
                 "title": "Two-Factor Authentication",
                 "description": "Enter the 6-digit code from your authenticator app.",
-                "data": {"totp_code": "TOTP Code"}
+                "data": {
+                    "totp_code": "TOTP Code"
+                }
             },
             "reauth_confirm": {
                 "title": "Re-authenticate Aegis for Ajax",
                 "description": "Your Ajax session for {email} is no longer valid. Enter the current account password to restore access.",
-                "data": {"password": "Password"}
+                "data": {
+                    "password": "Password"
+                }
             },
             "reauth_2fa": {
                 "title": "Two-Factor Authentication",
                 "description": "Enter the 6-digit code from your authenticator app.",
-                "data": {"totp_code": "TOTP Code"}
+                "data": {
+                    "totp_code": "TOTP Code"
+                }
             }
         },
         "error": {
@@ -170,7 +180,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Capture photo"}},
+        "button": {
+            "capture_photo": {
+                "name": "Capture photo"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Security event",
@@ -186,6 +200,7 @@
                             "disarm": "Disarmed",
                             "disarm_night": "Disarmed night",
                             "door_open": "Door opened",
+                            "doorbell_pressed": "Doorbell pressed",
                             "fire": "Fire",
                             "flood": "Flood",
                             "glass_break": "Glass break",
@@ -199,43 +214,118 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "CRA connection"},
-            "gsm": {"name": "Cellular connected"},
-            "lid": {"name": "Lid opened"},
-            "ext_contact": {"name": "External contact broken"},
-            "ext_alert": {"name": "External contact alert"},
-            "drilling": {"name": "Case drilling"},
-            "anti_mask": {"name": "Anti-masking"},
-            "malfunction": {"name": "Malfunction"},
-            "interference": {"name": "Interference"},
-            "relay_stuck": {"name": "Relay stuck"},
-            "always_active": {"name": "Always active"},
-            "glass_break": {"name": "Glass break"},
-            "vibration": {"name": "Vibration"},
-            "wire_input_alert": {"name": "Wire input alert"},
-            "tamper": {"name": "Case tamper"},
-            "connectivity": {"name": "Connectivity"},
-            "problem": {"name": "Device problem"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Mains power"}
+            "monitoring": {
+                "name": "CRA connection"
+            },
+            "gsm": {
+                "name": "Cellular connected"
+            },
+            "lid": {
+                "name": "Lid opened"
+            },
+            "ext_contact": {
+                "name": "External contact broken"
+            },
+            "ext_alert": {
+                "name": "External contact alert"
+            },
+            "drilling": {
+                "name": "Case drilling"
+            },
+            "anti_mask": {
+                "name": "Anti-masking"
+            },
+            "malfunction": {
+                "name": "Malfunction"
+            },
+            "interference": {
+                "name": "Interference"
+            },
+            "relay_stuck": {
+                "name": "Relay stuck"
+            },
+            "always_active": {
+                "name": "Always active"
+            },
+            "glass_break": {
+                "name": "Glass break"
+            },
+            "vibration": {
+                "name": "Vibration"
+            },
+            "wire_input_alert": {
+                "name": "Wire input alert"
+            },
+            "tamper": {
+                "name": "Case tamper"
+            },
+            "connectivity": {
+                "name": "Connectivity"
+            },
+            "problem": {
+                "name": "Device problem"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Mains power"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "CRA company"},
-            "signal_strength": {"name": "Signal strength"},
-            "mobile_network_type": {"name": "Mobile network type"},
-            "wifi_signal_level": {"name": "Wi-Fi signal level"},
-            "sim_status": {"name": "SIM status"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Connection type"},
-            "wifi_ssid": {"name": "Wi-Fi SSID"},
-            "wifi_ip": {"name": "Wi-Fi IP address"},
-            "ethernet_ip": {"name": "Ethernet IP address"},
-            "ethernet_gateway": {"name": "Ethernet gateway"},
-            "ethernet_dns": {"name": "Ethernet DNS"},
-            "cellular_signal": {"name": "Cellular signal"},
-            "cellular_network": {"name": "Cellular network"}
+            "monitoring_company": {
+                "name": "CRA company"
+            },
+            "signal_strength": {
+                "name": "Signal strength"
+            },
+            "mobile_network_type": {
+                "name": "Mobile network type"
+            },
+            "wifi_signal_level": {
+                "name": "Wi-Fi signal level"
+            },
+            "sim_status": {
+                "name": "SIM status"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Connection type"
+            },
+            "wifi_ssid": {
+                "name": "Wi-Fi SSID"
+            },
+            "wifi_ip": {
+                "name": "Wi-Fi IP address"
+            },
+            "ethernet_ip": {
+                "name": "Ethernet IP address"
+            },
+            "ethernet_gateway": {
+                "name": "Ethernet gateway"
+            },
+            "ethernet_dns": {
+                "name": "Ethernet DNS"
+            },
+            "cellular_signal": {
+                "name": "Cellular signal"
+            },
+            "cellular_network": {
+                "name": "Cellular network"
+            }
         },
-        "switch": {"channel_1": {"name": "Channel 1"}, "channel_2": {"name": "Channel 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Channel 1"
+            },
+            "channel_2": {
+                "name": "Channel 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -13,12 +13,16 @@
             "2fa": {
                 "title": "Autenticacio de dos factors",
                 "description": "Introdueix el codi de 6 digits de la teva app d'autenticacio.",
-                "data": {"totp_code": "Codi TOTP"}
+                "data": {
+                    "totp_code": "Codi TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Seleccionar espais",
                 "description": "Tria quins espais (hubs) afegir.",
-                "data": {"spaces": "Espais"}
+                "data": {
+                    "spaces": "Espais"
+                }
             },
             "reconfigure": {
                 "title": "Reconfigurar Aegis for Ajax",
@@ -32,17 +36,23 @@
             "reconfigure_2fa": {
                 "title": "Autenticacio de dos factors",
                 "description": "Introdueix el codi de 6 digits de la teva app d'autenticacio.",
-                "data": {"totp_code": "Codi TOTP"}
+                "data": {
+                    "totp_code": "Codi TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Reautenticar Aegis for Ajax",
                 "description": "La sessio Ajax per a {email} ja no es valida. Introdueix la contrasenya actual del compte per restaurar l'acces.",
-                "data": {"password": "Contrasenya"}
+                "data": {
+                    "password": "Contrasenya"
+                }
             },
             "reauth_2fa": {
                 "title": "Autenticacio de dos factors",
                 "description": "Introdueix el codi de 6 digits de la teva app d'autenticacio.",
-                "data": {"totp_code": "Codi TOTP"}
+                "data": {
+                    "totp_code": "Codi TOTP"
+                }
             }
         },
         "error": {
@@ -154,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Capturar foto"}},
+        "button": {
+            "capture_photo": {
+                "name": "Capturar foto"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Esdeveniment de seguretat",
@@ -170,6 +184,7 @@
                             "disarm": "Desarmat",
                             "disarm_night": "Desarmat nocturn",
                             "door_open": "Porta oberta",
+                            "doorbell_pressed": "Timbre premut",
                             "fire": "Foc",
                             "flood": "Inundacio",
                             "glass_break": "Trencament de vidre",
@@ -183,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Connexio CRA"},
-            "gsm": {"name": "Mobil connectat"},
-            "lid": {"name": "Tapa oberta"},
-            "ext_contact": {"name": "Contacte extern trencat"},
-            "ext_alert": {"name": "Alerta contacte extern"},
-            "drilling": {"name": "Perforacio de caixa"},
-            "anti_mask": {"name": "Anti-enmascarament"},
-            "malfunction": {"name": "Avaria"},
-            "interference": {"name": "Interferencia"},
-            "relay_stuck": {"name": "Rele bloquejat"},
-            "always_active": {"name": "Sempre actiu"},
-            "glass_break": {"name": "Trencament de vidre"},
-            "vibration": {"name": "Vibració"},
-            "tilt": {"name": "Inclinació"},
-            "steam": {"name": "Vapor"},
-            "wire_input_alert": {"name": "Alerta d'entrada cablejada"},
-            "tamper": {"name": "Manipulació de carcassa"},
-            "connectivity": {"name": "Connectivitat"},
-            "problem": {"name": "Problema del dispositiu"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Alimentació externa"}
+            "monitoring": {
+                "name": "Connexio CRA"
+            },
+            "gsm": {
+                "name": "Mobil connectat"
+            },
+            "lid": {
+                "name": "Tapa oberta"
+            },
+            "ext_contact": {
+                "name": "Contacte extern trencat"
+            },
+            "ext_alert": {
+                "name": "Alerta contacte extern"
+            },
+            "drilling": {
+                "name": "Perforacio de caixa"
+            },
+            "anti_mask": {
+                "name": "Anti-enmascarament"
+            },
+            "malfunction": {
+                "name": "Avaria"
+            },
+            "interference": {
+                "name": "Interferencia"
+            },
+            "relay_stuck": {
+                "name": "Rele bloquejat"
+            },
+            "always_active": {
+                "name": "Sempre actiu"
+            },
+            "glass_break": {
+                "name": "Trencament de vidre"
+            },
+            "vibration": {
+                "name": "Vibració"
+            },
+            "tilt": {
+                "name": "Inclinació"
+            },
+            "steam": {
+                "name": "Vapor"
+            },
+            "wire_input_alert": {
+                "name": "Alerta d'entrada cablejada"
+            },
+            "tamper": {
+                "name": "Manipulació de carcassa"
+            },
+            "connectivity": {
+                "name": "Connectivitat"
+            },
+            "problem": {
+                "name": "Problema del dispositiu"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Alimentació externa"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Companyia CRA"},
-            "signal_strength": {"name": "Intensitat de senyal"},
-            "mobile_network_type": {"name": "Tipus de xarxa mòbil"},
-            "wifi_signal_level": {"name": "Nivell de senyal Wi-Fi"},
-            "sim_status": {"name": "Estat SIM"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Tipus de connexió"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "Adreça IP Wi-Fi"},
-            "ethernet_ip": {"name": "Adreça IP Ethernet"},
-            "ethernet_gateway": {"name": "Porta d'enllaç Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Senyal cel·lular"},
-            "cellular_network": {"name": "Xarxa cel·lular"}
+            "monitoring_company": {
+                "name": "Companyia CRA"
+            },
+            "signal_strength": {
+                "name": "Intensitat de senyal"
+            },
+            "mobile_network_type": {
+                "name": "Tipus de xarxa mòbil"
+            },
+            "wifi_signal_level": {
+                "name": "Nivell de senyal Wi-Fi"
+            },
+            "sim_status": {
+                "name": "Estat SIM"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Tipus de connexió"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "Adreça IP Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "Adreça IP Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Porta d'enllaç Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Senyal cel·lular"
+            },
+            "cellular_network": {
+                "name": "Xarxa cel·lular"
+            }
         },
-        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Canal 1"
+            },
+            "channel_2": {
+                "name": "Canal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -13,32 +13,46 @@
             "2fa": {
                 "title": "Dvoufaktorové ověření",
                 "description": "Zadejte 6místný kód z vaší ověřovací aplikace.",
-                "data": {"totp_code": "Kód TOTP"}
+                "data": {
+                    "totp_code": "Kód TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Vyberte prostory",
                 "description": "Zvolte, které prostory (huby) chcete přidat.",
-                "data": {"spaces": "Prostory"}
+                "data": {
+                    "spaces": "Prostory"
+                }
             },
             "reconfigure": {
                 "title": "Překonfigurovat Aegis for Ajax",
                 "description": "Aktualizujte přihlašovací údaje.",
-                "data": {"email": "E-mail", "password": "Heslo", "app_label": "Štítek aplikace"}
+                "data": {
+                    "email": "E-mail",
+                    "password": "Heslo",
+                    "app_label": "Štítek aplikace"
+                }
             },
             "reconfigure_2fa": {
                 "title": "Dvoufaktorové ověření",
                 "description": "Zadejte 6místný kód z vaší ověřovací aplikace.",
-                "data": {"totp_code": "Kód TOTP"}
+                "data": {
+                    "totp_code": "Kód TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Opětovné ověření Aegis for Ajax",
                 "description": "Vaše Ajax relace pro {email} již není platná. Zadejte aktuální heslo k účtu pro obnovení přístupu.",
-                "data": {"password": "Heslo"}
+                "data": {
+                    "password": "Heslo"
+                }
             },
             "reauth_2fa": {
                 "title": "Dvoufaktorové ověření",
                 "description": "Zadejte 6místný kód z vaší ověřovací aplikace.",
-                "data": {"totp_code": "Kód TOTP"}
+                "data": {
+                    "totp_code": "Kód TOTP"
+                }
             }
         },
         "error": {
@@ -150,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Pořídit fotografii"}},
+        "button": {
+            "capture_photo": {
+                "name": "Pořídit fotografii"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Bezpečnostní událost",
@@ -166,6 +184,7 @@
                             "disarm": "Odstřeženo",
                             "disarm_night": "Noční režim vypnut",
                             "door_open": "Dveře otevřeny",
+                            "doorbell_pressed": "Stisknutí zvonku",
                             "fire": "Požár",
                             "flood": "Záplava",
                             "glass_break": "Rozbití skla",
@@ -179,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Připojení k pultu centrální ochrany"},
-            "gsm": {"name": "Mobilní síť připojena"},
-            "lid": {"name": "Kryt otevřen"},
-            "ext_contact": {"name": "Externí kontakt přerušen"},
-            "ext_alert": {"name": "Poplach externího kontaktu"},
-            "drilling": {"name": "Vrtání skříně detekováno"},
-            "anti_mask": {"name": "Ochrana proti maskování"},
-            "malfunction": {"name": "Porucha"},
-            "interference": {"name": "Rušení"},
-            "relay_stuck": {"name": "Relé zaseknuté"},
-            "always_active": {"name": "Vždy aktivní"},
-            "glass_break": {"name": "Rozbití skla"},
-            "vibration": {"name": "Vibrace"},
-            "tilt": {"name": "Náklon"},
-            "steam": {"name": "Pára"},
-            "wire_input_alert": {"name": "Výstraha drátového vstupu"},
-            "tamper": {"name": "Sabotáž krytu"},
-            "connectivity": {"name": "Připojení"},
-            "problem": {"name": "Problém zařízení"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Napájení ze sítě"}
+            "monitoring": {
+                "name": "Připojení k pultu centrální ochrany"
+            },
+            "gsm": {
+                "name": "Mobilní síť připojena"
+            },
+            "lid": {
+                "name": "Kryt otevřen"
+            },
+            "ext_contact": {
+                "name": "Externí kontakt přerušen"
+            },
+            "ext_alert": {
+                "name": "Poplach externího kontaktu"
+            },
+            "drilling": {
+                "name": "Vrtání skříně detekováno"
+            },
+            "anti_mask": {
+                "name": "Ochrana proti maskování"
+            },
+            "malfunction": {
+                "name": "Porucha"
+            },
+            "interference": {
+                "name": "Rušení"
+            },
+            "relay_stuck": {
+                "name": "Relé zaseknuté"
+            },
+            "always_active": {
+                "name": "Vždy aktivní"
+            },
+            "glass_break": {
+                "name": "Rozbití skla"
+            },
+            "vibration": {
+                "name": "Vibrace"
+            },
+            "tilt": {
+                "name": "Náklon"
+            },
+            "steam": {
+                "name": "Pára"
+            },
+            "wire_input_alert": {
+                "name": "Výstraha drátového vstupu"
+            },
+            "tamper": {
+                "name": "Sabotáž krytu"
+            },
+            "connectivity": {
+                "name": "Připojení"
+            },
+            "problem": {
+                "name": "Problém zařízení"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Napájení ze sítě"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Společnost PCO"},
-            "signal_strength": {"name": "Síla signálu"},
-            "mobile_network_type": {"name": "Typ mobilní sítě"},
-            "wifi_signal_level": {"name": "Úroveň Wi-Fi signálu"},
-            "sim_status": {"name": "Stav SIM karty"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Typ připojení"},
-            "wifi_ssid": {"name": "Wi-Fi SSID"},
-            "wifi_ip": {"name": "Wi-Fi IP adresa"},
-            "ethernet_ip": {"name": "IP adresa Ethernet"},
-            "ethernet_gateway": {"name": "Brána Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Signál mobilní sítě"},
-            "cellular_network": {"name": "Mobilní síť"}
+            "monitoring_company": {
+                "name": "Společnost PCO"
+            },
+            "signal_strength": {
+                "name": "Síla signálu"
+            },
+            "mobile_network_type": {
+                "name": "Typ mobilní sítě"
+            },
+            "wifi_signal_level": {
+                "name": "Úroveň Wi-Fi signálu"
+            },
+            "sim_status": {
+                "name": "Stav SIM karty"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Typ připojení"
+            },
+            "wifi_ssid": {
+                "name": "Wi-Fi SSID"
+            },
+            "wifi_ip": {
+                "name": "Wi-Fi IP adresa"
+            },
+            "ethernet_ip": {
+                "name": "IP adresa Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Brána Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Signál mobilní sítě"
+            },
+            "cellular_network": {
+                "name": "Mobilní síť"
+            }
         },
-        "switch": {"channel_1": {"name": "Kanál 1"}, "channel_2": {"name": "Kanál 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Kanál 1"
+            },
+            "channel_2": {
+                "name": "Kanál 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -13,32 +13,46 @@
             "2fa": {
                 "title": "Zwei-Faktor-Authentifizierung",
                 "description": "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein.",
-                "data": {"totp_code": "TOTP-Code"}
+                "data": {
+                    "totp_code": "TOTP-Code"
+                }
             },
             "select_spaces": {
                 "title": "Bereiche auswählen",
                 "description": "Wählen Sie aus, welche Bereiche (Hubs) hinzugefügt werden sollen.",
-                "data": {"spaces": "Bereiche"}
+                "data": {
+                    "spaces": "Bereiche"
+                }
             },
             "reconfigure": {
                 "title": "Aegis for Ajax neu konfigurieren",
                 "description": "Aktualisieren Sie Ihre Zugangsdaten.",
-                "data": {"email": "E-Mail", "password": "Passwort", "app_label": "App-Label"}
+                "data": {
+                    "email": "E-Mail",
+                    "password": "Passwort",
+                    "app_label": "App-Label"
+                }
             },
             "reconfigure_2fa": {
                 "title": "Zwei-Faktor-Authentifizierung",
                 "description": "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein.",
-                "data": {"totp_code": "TOTP-Code"}
+                "data": {
+                    "totp_code": "TOTP-Code"
+                }
             },
             "reauth_confirm": {
                 "title": "Aegis for Ajax neu authentifizieren",
                 "description": "Ihre Ajax-Sitzung für {email} ist nicht mehr gültig. Geben Sie das aktuelle Konto-Passwort ein, um den Zugriff wiederherzustellen.",
-                "data": {"password": "Passwort"}
+                "data": {
+                    "password": "Passwort"
+                }
             },
             "reauth_2fa": {
                 "title": "Zwei-Faktor-Authentifizierung",
                 "description": "Geben Sie den 6-stelligen Code aus Ihrer Authenticator-App ein.",
-                "data": {"totp_code": "TOTP-Code"}
+                "data": {
+                    "totp_code": "TOTP-Code"
+                }
             }
         },
         "error": {
@@ -150,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Foto aufnehmen"}},
+        "button": {
+            "capture_photo": {
+                "name": "Foto aufnehmen"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Sicherheitsereignis",
@@ -166,6 +184,7 @@
                             "disarm": "Unscharfgeschaltet",
                             "disarm_night": "Nachtmodus deaktiviert",
                             "door_open": "Tür geöffnet",
+                            "doorbell_pressed": "Klingel gedrückt",
                             "fire": "Feuer",
                             "flood": "Überflutung",
                             "glass_break": "Glasbruch",
@@ -179,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Notruf-Leitstelle verbunden"},
-            "gsm": {"name": "Mobilfunk verbunden"},
-            "lid": {"name": "Gehäusedeckel geöffnet"},
-            "ext_contact": {"name": "Externer Kontakt unterbrochen"},
-            "ext_alert": {"name": "Externer Kontaktalarm"},
-            "drilling": {"name": "Gehäusebohrung erkannt"},
-            "anti_mask": {"name": "Abdeckungsschutz"},
-            "malfunction": {"name": "Fehlfunktion"},
-            "interference": {"name": "Störung"},
-            "relay_stuck": {"name": "Relais blockiert"},
-            "always_active": {"name": "Immer aktiv"},
-            "glass_break": {"name": "Glasbruch"},
-            "vibration": {"name": "Vibration"},
-            "tilt": {"name": "Neigung"},
-            "steam": {"name": "Dampf"},
-            "wire_input_alert": {"name": "Drahteingang ausgelöst"},
-            "tamper": {"name": "Gehäusemanipulation"},
-            "connectivity": {"name": "Konnektivität"},
-            "problem": {"name": "Geräteproblem"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "WLAN"},
-            "mains_power": {"name": "Netzstrom"}
+            "monitoring": {
+                "name": "Notruf-Leitstelle verbunden"
+            },
+            "gsm": {
+                "name": "Mobilfunk verbunden"
+            },
+            "lid": {
+                "name": "Gehäusedeckel geöffnet"
+            },
+            "ext_contact": {
+                "name": "Externer Kontakt unterbrochen"
+            },
+            "ext_alert": {
+                "name": "Externer Kontaktalarm"
+            },
+            "drilling": {
+                "name": "Gehäusebohrung erkannt"
+            },
+            "anti_mask": {
+                "name": "Abdeckungsschutz"
+            },
+            "malfunction": {
+                "name": "Fehlfunktion"
+            },
+            "interference": {
+                "name": "Störung"
+            },
+            "relay_stuck": {
+                "name": "Relais blockiert"
+            },
+            "always_active": {
+                "name": "Immer aktiv"
+            },
+            "glass_break": {
+                "name": "Glasbruch"
+            },
+            "vibration": {
+                "name": "Vibration"
+            },
+            "tilt": {
+                "name": "Neigung"
+            },
+            "steam": {
+                "name": "Dampf"
+            },
+            "wire_input_alert": {
+                "name": "Drahteingang ausgelöst"
+            },
+            "tamper": {
+                "name": "Gehäusemanipulation"
+            },
+            "connectivity": {
+                "name": "Konnektivität"
+            },
+            "problem": {
+                "name": "Geräteproblem"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "WLAN"
+            },
+            "mains_power": {
+                "name": "Netzstrom"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Leitstellenanbieter"},
-            "signal_strength": {"name": "Signalstärke"},
-            "mobile_network_type": {"name": "Mobilfunknetztyp"},
-            "wifi_signal_level": {"name": "WLAN-Signalstärke"},
-            "sim_status": {"name": "SIM-Status"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Verbindungstyp"},
-            "wifi_ssid": {"name": "WLAN-SSID"},
-            "wifi_ip": {"name": "WLAN-IP-Adresse"},
-            "ethernet_ip": {"name": "Ethernet IP-Adresse"},
-            "ethernet_gateway": {"name": "Ethernet-Gateway"},
-            "ethernet_dns": {"name": "Ethernet-DNS"},
-            "cellular_signal": {"name": "Mobilfunksignal"},
-            "cellular_network": {"name": "Mobilfunknetz"}
+            "monitoring_company": {
+                "name": "Leitstellenanbieter"
+            },
+            "signal_strength": {
+                "name": "Signalstärke"
+            },
+            "mobile_network_type": {
+                "name": "Mobilfunknetztyp"
+            },
+            "wifi_signal_level": {
+                "name": "WLAN-Signalstärke"
+            },
+            "sim_status": {
+                "name": "SIM-Status"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Verbindungstyp"
+            },
+            "wifi_ssid": {
+                "name": "WLAN-SSID"
+            },
+            "wifi_ip": {
+                "name": "WLAN-IP-Adresse"
+            },
+            "ethernet_ip": {
+                "name": "Ethernet IP-Adresse"
+            },
+            "ethernet_gateway": {
+                "name": "Ethernet-Gateway"
+            },
+            "ethernet_dns": {
+                "name": "Ethernet-DNS"
+            },
+            "cellular_signal": {
+                "name": "Mobilfunksignal"
+            },
+            "cellular_network": {
+                "name": "Mobilfunknetz"
+            }
         },
-        "switch": {"channel_1": {"name": "Kanal 1"}, "channel_2": {"name": "Kanal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Kanal 1"
+            },
+            "channel_2": {
+                "name": "Kanal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -13,12 +13,16 @@
             "2fa": {
                 "title": "Two-Factor Authentication",
                 "description": "Enter the 6-digit code from your authenticator app.",
-                "data": {"totp_code": "TOTP Code"}
+                "data": {
+                    "totp_code": "TOTP Code"
+                }
             },
             "select_spaces": {
                 "title": "Select Spaces",
                 "description": "Choose which spaces (hubs) to add.",
-                "data": {"spaces": "Spaces"}
+                "data": {
+                    "spaces": "Spaces"
+                }
             },
             "reconfigure": {
                 "title": "Reconfigure Aegis for Ajax",
@@ -32,17 +36,23 @@
             "reconfigure_2fa": {
                 "title": "Two-Factor Authentication",
                 "description": "Enter the 6-digit code from your authenticator app.",
-                "data": {"totp_code": "TOTP Code"}
+                "data": {
+                    "totp_code": "TOTP Code"
+                }
             },
             "reauth_confirm": {
                 "title": "Re-authenticate Aegis for Ajax",
                 "description": "Your Ajax session for {email} is no longer valid. Enter the current account password to restore access.",
-                "data": {"password": "Password"}
+                "data": {
+                    "password": "Password"
+                }
             },
             "reauth_2fa": {
                 "title": "Two-Factor Authentication",
                 "description": "Enter the 6-digit code from your authenticator app.",
-                "data": {"totp_code": "TOTP Code"}
+                "data": {
+                    "totp_code": "TOTP Code"
+                }
             }
         },
         "error": {
@@ -170,7 +180,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Capture photo"}},
+        "button": {
+            "capture_photo": {
+                "name": "Capture photo"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Security event",
@@ -186,6 +200,7 @@
                             "disarm": "Disarmed",
                             "disarm_night": "Disarmed night",
                             "door_open": "Door opened",
+                            "doorbell_pressed": "Doorbell pressed",
                             "fire": "Fire",
                             "flood": "Flood",
                             "glass_break": "Glass break",
@@ -199,45 +214,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "CRA connection"},
-            "gsm": {"name": "Cellular connected"},
-            "lid": {"name": "Lid opened"},
-            "ext_contact": {"name": "External contact broken"},
-            "ext_alert": {"name": "External contact alert"},
-            "drilling": {"name": "Case drilling"},
-            "anti_mask": {"name": "Anti-masking"},
-            "malfunction": {"name": "Malfunction"},
-            "interference": {"name": "Interference"},
-            "relay_stuck": {"name": "Relay stuck"},
-            "always_active": {"name": "Always active"},
-            "glass_break": {"name": "Glass break"},
-            "vibration": {"name": "Vibration"},
-            "tilt": {"name": "Tilt"},
-            "steam": {"name": "Steam"},
-            "wire_input_alert": {"name": "Wire input alert"},
-            "tamper": {"name": "Case tamper"},
-            "connectivity": {"name": "Connectivity"},
-            "problem": {"name": "Device problem"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Mains power"}
+            "monitoring": {
+                "name": "CRA connection"
+            },
+            "gsm": {
+                "name": "Cellular connected"
+            },
+            "lid": {
+                "name": "Lid opened"
+            },
+            "ext_contact": {
+                "name": "External contact broken"
+            },
+            "ext_alert": {
+                "name": "External contact alert"
+            },
+            "drilling": {
+                "name": "Case drilling"
+            },
+            "anti_mask": {
+                "name": "Anti-masking"
+            },
+            "malfunction": {
+                "name": "Malfunction"
+            },
+            "interference": {
+                "name": "Interference"
+            },
+            "relay_stuck": {
+                "name": "Relay stuck"
+            },
+            "always_active": {
+                "name": "Always active"
+            },
+            "glass_break": {
+                "name": "Glass break"
+            },
+            "vibration": {
+                "name": "Vibration"
+            },
+            "tilt": {
+                "name": "Tilt"
+            },
+            "steam": {
+                "name": "Steam"
+            },
+            "wire_input_alert": {
+                "name": "Wire input alert"
+            },
+            "tamper": {
+                "name": "Case tamper"
+            },
+            "connectivity": {
+                "name": "Connectivity"
+            },
+            "problem": {
+                "name": "Device problem"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Mains power"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "CRA company"},
-            "signal_strength": {"name": "Signal strength"},
-            "mobile_network_type": {"name": "Mobile network type"},
-            "wifi_signal_level": {"name": "Wi-Fi signal level"},
-            "sim_status": {"name": "SIM status"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Connection type"},
-            "wifi_ssid": {"name": "Wi-Fi SSID"},
-            "wifi_ip": {"name": "Wi-Fi IP address"},
-            "ethernet_ip": {"name": "Ethernet IP address"},
-            "ethernet_gateway": {"name": "Ethernet gateway"},
-            "ethernet_dns": {"name": "Ethernet DNS"},
-            "cellular_signal": {"name": "Cellular signal"},
-            "cellular_network": {"name": "Cellular network"}
+            "monitoring_company": {
+                "name": "CRA company"
+            },
+            "signal_strength": {
+                "name": "Signal strength"
+            },
+            "mobile_network_type": {
+                "name": "Mobile network type"
+            },
+            "wifi_signal_level": {
+                "name": "Wi-Fi signal level"
+            },
+            "sim_status": {
+                "name": "SIM status"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Connection type"
+            },
+            "wifi_ssid": {
+                "name": "Wi-Fi SSID"
+            },
+            "wifi_ip": {
+                "name": "Wi-Fi IP address"
+            },
+            "ethernet_ip": {
+                "name": "Ethernet IP address"
+            },
+            "ethernet_gateway": {
+                "name": "Ethernet gateway"
+            },
+            "ethernet_dns": {
+                "name": "Ethernet DNS"
+            },
+            "cellular_signal": {
+                "name": "Cellular signal"
+            },
+            "cellular_network": {
+                "name": "Cellular network"
+            }
         },
-        "switch": {"channel_1": {"name": "Channel 1"}, "channel_2": {"name": "Channel 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Channel 1"
+            },
+            "channel_2": {
+                "name": "Channel 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -13,12 +13,16 @@
             "2fa": {
                 "title": "Autenticacion de dos factores",
                 "description": "Introduce el codigo de 6 digitos de tu app de autenticacion.",
-                "data": {"totp_code": "Codigo TOTP"}
+                "data": {
+                    "totp_code": "Codigo TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Seleccionar espacios",
                 "description": "Elige que espacios (hubs) anadir.",
-                "data": {"spaces": "Espacios"}
+                "data": {
+                    "spaces": "Espacios"
+                }
             },
             "reconfigure": {
                 "title": "Reconfigurar Aegis for Ajax",
@@ -32,17 +36,23 @@
             "reconfigure_2fa": {
                 "title": "Autenticacion de dos factores",
                 "description": "Introduce el codigo de 6 digitos de tu app de autenticacion.",
-                "data": {"totp_code": "Codigo TOTP"}
+                "data": {
+                    "totp_code": "Codigo TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Reautenticar Aegis for Ajax",
                 "description": "La sesion de Ajax para {email} ya no es valida. Introduce la contrasena actual de la cuenta para restaurar el acceso.",
-                "data": {"password": "Contrasena"}
+                "data": {
+                    "password": "Contrasena"
+                }
             },
             "reauth_2fa": {
                 "title": "Autenticacion de dos factores",
                 "description": "Introduce el codigo de 6 digitos de tu app de autenticacion.",
-                "data": {"totp_code": "Codigo TOTP"}
+                "data": {
+                    "totp_code": "Codigo TOTP"
+                }
             }
         },
         "error": {
@@ -170,7 +180,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Capturar foto"}},
+        "button": {
+            "capture_photo": {
+                "name": "Capturar foto"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Evento de seguridad",
@@ -186,6 +200,7 @@
                             "disarm": "Desarmado",
                             "disarm_night": "Desarmado nocturno",
                             "door_open": "Puerta abierta",
+                            "doorbell_pressed": "Timbre pulsado",
                             "fire": "Fuego",
                             "flood": "Inundacion",
                             "glass_break": "Rotura de cristal",
@@ -199,45 +214,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Conexion CRA"},
-            "gsm": {"name": "Celular conectado"},
-            "lid": {"name": "Tapa abierta"},
-            "ext_contact": {"name": "Contacto externo roto"},
-            "ext_alert": {"name": "Alerta contacto externo"},
-            "drilling": {"name": "Taladrado de caja"},
-            "anti_mask": {"name": "Anti-enmascaramiento"},
-            "malfunction": {"name": "Averia"},
-            "interference": {"name": "Interferencia"},
-            "relay_stuck": {"name": "Rele bloqueado"},
-            "always_active": {"name": "Siempre activo"},
-            "glass_break": {"name": "Rotura de cristal"},
-            "vibration": {"name": "Vibración"},
-            "tilt": {"name": "Inclinación"},
-            "steam": {"name": "Vapor"},
-            "wire_input_alert": {"name": "Alerta de entrada cableada"},
-            "tamper": {"name": "Manipulación de carcasa"},
-            "connectivity": {"name": "Conectividad"},
-            "problem": {"name": "Problema del dispositivo"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Alimentación externa"}
+            "monitoring": {
+                "name": "Conexion CRA"
+            },
+            "gsm": {
+                "name": "Celular conectado"
+            },
+            "lid": {
+                "name": "Tapa abierta"
+            },
+            "ext_contact": {
+                "name": "Contacto externo roto"
+            },
+            "ext_alert": {
+                "name": "Alerta contacto externo"
+            },
+            "drilling": {
+                "name": "Taladrado de caja"
+            },
+            "anti_mask": {
+                "name": "Anti-enmascaramiento"
+            },
+            "malfunction": {
+                "name": "Averia"
+            },
+            "interference": {
+                "name": "Interferencia"
+            },
+            "relay_stuck": {
+                "name": "Rele bloqueado"
+            },
+            "always_active": {
+                "name": "Siempre activo"
+            },
+            "glass_break": {
+                "name": "Rotura de cristal"
+            },
+            "vibration": {
+                "name": "Vibración"
+            },
+            "tilt": {
+                "name": "Inclinación"
+            },
+            "steam": {
+                "name": "Vapor"
+            },
+            "wire_input_alert": {
+                "name": "Alerta de entrada cableada"
+            },
+            "tamper": {
+                "name": "Manipulación de carcasa"
+            },
+            "connectivity": {
+                "name": "Conectividad"
+            },
+            "problem": {
+                "name": "Problema del dispositivo"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Alimentación externa"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Compañía CRA"},
-            "signal_strength": {"name": "Intensidad de señal"},
-            "mobile_network_type": {"name": "Tipo de red móvil"},
-            "wifi_signal_level": {"name": "Nivel de señal Wi-Fi"},
-            "sim_status": {"name": "Estado SIM"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Tipo de conexión"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "IP Wi-Fi"},
-            "ethernet_ip": {"name": "IP Ethernet"},
-            "ethernet_gateway": {"name": "Puerta de enlace Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Señal celular"},
-            "cellular_network": {"name": "Red celular"}
+            "monitoring_company": {
+                "name": "Compañía CRA"
+            },
+            "signal_strength": {
+                "name": "Intensidad de señal"
+            },
+            "mobile_network_type": {
+                "name": "Tipo de red móvil"
+            },
+            "wifi_signal_level": {
+                "name": "Nivel de señal Wi-Fi"
+            },
+            "sim_status": {
+                "name": "Estado SIM"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Tipo de conexión"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "IP Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "IP Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Puerta de enlace Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Señal celular"
+            },
+            "cellular_network": {
+                "name": "Red celular"
+            }
         },
-        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Canal 1"
+            },
+            "channel_2": {
+                "name": "Canal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -13,12 +13,16 @@
             "2fa": {
                 "title": "Authentification à deux facteurs",
                 "description": "Entrez le code à 6 chiffres de votre application d'authentification.",
-                "data": {"totp_code": "Code TOTP"}
+                "data": {
+                    "totp_code": "Code TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Sélectionner les espaces",
                 "description": "Choisissez les espaces (hubs) à ajouter.",
-                "data": {"spaces": "Espaces"}
+                "data": {
+                    "spaces": "Espaces"
+                }
             },
             "reconfigure": {
                 "title": "Reconfigurer Aegis for Ajax",
@@ -32,17 +36,23 @@
             "reconfigure_2fa": {
                 "title": "Authentification à deux facteurs",
                 "description": "Entrez le code à 6 chiffres de votre application d'authentification.",
-                "data": {"totp_code": "Code TOTP"}
+                "data": {
+                    "totp_code": "Code TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Réauthentifier Aegis for Ajax",
                 "description": "Votre session Ajax pour {email} n'est plus valide. Saisissez le mot de passe actuel du compte pour restaurer l'accès.",
-                "data": {"password": "Mot de passe"}
+                "data": {
+                    "password": "Mot de passe"
+                }
             },
             "reauth_2fa": {
                 "title": "Authentification à deux facteurs",
                 "description": "Saisissez le code à 6 chiffres de votre application d'authentification.",
-                "data": {"totp_code": "Code TOTP"}
+                "data": {
+                    "totp_code": "Code TOTP"
+                }
             }
         },
         "error": {
@@ -154,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Prendre une photo"}},
+        "button": {
+            "capture_photo": {
+                "name": "Prendre une photo"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Événement de sécurité",
@@ -170,6 +184,7 @@
                             "disarm": "Désarmé",
                             "disarm_night": "Mode nuit désactivé",
                             "door_open": "Porte ouverte",
+                            "doorbell_pressed": "Sonnette appuyée",
                             "fire": "Incendie",
                             "flood": "Inondation",
                             "glass_break": "Bris de verre",
@@ -183,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Connexion télésurveillance"},
-            "gsm": {"name": "Réseau cellulaire connecté"},
-            "lid": {"name": "Couvercle ouvert"},
-            "ext_contact": {"name": "Contact externe ouvert"},
-            "ext_alert": {"name": "Alerte contact externe"},
-            "drilling": {"name": "Perçage du boîtier détecté"},
-            "anti_mask": {"name": "Anti-masquage"},
-            "malfunction": {"name": "Dysfonctionnement"},
-            "interference": {"name": "Interférence"},
-            "relay_stuck": {"name": "Relais bloqué"},
-            "always_active": {"name": "Toujours actif"},
-            "glass_break": {"name": "Bris de verre"},
-            "vibration": {"name": "Vibration"},
-            "tilt": {"name": "Inclinaison"},
-            "steam": {"name": "Vapeur"},
-            "wire_input_alert": {"name": "Alerte d'entrée filaire"},
-            "tamper": {"name": "Sabotage du boîtier"},
-            "connectivity": {"name": "Connectivité"},
-            "problem": {"name": "Problème appareil"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Alimentation secteur"}
+            "monitoring": {
+                "name": "Connexion télésurveillance"
+            },
+            "gsm": {
+                "name": "Réseau cellulaire connecté"
+            },
+            "lid": {
+                "name": "Couvercle ouvert"
+            },
+            "ext_contact": {
+                "name": "Contact externe ouvert"
+            },
+            "ext_alert": {
+                "name": "Alerte contact externe"
+            },
+            "drilling": {
+                "name": "Perçage du boîtier détecté"
+            },
+            "anti_mask": {
+                "name": "Anti-masquage"
+            },
+            "malfunction": {
+                "name": "Dysfonctionnement"
+            },
+            "interference": {
+                "name": "Interférence"
+            },
+            "relay_stuck": {
+                "name": "Relais bloqué"
+            },
+            "always_active": {
+                "name": "Toujours actif"
+            },
+            "glass_break": {
+                "name": "Bris de verre"
+            },
+            "vibration": {
+                "name": "Vibration"
+            },
+            "tilt": {
+                "name": "Inclinaison"
+            },
+            "steam": {
+                "name": "Vapeur"
+            },
+            "wire_input_alert": {
+                "name": "Alerte d'entrée filaire"
+            },
+            "tamper": {
+                "name": "Sabotage du boîtier"
+            },
+            "connectivity": {
+                "name": "Connectivité"
+            },
+            "problem": {
+                "name": "Problème appareil"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Alimentation secteur"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Société de télésurveillance"},
-            "signal_strength": {"name": "Intensité du signal"},
-            "mobile_network_type": {"name": "Type de réseau mobile"},
-            "wifi_signal_level": {"name": "Niveau de signal Wi-Fi"},
-            "sim_status": {"name": "État de la carte SIM"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Type de connexion"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "Adresse IP Wi-Fi"},
-            "ethernet_ip": {"name": "Adresse IP Ethernet"},
-            "ethernet_gateway": {"name": "Passerelle Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Signal cellulaire"},
-            "cellular_network": {"name": "Réseau cellulaire"}
+            "monitoring_company": {
+                "name": "Société de télésurveillance"
+            },
+            "signal_strength": {
+                "name": "Intensité du signal"
+            },
+            "mobile_network_type": {
+                "name": "Type de réseau mobile"
+            },
+            "wifi_signal_level": {
+                "name": "Niveau de signal Wi-Fi"
+            },
+            "sim_status": {
+                "name": "État de la carte SIM"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Type de connexion"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "Adresse IP Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "Adresse IP Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Passerelle Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Signal cellulaire"
+            },
+            "cellular_network": {
+                "name": "Réseau cellulaire"
+            }
         },
-        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Canal 1"
+            },
+            "channel_2": {
+                "name": "Canal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -13,32 +13,46 @@
             "2fa": {
                 "title": "Autenticazione a due fattori",
                 "description": "Inserisci il codice a 6 cifre dalla tua app di autenticazione.",
-                "data": {"totp_code": "Codice TOTP"}
+                "data": {
+                    "totp_code": "Codice TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Seleziona spazi",
                 "description": "Scegli quali spazi (hub) aggiungere.",
-                "data": {"spaces": "Spazi"}
+                "data": {
+                    "spaces": "Spazi"
+                }
             },
             "reconfigure": {
                 "title": "Riconfigura Aegis for Ajax",
                 "description": "Aggiorna le credenziali dell'account.",
-                "data": {"email": "E-mail", "password": "Password", "app_label": "Etichetta app"}
+                "data": {
+                    "email": "E-mail",
+                    "password": "Password",
+                    "app_label": "Etichetta app"
+                }
             },
             "reconfigure_2fa": {
                 "title": "Autenticazione a due fattori",
                 "description": "Inserisci il codice a 6 cifre dalla tua app di autenticazione.",
-                "data": {"totp_code": "Codice TOTP"}
+                "data": {
+                    "totp_code": "Codice TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Riautentica Aegis for Ajax",
                 "description": "La sessione Ajax per {email} non è più valida. Inserisci la password attuale dell'account per ripristinare l'accesso.",
-                "data": {"password": "Password"}
+                "data": {
+                    "password": "Password"
+                }
             },
             "reauth_2fa": {
                 "title": "Autenticazione a due fattori",
                 "description": "Inserisci il codice a 6 cifre dell'app di autenticazione.",
-                "data": {"totp_code": "Codice TOTP"}
+                "data": {
+                    "totp_code": "Codice TOTP"
+                }
             }
         },
         "error": {
@@ -150,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Scatta foto"}},
+        "button": {
+            "capture_photo": {
+                "name": "Scatta foto"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Evento di sicurezza",
@@ -166,6 +184,7 @@
                             "disarm": "Disinserito",
                             "disarm_night": "Modo notte disattivato",
                             "door_open": "Porta aperta",
+                            "doorbell_pressed": "Campanello premuto",
                             "fire": "Incendio",
                             "flood": "Allagamento",
                             "glass_break": "Rottura vetro",
@@ -179,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Connessione istituto di vigilanza"},
-            "gsm": {"name": "Rete cellulare connessa"},
-            "lid": {"name": "Coperchio aperto"},
-            "ext_contact": {"name": "Contatto esterno aperto"},
-            "ext_alert": {"name": "Allarme contatto esterno"},
-            "drilling": {"name": "Perforazione del contenitore"},
-            "anti_mask": {"name": "Anti-mascheramento"},
-            "malfunction": {"name": "Malfunzionamento"},
-            "interference": {"name": "Interferenza"},
-            "relay_stuck": {"name": "Relè bloccato"},
-            "always_active": {"name": "Sempre attivo"},
-            "glass_break": {"name": "Rottura vetro"},
-            "vibration": {"name": "Vibrazione"},
-            "tilt": {"name": "Inclinazione"},
-            "steam": {"name": "Vapore"},
-            "wire_input_alert": {"name": "Allarme ingresso cablato"},
-            "tamper": {"name": "Manomissione involucro"},
-            "connectivity": {"name": "Connettività"},
-            "problem": {"name": "Problema dispositivo"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Alimentazione di rete"}
+            "monitoring": {
+                "name": "Connessione istituto di vigilanza"
+            },
+            "gsm": {
+                "name": "Rete cellulare connessa"
+            },
+            "lid": {
+                "name": "Coperchio aperto"
+            },
+            "ext_contact": {
+                "name": "Contatto esterno aperto"
+            },
+            "ext_alert": {
+                "name": "Allarme contatto esterno"
+            },
+            "drilling": {
+                "name": "Perforazione del contenitore"
+            },
+            "anti_mask": {
+                "name": "Anti-mascheramento"
+            },
+            "malfunction": {
+                "name": "Malfunzionamento"
+            },
+            "interference": {
+                "name": "Interferenza"
+            },
+            "relay_stuck": {
+                "name": "Relè bloccato"
+            },
+            "always_active": {
+                "name": "Sempre attivo"
+            },
+            "glass_break": {
+                "name": "Rottura vetro"
+            },
+            "vibration": {
+                "name": "Vibrazione"
+            },
+            "tilt": {
+                "name": "Inclinazione"
+            },
+            "steam": {
+                "name": "Vapore"
+            },
+            "wire_input_alert": {
+                "name": "Allarme ingresso cablato"
+            },
+            "tamper": {
+                "name": "Manomissione involucro"
+            },
+            "connectivity": {
+                "name": "Connettività"
+            },
+            "problem": {
+                "name": "Problema dispositivo"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Alimentazione di rete"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Società di vigilanza"},
-            "signal_strength": {"name": "Intensità del segnale"},
-            "mobile_network_type": {"name": "Tipo di rete mobile"},
-            "wifi_signal_level": {"name": "Livello segnale Wi-Fi"},
-            "sim_status": {"name": "Stato SIM"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Tipo connessione"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "Indirizzo IP Wi-Fi"},
-            "ethernet_ip": {"name": "Indirizzo IP Ethernet"},
-            "ethernet_gateway": {"name": "Gateway Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Segnale cellulare"},
-            "cellular_network": {"name": "Rete cellulare"}
+            "monitoring_company": {
+                "name": "Società di vigilanza"
+            },
+            "signal_strength": {
+                "name": "Intensità del segnale"
+            },
+            "mobile_network_type": {
+                "name": "Tipo di rete mobile"
+            },
+            "wifi_signal_level": {
+                "name": "Livello segnale Wi-Fi"
+            },
+            "sim_status": {
+                "name": "Stato SIM"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Tipo connessione"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "Indirizzo IP Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "Indirizzo IP Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Gateway Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Segnale cellulare"
+            },
+            "cellular_network": {
+                "name": "Rete cellulare"
+            }
         },
-        "switch": {"channel_1": {"name": "Canale 1"}, "channel_2": {"name": "Canale 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Canale 1"
+            },
+            "channel_2": {
+                "name": "Canale 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -13,32 +13,46 @@
             "2fa": {
                 "title": "Twee-factor-authenticatie",
                 "description": "Voer de 6-cijferige code in van uw authenticator-app.",
-                "data": {"totp_code": "TOTP-code"}
+                "data": {
+                    "totp_code": "TOTP-code"
+                }
             },
             "select_spaces": {
                 "title": "Selecteer ruimtes",
                 "description": "Kies welke ruimtes (hubs) u wilt toevoegen.",
-                "data": {"spaces": "Ruimtes"}
+                "data": {
+                    "spaces": "Ruimtes"
+                }
             },
             "reconfigure": {
                 "title": "Aegis for Ajax herconfigureren",
                 "description": "Werk uw accountgegevens bij.",
-                "data": {"email": "E-mail", "password": "Wachtwoord", "app_label": "App-label"}
+                "data": {
+                    "email": "E-mail",
+                    "password": "Wachtwoord",
+                    "app_label": "App-label"
+                }
             },
             "reconfigure_2fa": {
                 "title": "Twee-factor-authenticatie",
                 "description": "Voer de 6-cijferige code in van uw authenticator-app.",
-                "data": {"totp_code": "TOTP-code"}
+                "data": {
+                    "totp_code": "TOTP-code"
+                }
             },
             "reauth_confirm": {
                 "title": "Aegis for Ajax opnieuw authenticeren",
                 "description": "Je Ajax-sessie voor {email} is niet langer geldig. Voer het huidige accountwachtwoord in om de toegang te herstellen.",
-                "data": {"password": "Wachtwoord"}
+                "data": {
+                    "password": "Wachtwoord"
+                }
             },
             "reauth_2fa": {
                 "title": "Tweefactorauthenticatie",
                 "description": "Voer de 6-cijferige code uit je authenticator-app in.",
-                "data": {"totp_code": "TOTP-code"}
+                "data": {
+                    "totp_code": "TOTP-code"
+                }
             }
         },
         "error": {
@@ -150,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Foto maken"}},
+        "button": {
+            "capture_photo": {
+                "name": "Foto maken"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Beveiligingsgebeurtenis",
@@ -166,6 +184,7 @@
                             "disarm": "Uitgeschakeld",
                             "disarm_night": "Nachtmodus uitgeschakeld",
                             "door_open": "Deur geopend",
+                            "doorbell_pressed": "Bel ingedrukt",
                             "fire": "Brand",
                             "flood": "Overstroming",
                             "glass_break": "Glasbreuk",
@@ -179,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Verbinding meldkamer"},
-            "gsm": {"name": "Mobiel netwerk verbonden"},
-            "lid": {"name": "Deksel geopend"},
-            "ext_contact": {"name": "Extern contact verbroken"},
-            "ext_alert": {"name": "Alarm extern contact"},
-            "drilling": {"name": "Boren in behuizing"},
-            "anti_mask": {"name": "Anti-masking"},
-            "malfunction": {"name": "Storing"},
-            "interference": {"name": "Interferentie"},
-            "relay_stuck": {"name": "Relais geblokkeerd"},
-            "always_active": {"name": "Altijd actief"},
-            "glass_break": {"name": "Glasbreuk"},
-            "vibration": {"name": "Vibratie"},
-            "tilt": {"name": "Kanteling"},
-            "steam": {"name": "Stoom"},
-            "wire_input_alert": {"name": "Bedrade ingang alarm"},
-            "tamper": {"name": "Behuizing sabotage"},
-            "connectivity": {"name": "Verbinding"},
-            "problem": {"name": "Apparaatprobleem"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Netstroom"}
+            "monitoring": {
+                "name": "Verbinding meldkamer"
+            },
+            "gsm": {
+                "name": "Mobiel netwerk verbonden"
+            },
+            "lid": {
+                "name": "Deksel geopend"
+            },
+            "ext_contact": {
+                "name": "Extern contact verbroken"
+            },
+            "ext_alert": {
+                "name": "Alarm extern contact"
+            },
+            "drilling": {
+                "name": "Boren in behuizing"
+            },
+            "anti_mask": {
+                "name": "Anti-masking"
+            },
+            "malfunction": {
+                "name": "Storing"
+            },
+            "interference": {
+                "name": "Interferentie"
+            },
+            "relay_stuck": {
+                "name": "Relais geblokkeerd"
+            },
+            "always_active": {
+                "name": "Altijd actief"
+            },
+            "glass_break": {
+                "name": "Glasbreuk"
+            },
+            "vibration": {
+                "name": "Vibratie"
+            },
+            "tilt": {
+                "name": "Kanteling"
+            },
+            "steam": {
+                "name": "Stoom"
+            },
+            "wire_input_alert": {
+                "name": "Bedrade ingang alarm"
+            },
+            "tamper": {
+                "name": "Behuizing sabotage"
+            },
+            "connectivity": {
+                "name": "Verbinding"
+            },
+            "problem": {
+                "name": "Apparaatprobleem"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Netstroom"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Meldkamerbedrijf"},
-            "signal_strength": {"name": "Signaalsterkte"},
-            "mobile_network_type": {"name": "Mobiel netwerktype"},
-            "wifi_signal_level": {"name": "Wi-Fi-signaalsterkte"},
-            "sim_status": {"name": "SIM-status"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Verbindingstype"},
-            "wifi_ssid": {"name": "Wi-Fi-SSID"},
-            "wifi_ip": {"name": "Wi-Fi-IP-adres"},
-            "ethernet_ip": {"name": "Ethernet IP-adres"},
-            "ethernet_gateway": {"name": "Ethernet-gateway"},
-            "ethernet_dns": {"name": "Ethernet-DNS"},
-            "cellular_signal": {"name": "Mobiel signaal"},
-            "cellular_network": {"name": "Mobiel netwerk"}
+            "monitoring_company": {
+                "name": "Meldkamerbedrijf"
+            },
+            "signal_strength": {
+                "name": "Signaalsterkte"
+            },
+            "mobile_network_type": {
+                "name": "Mobiel netwerktype"
+            },
+            "wifi_signal_level": {
+                "name": "Wi-Fi-signaalsterkte"
+            },
+            "sim_status": {
+                "name": "SIM-status"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Verbindingstype"
+            },
+            "wifi_ssid": {
+                "name": "Wi-Fi-SSID"
+            },
+            "wifi_ip": {
+                "name": "Wi-Fi-IP-adres"
+            },
+            "ethernet_ip": {
+                "name": "Ethernet IP-adres"
+            },
+            "ethernet_gateway": {
+                "name": "Ethernet-gateway"
+            },
+            "ethernet_dns": {
+                "name": "Ethernet-DNS"
+            },
+            "cellular_signal": {
+                "name": "Mobiel signaal"
+            },
+            "cellular_network": {
+                "name": "Mobiel netwerk"
+            }
         },
-        "switch": {"channel_1": {"name": "Kanaal 1"}, "channel_2": {"name": "Kanaal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Kanaal 1"
+            },
+            "channel_2": {
+                "name": "Kanaal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -13,32 +13,46 @@
             "2fa": {
                 "title": "Uwierzytelnianie dwuskładnikowe",
                 "description": "Wprowadź 6-cyfrowy kod z aplikacji uwierzytelniającej.",
-                "data": {"totp_code": "Kod TOTP"}
+                "data": {
+                    "totp_code": "Kod TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Wybierz przestrzenie",
                 "description": "Wybierz przestrzenie (huby) do dodania.",
-                "data": {"spaces": "Przestrzenie"}
+                "data": {
+                    "spaces": "Przestrzenie"
+                }
             },
             "reconfigure": {
                 "title": "Rekonfiguracja Aegis for Ajax",
                 "description": "Zaktualizuj dane logowania.",
-                "data": {"email": "E-mail", "password": "Hasło", "app_label": "Etykieta aplikacji"}
+                "data": {
+                    "email": "E-mail",
+                    "password": "Hasło",
+                    "app_label": "Etykieta aplikacji"
+                }
             },
             "reconfigure_2fa": {
                 "title": "Uwierzytelnianie dwuskładnikowe",
                 "description": "Wprowadź 6-cyfrowy kod z aplikacji uwierzytelniającej.",
-                "data": {"totp_code": "Kod TOTP"}
+                "data": {
+                    "totp_code": "Kod TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Ponowne uwierzytelnienie Aegis for Ajax",
                 "description": "Twoja sesja Ajax dla {email} nie jest już ważna. Wprowadź aktualne hasło konta, aby przywrócić dostęp.",
-                "data": {"password": "Hasło"}
+                "data": {
+                    "password": "Hasło"
+                }
             },
             "reauth_2fa": {
                 "title": "Uwierzytelnianie dwuskładnikowe",
                 "description": "Wprowadź 6-cyfrowy kod z aplikacji uwierzytelniającej.",
-                "data": {"totp_code": "Kod TOTP"}
+                "data": {
+                    "totp_code": "Kod TOTP"
+                }
             }
         },
         "error": {
@@ -150,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Zrób zdjęcie"}},
+        "button": {
+            "capture_photo": {
+                "name": "Zrób zdjęcie"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Zdarzenie bezpieczeństwa",
@@ -166,6 +184,7 @@
                             "disarm": "Rozbrojony",
                             "disarm_night": "Tryb nocny wyłączony",
                             "door_open": "Drzwi otwarte",
+                            "doorbell_pressed": "Naciśnięto dzwonek",
                             "fire": "Pożar",
                             "flood": "Zalanie",
                             "glass_break": "Rozbicie szyby",
@@ -179,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Połączenie z centrum monitoringu"},
-            "gsm": {"name": "Sieć komórkowa"},
-            "lid": {"name": "Pokrywa otwarta"},
-            "ext_contact": {"name": "Zewnętrzny styk przerwany"},
-            "ext_alert": {"name": "Alarm zewnętrznego styku"},
-            "drilling": {"name": "Wiercenie obudowy"},
-            "anti_mask": {"name": "Antymaskowanie"},
-            "malfunction": {"name": "Usterka"},
-            "interference": {"name": "Zakłócenia"},
-            "relay_stuck": {"name": "Przekaźnik zablokowany"},
-            "always_active": {"name": "Zawsze aktywny"},
-            "glass_break": {"name": "Rozbicie szyby"},
-            "vibration": {"name": "Wibracja"},
-            "tilt": {"name": "Przechylenie"},
-            "steam": {"name": "Para"},
-            "wire_input_alert": {"name": "Alarm wejścia przewodowego"},
-            "tamper": {"name": "Sabotaż obudowy"},
-            "connectivity": {"name": "Łączność"},
-            "problem": {"name": "Problem urządzenia"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Zasilanie sieciowe"}
+            "monitoring": {
+                "name": "Połączenie z centrum monitoringu"
+            },
+            "gsm": {
+                "name": "Sieć komórkowa"
+            },
+            "lid": {
+                "name": "Pokrywa otwarta"
+            },
+            "ext_contact": {
+                "name": "Zewnętrzny styk przerwany"
+            },
+            "ext_alert": {
+                "name": "Alarm zewnętrznego styku"
+            },
+            "drilling": {
+                "name": "Wiercenie obudowy"
+            },
+            "anti_mask": {
+                "name": "Antymaskowanie"
+            },
+            "malfunction": {
+                "name": "Usterka"
+            },
+            "interference": {
+                "name": "Zakłócenia"
+            },
+            "relay_stuck": {
+                "name": "Przekaźnik zablokowany"
+            },
+            "always_active": {
+                "name": "Zawsze aktywny"
+            },
+            "glass_break": {
+                "name": "Rozbicie szyby"
+            },
+            "vibration": {
+                "name": "Wibracja"
+            },
+            "tilt": {
+                "name": "Przechylenie"
+            },
+            "steam": {
+                "name": "Para"
+            },
+            "wire_input_alert": {
+                "name": "Alarm wejścia przewodowego"
+            },
+            "tamper": {
+                "name": "Sabotaż obudowy"
+            },
+            "connectivity": {
+                "name": "Łączność"
+            },
+            "problem": {
+                "name": "Problem urządzenia"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Zasilanie sieciowe"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Firma monitorująca"},
-            "signal_strength": {"name": "Siła sygnału"},
-            "mobile_network_type": {"name": "Typ sieci komórkowej"},
-            "wifi_signal_level": {"name": "Poziom sygnału Wi-Fi"},
-            "sim_status": {"name": "Status karty SIM"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Typ połączenia"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "Adres IP Wi-Fi"},
-            "ethernet_ip": {"name": "Adres IP Ethernet"},
-            "ethernet_gateway": {"name": "Brama Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Sygnał komórkowy"},
-            "cellular_network": {"name": "Sieć komórkowa"}
+            "monitoring_company": {
+                "name": "Firma monitorująca"
+            },
+            "signal_strength": {
+                "name": "Siła sygnału"
+            },
+            "mobile_network_type": {
+                "name": "Typ sieci komórkowej"
+            },
+            "wifi_signal_level": {
+                "name": "Poziom sygnału Wi-Fi"
+            },
+            "sim_status": {
+                "name": "Status karty SIM"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Typ połączenia"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "Adres IP Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "Adres IP Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Brama Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Sygnał komórkowy"
+            },
+            "cellular_network": {
+                "name": "Sieć komórkowa"
+            }
         },
-        "switch": {"channel_1": {"name": "Kanał 1"}, "channel_2": {"name": "Kanał 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Kanał 1"
+            },
+            "channel_2": {
+                "name": "Kanał 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -13,12 +13,16 @@
             "2fa": {
                 "title": "Autenticação de dois fatores",
                 "description": "Insira o código de 6 dígitos do seu aplicativo autenticador.",
-                "data": {"totp_code": "Código TOTP"}
+                "data": {
+                    "totp_code": "Código TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Selecionar espaços",
                 "description": "Escolha quais espaços (hubs) adicionar.",
-                "data": {"spaces": "Espaços"}
+                "data": {
+                    "spaces": "Espaços"
+                }
             },
             "reconfigure": {
                 "title": "Reconfigurar Aegis for Ajax",
@@ -32,17 +36,23 @@
             "reconfigure_2fa": {
                 "title": "Autenticação de dois fatores",
                 "description": "Insira o código de 6 dígitos do seu aplicativo autenticador.",
-                "data": {"totp_code": "Código TOTP"}
+                "data": {
+                    "totp_code": "Código TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Reautenticar Aegis for Ajax",
                 "description": "Sua sessão do Ajax para {email} não é mais válida. Digite a senha atual da conta para restaurar o acesso.",
-                "data": {"password": "Senha"}
+                "data": {
+                    "password": "Senha"
+                }
             },
             "reauth_2fa": {
                 "title": "Autenticação de dois fatores",
                 "description": "Digite o código de 6 dígitos do seu app de autenticação.",
-                "data": {"totp_code": "Código TOTP"}
+                "data": {
+                    "totp_code": "Código TOTP"
+                }
             }
         },
         "error": {
@@ -154,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Tirar foto"}},
+        "button": {
+            "capture_photo": {
+                "name": "Tirar foto"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Evento de segurança",
@@ -170,6 +184,7 @@
                             "disarm": "Desarmado",
                             "disarm_night": "Modo noturno desativado",
                             "door_open": "Porta aberta",
+                            "doorbell_pressed": "Campainha tocada",
                             "fire": "Incêndio",
                             "flood": "Inundação",
                             "glass_break": "Quebra de vidro",
@@ -183,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Conexão com central de monitoramento"},
-            "gsm": {"name": "Rede celular conectada"},
-            "lid": {"name": "Tampa aberta"},
-            "ext_contact": {"name": "Contato externo aberto"},
-            "ext_alert": {"name": "Alerta de contato externo"},
-            "drilling": {"name": "Perfuração da caixa detectada"},
-            "anti_mask": {"name": "Anti-mascaramento"},
-            "malfunction": {"name": "Falha"},
-            "interference": {"name": "Interferência"},
-            "relay_stuck": {"name": "Relé preso"},
-            "always_active": {"name": "Sempre ativo"},
-            "glass_break": {"name": "Quebra de vidro"},
-            "vibration": {"name": "Vibração"},
-            "tilt": {"name": "Inclinação"},
-            "steam": {"name": "Vapor"},
-            "wire_input_alert": {"name": "Alerta de entrada com fio"},
-            "tamper": {"name": "Violação da caixa"},
-            "connectivity": {"name": "Conectividade"},
-            "problem": {"name": "Problema do dispositivo"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Energia externa"}
+            "monitoring": {
+                "name": "Conexão com central de monitoramento"
+            },
+            "gsm": {
+                "name": "Rede celular conectada"
+            },
+            "lid": {
+                "name": "Tampa aberta"
+            },
+            "ext_contact": {
+                "name": "Contato externo aberto"
+            },
+            "ext_alert": {
+                "name": "Alerta de contato externo"
+            },
+            "drilling": {
+                "name": "Perfuração da caixa detectada"
+            },
+            "anti_mask": {
+                "name": "Anti-mascaramento"
+            },
+            "malfunction": {
+                "name": "Falha"
+            },
+            "interference": {
+                "name": "Interferência"
+            },
+            "relay_stuck": {
+                "name": "Relé preso"
+            },
+            "always_active": {
+                "name": "Sempre ativo"
+            },
+            "glass_break": {
+                "name": "Quebra de vidro"
+            },
+            "vibration": {
+                "name": "Vibração"
+            },
+            "tilt": {
+                "name": "Inclinação"
+            },
+            "steam": {
+                "name": "Vapor"
+            },
+            "wire_input_alert": {
+                "name": "Alerta de entrada com fio"
+            },
+            "tamper": {
+                "name": "Violação da caixa"
+            },
+            "connectivity": {
+                "name": "Conectividade"
+            },
+            "problem": {
+                "name": "Problema do dispositivo"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Energia externa"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Empresa da central de monitoramento"},
-            "signal_strength": {"name": "Intensidade do sinal"},
-            "mobile_network_type": {"name": "Tipo de rede móvel"},
-            "wifi_signal_level": {"name": "Nível de sinal Wi-Fi"},
-            "sim_status": {"name": "Status do SIM"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Tipo de conexão"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "Endereço IP Wi-Fi"},
-            "ethernet_ip": {"name": "Endereço IP Ethernet"},
-            "ethernet_gateway": {"name": "Gateway Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Sinal celular"},
-            "cellular_network": {"name": "Rede celular"}
+            "monitoring_company": {
+                "name": "Empresa da central de monitoramento"
+            },
+            "signal_strength": {
+                "name": "Intensidade do sinal"
+            },
+            "mobile_network_type": {
+                "name": "Tipo de rede móvel"
+            },
+            "wifi_signal_level": {
+                "name": "Nível de sinal Wi-Fi"
+            },
+            "sim_status": {
+                "name": "Status do SIM"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Tipo de conexão"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "Endereço IP Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "Endereço IP Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Gateway Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Sinal celular"
+            },
+            "cellular_network": {
+                "name": "Rede celular"
+            }
         },
-        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Canal 1"
+            },
+            "channel_2": {
+                "name": "Canal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -13,12 +13,16 @@
             "2fa": {
                 "title": "Autenticação de dois fatores",
                 "description": "Introduza o código de 6 dígitos da sua aplicação de autenticação.",
-                "data": {"totp_code": "Código TOTP"}
+                "data": {
+                    "totp_code": "Código TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Selecionar espaços",
                 "description": "Escolha quais os espaços (hubs) a adicionar.",
-                "data": {"spaces": "Espaços"}
+                "data": {
+                    "spaces": "Espaços"
+                }
             },
             "reconfigure": {
                 "title": "Reconfigurar Aegis for Ajax",
@@ -32,17 +36,23 @@
             "reconfigure_2fa": {
                 "title": "Autenticação de dois fatores",
                 "description": "Introduza o código de 6 dígitos da sua aplicação de autenticação.",
-                "data": {"totp_code": "Código TOTP"}
+                "data": {
+                    "totp_code": "Código TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Reautenticar Aegis for Ajax",
                 "description": "A sua sessão Ajax para {email} já não é válida. Introduza a palavra-passe atual da conta para restaurar o acesso.",
-                "data": {"password": "Palavra-passe"}
+                "data": {
+                    "password": "Palavra-passe"
+                }
             },
             "reauth_2fa": {
                 "title": "Autenticação de dois fatores",
                 "description": "Introduza o código de 6 dígitos da sua aplicação de autenticação.",
-                "data": {"totp_code": "Código TOTP"}
+                "data": {
+                    "totp_code": "Código TOTP"
+                }
             }
         },
         "error": {
@@ -154,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Tirar foto"}},
+        "button": {
+            "capture_photo": {
+                "name": "Tirar foto"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Evento de segurança",
@@ -170,6 +184,7 @@
                             "disarm": "Desarmado",
                             "disarm_night": "Modo noturno desativado",
                             "door_open": "Porta aberta",
+                            "doorbell_pressed": "Campainha tocada",
                             "fire": "Incêndio",
                             "flood": "Inundação",
                             "glass_break": "Quebra de vidro",
@@ -183,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Ligação à central de monitorização"},
-            "gsm": {"name": "Rede celular ligada"},
-            "lid": {"name": "Tampa aberta"},
-            "ext_contact": {"name": "Contacto externo interrompido"},
-            "ext_alert": {"name": "Alerta de contacto externo"},
-            "drilling": {"name": "Perfuração da caixa"},
-            "anti_mask": {"name": "Anti-mascaramento"},
-            "malfunction": {"name": "Avaria"},
-            "interference": {"name": "Interferência"},
-            "relay_stuck": {"name": "Relé bloqueado"},
-            "always_active": {"name": "Sempre ativo"},
-            "glass_break": {"name": "Quebra de vidro"},
-            "vibration": {"name": "Vibração"},
-            "tilt": {"name": "Inclinação"},
-            "steam": {"name": "Vapor"},
-            "wire_input_alert": {"name": "Alerta de entrada com fio"},
-            "tamper": {"name": "Violação da caixa"},
-            "connectivity": {"name": "Conectividade"},
-            "problem": {"name": "Problema do dispositivo"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Alimentação externa"}
+            "monitoring": {
+                "name": "Ligação à central de monitorização"
+            },
+            "gsm": {
+                "name": "Rede celular ligada"
+            },
+            "lid": {
+                "name": "Tampa aberta"
+            },
+            "ext_contact": {
+                "name": "Contacto externo interrompido"
+            },
+            "ext_alert": {
+                "name": "Alerta de contacto externo"
+            },
+            "drilling": {
+                "name": "Perfuração da caixa"
+            },
+            "anti_mask": {
+                "name": "Anti-mascaramento"
+            },
+            "malfunction": {
+                "name": "Avaria"
+            },
+            "interference": {
+                "name": "Interferência"
+            },
+            "relay_stuck": {
+                "name": "Relé bloqueado"
+            },
+            "always_active": {
+                "name": "Sempre ativo"
+            },
+            "glass_break": {
+                "name": "Quebra de vidro"
+            },
+            "vibration": {
+                "name": "Vibração"
+            },
+            "tilt": {
+                "name": "Inclinação"
+            },
+            "steam": {
+                "name": "Vapor"
+            },
+            "wire_input_alert": {
+                "name": "Alerta de entrada com fio"
+            },
+            "tamper": {
+                "name": "Violação da caixa"
+            },
+            "connectivity": {
+                "name": "Conectividade"
+            },
+            "problem": {
+                "name": "Problema do dispositivo"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Alimentação externa"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Empresa CRA"},
-            "signal_strength": {"name": "Intensidade do sinal"},
-            "mobile_network_type": {"name": "Tipo de rede móvel"},
-            "wifi_signal_level": {"name": "Nível de sinal Wi-Fi"},
-            "sim_status": {"name": "Estado do SIM"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Tipo de ligação"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "Endereço IP Wi-Fi"},
-            "ethernet_ip": {"name": "Endereço IP Ethernet"},
-            "ethernet_gateway": {"name": "Gateway Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Sinal celular"},
-            "cellular_network": {"name": "Rede celular"}
+            "monitoring_company": {
+                "name": "Empresa CRA"
+            },
+            "signal_strength": {
+                "name": "Intensidade do sinal"
+            },
+            "mobile_network_type": {
+                "name": "Tipo de rede móvel"
+            },
+            "wifi_signal_level": {
+                "name": "Nível de sinal Wi-Fi"
+            },
+            "sim_status": {
+                "name": "Estado do SIM"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Tipo de ligação"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "Endereço IP Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "Endereço IP Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Gateway Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Sinal celular"
+            },
+            "cellular_network": {
+                "name": "Rede celular"
+            }
         },
-        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Canal 1"
+            },
+            "channel_2": {
+                "name": "Canal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -13,12 +13,16 @@
             "2fa": {
                 "title": "Autentificare în doi pași",
                 "description": "Introduceți codul de 6 cifre din aplicația de autentificare.",
-                "data": {"totp_code": "Cod TOTP"}
+                "data": {
+                    "totp_code": "Cod TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Selectați spațiile",
                 "description": "Alegeți ce spații (hub-uri) să adăugați.",
-                "data": {"spaces": "Spații"}
+                "data": {
+                    "spaces": "Spații"
+                }
             },
             "reconfigure": {
                 "title": "Reconfigurare Aegis for Ajax",
@@ -32,17 +36,23 @@
             "reconfigure_2fa": {
                 "title": "Autentificare în doi pași",
                 "description": "Introduceți codul de 6 cifre din aplicația de autentificare.",
-                "data": {"totp_code": "Cod TOTP"}
+                "data": {
+                    "totp_code": "Cod TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Reautentificare Aegis for Ajax",
                 "description": "Sesiunea Ajax pentru {email} nu mai este validă. Introduceți parola curentă a contului pentru a restabili accesul.",
-                "data": {"password": "Parolă"}
+                "data": {
+                    "password": "Parolă"
+                }
             },
             "reauth_2fa": {
                 "title": "Autentificare cu doi factori",
                 "description": "Introduceți codul din 6 cifre din aplicația de autentificare.",
-                "data": {"totp_code": "Cod TOTP"}
+                "data": {
+                    "totp_code": "Cod TOTP"
+                }
             }
         },
         "error": {
@@ -154,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Capturați fotografie"}},
+        "button": {
+            "capture_photo": {
+                "name": "Capturați fotografie"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Eveniment de securitate",
@@ -170,6 +184,7 @@
                             "disarm": "Dezarmat",
                             "disarm_night": "Mod noapte dezactivat",
                             "door_open": "Usa deschisa",
+                            "doorbell_pressed": "Sonerie apăsată",
                             "fire": "Incendiu",
                             "flood": "Inundatie",
                             "glass_break": "Spargere geam",
@@ -183,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Conexiune dispecerat"},
-            "gsm": {"name": "Rețea celulară conectată"},
-            "lid": {"name": "Capac deschis"},
-            "ext_contact": {"name": "Contact extern deschis"},
-            "ext_alert": {"name": "Alertă contact extern"},
-            "drilling": {"name": "Găurire carcasă detectată"},
-            "anti_mask": {"name": "Anti-mascare"},
-            "malfunction": {"name": "Defecțiune"},
-            "interference": {"name": "Interferență"},
-            "relay_stuck": {"name": "Releu blocat"},
-            "always_active": {"name": "Întotdeauna activ"},
-            "glass_break": {"name": "Spargere geam"},
-            "vibration": {"name": "Vibrație"},
-            "tilt": {"name": "Înclinare"},
-            "steam": {"name": "Abur"},
-            "wire_input_alert": {"name": "Alertă intrare cablată"},
-            "tamper": {"name": "Sabotaj carcasă"},
-            "connectivity": {"name": "Conectivitate"},
-            "problem": {"name": "Problemă dispozitiv"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Alimentare rețea"}
+            "monitoring": {
+                "name": "Conexiune dispecerat"
+            },
+            "gsm": {
+                "name": "Rețea celulară conectată"
+            },
+            "lid": {
+                "name": "Capac deschis"
+            },
+            "ext_contact": {
+                "name": "Contact extern deschis"
+            },
+            "ext_alert": {
+                "name": "Alertă contact extern"
+            },
+            "drilling": {
+                "name": "Găurire carcasă detectată"
+            },
+            "anti_mask": {
+                "name": "Anti-mascare"
+            },
+            "malfunction": {
+                "name": "Defecțiune"
+            },
+            "interference": {
+                "name": "Interferență"
+            },
+            "relay_stuck": {
+                "name": "Releu blocat"
+            },
+            "always_active": {
+                "name": "Întotdeauna activ"
+            },
+            "glass_break": {
+                "name": "Spargere geam"
+            },
+            "vibration": {
+                "name": "Vibrație"
+            },
+            "tilt": {
+                "name": "Înclinare"
+            },
+            "steam": {
+                "name": "Abur"
+            },
+            "wire_input_alert": {
+                "name": "Alertă intrare cablată"
+            },
+            "tamper": {
+                "name": "Sabotaj carcasă"
+            },
+            "connectivity": {
+                "name": "Conectivitate"
+            },
+            "problem": {
+                "name": "Problemă dispozitiv"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Alimentare rețea"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Companie de monitorizare"},
-            "signal_strength": {"name": "Puterea semnalului"},
-            "mobile_network_type": {"name": "Tip rețea mobilă"},
-            "wifi_signal_level": {"name": "Nivel semnal Wi-Fi"},
-            "sim_status": {"name": "Status SIM"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Tip conexiune"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "Adresă IP Wi-Fi"},
-            "ethernet_ip": {"name": "Adresă IP Ethernet"},
-            "ethernet_gateway": {"name": "Gateway Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Semnal celular"},
-            "cellular_network": {"name": "Rețea celulară"}
+            "monitoring_company": {
+                "name": "Companie de monitorizare"
+            },
+            "signal_strength": {
+                "name": "Puterea semnalului"
+            },
+            "mobile_network_type": {
+                "name": "Tip rețea mobilă"
+            },
+            "wifi_signal_level": {
+                "name": "Nivel semnal Wi-Fi"
+            },
+            "sim_status": {
+                "name": "Status SIM"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Tip conexiune"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "Adresă IP Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "Adresă IP Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Gateway Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Semnal celular"
+            },
+            "cellular_network": {
+                "name": "Rețea celulară"
+            }
         },
-        "switch": {"channel_1": {"name": "Canal 1"}, "channel_2": {"name": "Canal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Canal 1"
+            },
+            "channel_2": {
+                "name": "Canal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -13,32 +13,46 @@
             "2fa": {
                 "title": "İki Faktörlü Doğrulama",
                 "description": "Doğrulama uygulamanızdaki 6 haneli kodu girin.",
-                "data": {"totp_code": "TOTP Kodu"}
+                "data": {
+                    "totp_code": "TOTP Kodu"
+                }
             },
             "select_spaces": {
                 "title": "Alan Seçimi",
                 "description": "Eklemek istediğiniz alanları (hub'ları) seçin.",
-                "data": {"spaces": "Alanlar"}
+                "data": {
+                    "spaces": "Alanlar"
+                }
             },
             "reconfigure": {
                 "title": "Aegis for Ajax — Yeniden yapılandır",
                 "description": "Hesap kimlik bilgilerinizi güncelleyin.",
-                "data": {"email": "E-posta", "password": "Şifre", "app_label": "Uygulama etiketi"}
+                "data": {
+                    "email": "E-posta",
+                    "password": "Şifre",
+                    "app_label": "Uygulama etiketi"
+                }
             },
             "reconfigure_2fa": {
                 "title": "İki Faktörlü Doğrulama",
                 "description": "Doğrulama uygulamanızdaki 6 haneli kodu girin.",
-                "data": {"totp_code": "TOTP Kodu"}
+                "data": {
+                    "totp_code": "TOTP Kodu"
+                }
             },
             "reauth_confirm": {
                 "title": "Aegis for Ajax yeniden kimlik doğrulaması",
                 "description": "{email} için Ajax oturumunuz artık geçerli değil. Erişimi geri yüklemek için hesabın mevcut parolasını girin.",
-                "data": {"password": "Parola"}
+                "data": {
+                    "password": "Parola"
+                }
             },
             "reauth_2fa": {
                 "title": "İki faktörlü kimlik doğrulama",
                 "description": "Kimlik doğrulama uygulamanızdan 6 haneli kodu girin.",
-                "data": {"totp_code": "TOTP Kodu"}
+                "data": {
+                    "totp_code": "TOTP Kodu"
+                }
             }
         },
         "error": {
@@ -150,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Fotoğraf çek"}},
+        "button": {
+            "capture_photo": {
+                "name": "Fotoğraf çek"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Güvenlik olayı",
@@ -166,6 +184,7 @@
                             "disarm": "Devre dışı",
                             "disarm_night": "Gece modu devre dışı",
                             "door_open": "Kapı açıldı",
+                            "doorbell_pressed": "Zile basıldı",
                             "fire": "Yangın",
                             "flood": "Su baskını",
                             "glass_break": "Cam kırılması",
@@ -179,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Güvenlik merkezi bağlantısı"},
-            "gsm": {"name": "Hücresel ağ bağlı"},
-            "lid": {"name": "Kapak açık"},
-            "ext_contact": {"name": "Harici kontak açık"},
-            "ext_alert": {"name": "Harici kontak alarmı"},
-            "drilling": {"name": "Gövde delme algılandı"},
-            "anti_mask": {"name": "Örtme koruması"},
-            "malfunction": {"name": "Arıza"},
-            "interference": {"name": "Parazit"},
-            "relay_stuck": {"name": "Röle takılı"},
-            "always_active": {"name": "Her zaman aktif"},
-            "glass_break": {"name": "Cam kırılması"},
-            "vibration": {"name": "Titreşim"},
-            "tilt": {"name": "Eğilme"},
-            "steam": {"name": "Buhar"},
-            "wire_input_alert": {"name": "Kablolu giriş uyarısı"},
-            "tamper": {"name": "Kasa kurcalama"},
-            "connectivity": {"name": "Bağlantı"},
-            "problem": {"name": "Cihaz sorunu"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Şebeke gücü"}
+            "monitoring": {
+                "name": "Güvenlik merkezi bağlantısı"
+            },
+            "gsm": {
+                "name": "Hücresel ağ bağlı"
+            },
+            "lid": {
+                "name": "Kapak açık"
+            },
+            "ext_contact": {
+                "name": "Harici kontak açık"
+            },
+            "ext_alert": {
+                "name": "Harici kontak alarmı"
+            },
+            "drilling": {
+                "name": "Gövde delme algılandı"
+            },
+            "anti_mask": {
+                "name": "Örtme koruması"
+            },
+            "malfunction": {
+                "name": "Arıza"
+            },
+            "interference": {
+                "name": "Parazit"
+            },
+            "relay_stuck": {
+                "name": "Röle takılı"
+            },
+            "always_active": {
+                "name": "Her zaman aktif"
+            },
+            "glass_break": {
+                "name": "Cam kırılması"
+            },
+            "vibration": {
+                "name": "Titreşim"
+            },
+            "tilt": {
+                "name": "Eğilme"
+            },
+            "steam": {
+                "name": "Buhar"
+            },
+            "wire_input_alert": {
+                "name": "Kablolu giriş uyarısı"
+            },
+            "tamper": {
+                "name": "Kasa kurcalama"
+            },
+            "connectivity": {
+                "name": "Bağlantı"
+            },
+            "problem": {
+                "name": "Cihaz sorunu"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Şebeke gücü"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "İzleme merkezi şirketi"},
-            "signal_strength": {"name": "Sinyal gücü"},
-            "mobile_network_type": {"name": "Mobil ağ türü"},
-            "wifi_signal_level": {"name": "Wi-Fi sinyal seviyesi"},
-            "sim_status": {"name": "SIM durumu"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Bağlantı türü"},
-            "wifi_ssid": {"name": "Wi-Fi SSID"},
-            "wifi_ip": {"name": "Wi-Fi IP adresi"},
-            "ethernet_ip": {"name": "Ethernet IP adresi"},
-            "ethernet_gateway": {"name": "Ethernet ağ geçidi"},
-            "ethernet_dns": {"name": "Ethernet DNS"},
-            "cellular_signal": {"name": "Hücresel sinyal"},
-            "cellular_network": {"name": "Hücresel ağ"}
+            "monitoring_company": {
+                "name": "İzleme merkezi şirketi"
+            },
+            "signal_strength": {
+                "name": "Sinyal gücü"
+            },
+            "mobile_network_type": {
+                "name": "Mobil ağ türü"
+            },
+            "wifi_signal_level": {
+                "name": "Wi-Fi sinyal seviyesi"
+            },
+            "sim_status": {
+                "name": "SIM durumu"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Bağlantı türü"
+            },
+            "wifi_ssid": {
+                "name": "Wi-Fi SSID"
+            },
+            "wifi_ip": {
+                "name": "Wi-Fi IP adresi"
+            },
+            "ethernet_ip": {
+                "name": "Ethernet IP adresi"
+            },
+            "ethernet_gateway": {
+                "name": "Ethernet ağ geçidi"
+            },
+            "ethernet_dns": {
+                "name": "Ethernet DNS"
+            },
+            "cellular_signal": {
+                "name": "Hücresel sinyal"
+            },
+            "cellular_network": {
+                "name": "Hücresel ağ"
+            }
         },
-        "switch": {"channel_1": {"name": "Kanal 1"}, "channel_2": {"name": "Kanal 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Kanal 1"
+            },
+            "channel_2": {
+                "name": "Kanal 2"
+            }
+        }
     }
 }

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -13,32 +13,46 @@
             "2fa": {
                 "title": "Двофакторна автентифікація",
                 "description": "Введіть 6-значний код з вашого додатку автентифікації.",
-                "data": {"totp_code": "Код TOTP"}
+                "data": {
+                    "totp_code": "Код TOTP"
+                }
             },
             "select_spaces": {
                 "title": "Вибір просторів",
                 "description": "Виберіть простори (хаби) для додавання.",
-                "data": {"spaces": "Простори"}
+                "data": {
+                    "spaces": "Простори"
+                }
             },
             "reconfigure": {
                 "title": "Переналаштувати Aegis for Ajax",
                 "description": "Оновіть облікові дані.",
-                "data": {"email": "E-mail", "password": "Пароль", "app_label": "Мітка додатку"}
+                "data": {
+                    "email": "E-mail",
+                    "password": "Пароль",
+                    "app_label": "Мітка додатку"
+                }
             },
             "reconfigure_2fa": {
                 "title": "Двофакторна автентифікація",
                 "description": "Введіть 6-значний код з вашого додатку автентифікації.",
-                "data": {"totp_code": "Код TOTP"}
+                "data": {
+                    "totp_code": "Код TOTP"
+                }
             },
             "reauth_confirm": {
                 "title": "Повторна автентифікація Aegis for Ajax",
                 "description": "Ваша сесія Ajax для {email} вже недійсна. Введіть поточний пароль облікового запису, щоб відновити доступ.",
-                "data": {"password": "Пароль"}
+                "data": {
+                    "password": "Пароль"
+                }
             },
             "reauth_2fa": {
                 "title": "Двофакторна автентифікація",
                 "description": "Введіть 6-значний код з вашого додатка автентифікатора.",
-                "data": {"totp_code": "Код TOTP"}
+                "data": {
+                    "totp_code": "Код TOTP"
+                }
             }
         },
         "error": {
@@ -150,7 +164,11 @@
         }
     },
     "entity": {
-        "button": {"capture_photo": {"name": "Зробити фото"}},
+        "button": {
+            "capture_photo": {
+                "name": "Зробити фото"
+            }
+        },
         "event": {
             "security_event": {
                 "name": "Подія безпеки",
@@ -166,6 +184,7 @@
                             "disarm": "Знято з охорони",
                             "disarm_night": "Нічний режим вимкнено",
                             "door_open": "Двері відчинені",
+                            "doorbell_pressed": "Натиснуто дзвінок",
                             "fire": "Пожежа",
                             "flood": "Затоплення",
                             "glass_break": "Розбиття скла",
@@ -179,45 +198,124 @@
             }
         },
         "binary_sensor": {
-            "monitoring": {"name": "Підключення до ЦМО"},
-            "gsm": {"name": "Стільниковий зв'язок"},
-            "lid": {"name": "Кришка відкрита"},
-            "ext_contact": {"name": "Зовнішній контакт розімкнений"},
-            "ext_alert": {"name": "Тривога зовнішнього контакту"},
-            "drilling": {"name": "Свердління корпусу"},
-            "anti_mask": {"name": "Антизамаскування"},
-            "malfunction": {"name": "Несправність"},
-            "interference": {"name": "Перешкоди"},
-            "relay_stuck": {"name": "Реле застрягло"},
-            "always_active": {"name": "Завжди активний"},
-            "glass_break": {"name": "Розбиття скла"},
-            "vibration": {"name": "Вібрація"},
-            "tilt": {"name": "Нахил"},
-            "steam": {"name": "Пара"},
-            "wire_input_alert": {"name": "Сповіщення дротового входу"},
-            "tamper": {"name": "Зламування корпусу"},
-            "connectivity": {"name": "Підключення"},
-            "problem": {"name": "Проблема пристрою"},
-            "ethernet": {"name": "Ethernet"},
-            "wifi": {"name": "Wi-Fi"},
-            "mains_power": {"name": "Зовнішнє живлення"}
+            "monitoring": {
+                "name": "Підключення до ЦМО"
+            },
+            "gsm": {
+                "name": "Стільниковий зв'язок"
+            },
+            "lid": {
+                "name": "Кришка відкрита"
+            },
+            "ext_contact": {
+                "name": "Зовнішній контакт розімкнений"
+            },
+            "ext_alert": {
+                "name": "Тривога зовнішнього контакту"
+            },
+            "drilling": {
+                "name": "Свердління корпусу"
+            },
+            "anti_mask": {
+                "name": "Антизамаскування"
+            },
+            "malfunction": {
+                "name": "Несправність"
+            },
+            "interference": {
+                "name": "Перешкоди"
+            },
+            "relay_stuck": {
+                "name": "Реле застрягло"
+            },
+            "always_active": {
+                "name": "Завжди активний"
+            },
+            "glass_break": {
+                "name": "Розбиття скла"
+            },
+            "vibration": {
+                "name": "Вібрація"
+            },
+            "tilt": {
+                "name": "Нахил"
+            },
+            "steam": {
+                "name": "Пара"
+            },
+            "wire_input_alert": {
+                "name": "Сповіщення дротового входу"
+            },
+            "tamper": {
+                "name": "Зламування корпусу"
+            },
+            "connectivity": {
+                "name": "Підключення"
+            },
+            "problem": {
+                "name": "Проблема пристрою"
+            },
+            "ethernet": {
+                "name": "Ethernet"
+            },
+            "wifi": {
+                "name": "Wi-Fi"
+            },
+            "mains_power": {
+                "name": "Зовнішнє живлення"
+            }
         },
         "sensor": {
-            "monitoring_company": {"name": "Компанія ЦМО"},
-            "signal_strength": {"name": "Рівень сигналу"},
-            "mobile_network_type": {"name": "Тип мобільної мережі"},
-            "wifi_signal_level": {"name": "Рівень сигналу Wi-Fi"},
-            "sim_status": {"name": "Стан SIM-карти"},
-            "sim_imei": {"name": "IMEI"},
-            "connection_type": {"name": "Тип з'єднання"},
-            "wifi_ssid": {"name": "SSID Wi-Fi"},
-            "wifi_ip": {"name": "IP-адреса Wi-Fi"},
-            "ethernet_ip": {"name": "IP-адреса Ethernet"},
-            "ethernet_gateway": {"name": "Шлюз Ethernet"},
-            "ethernet_dns": {"name": "DNS Ethernet"},
-            "cellular_signal": {"name": "Сигнал мобільної мережі"},
-            "cellular_network": {"name": "Мобільна мережа"}
+            "monitoring_company": {
+                "name": "Компанія ЦМО"
+            },
+            "signal_strength": {
+                "name": "Рівень сигналу"
+            },
+            "mobile_network_type": {
+                "name": "Тип мобільної мережі"
+            },
+            "wifi_signal_level": {
+                "name": "Рівень сигналу Wi-Fi"
+            },
+            "sim_status": {
+                "name": "Стан SIM-карти"
+            },
+            "sim_imei": {
+                "name": "IMEI"
+            },
+            "connection_type": {
+                "name": "Тип з'єднання"
+            },
+            "wifi_ssid": {
+                "name": "SSID Wi-Fi"
+            },
+            "wifi_ip": {
+                "name": "IP-адреса Wi-Fi"
+            },
+            "ethernet_ip": {
+                "name": "IP-адреса Ethernet"
+            },
+            "ethernet_gateway": {
+                "name": "Шлюз Ethernet"
+            },
+            "ethernet_dns": {
+                "name": "DNS Ethernet"
+            },
+            "cellular_signal": {
+                "name": "Сигнал мобільної мережі"
+            },
+            "cellular_network": {
+                "name": "Мобільна мережа"
+            }
         },
-        "switch": {"channel_1": {"name": "Канал 1"}, "channel_2": {"name": "Канал 2"}}
+        "switch": {
+            "channel_1": {
+                "name": "Канал 1"
+            },
+            "channel_2": {
+                "name": "Канал 2"
+            }
+        }
     }
 }

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -556,6 +556,99 @@ class TestExtractEventCompiledProtos:
         assert event_type == "alarm"
         assert data["raw_tag"] == "intrusion_alarm"
 
+    def test_hub_ring_button_pressed_resolves_to_doorbell_pressed(self) -> None:
+        # Wireless DoorBell (Jeweller standalone ring button paired with the
+        # hub) fires `ring_button_pressed` inside HubEventTag. Same FCM path
+        # as every other hub-level event we already parse (#119).
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
+            transition_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (  # noqa: E501
+            qualifier_pb2 as hub_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (
+            tag_pb2 as hub_tag_pb2,
+        )
+
+        qualifier = hub_qualifier_pb2.HubEventQualifier(
+            tag=hub_tag_pb2.HubEventTag(ring_button_pressed=hub_tag_pb2.RingButtonPressed()),
+            transition=transition_pb2.EventTransition(
+                impulse=transition_pb2.EventTransition.Impulse()
+            ),
+        )
+        wrapped = self._wrap(qualifier.SerializeToString())
+
+        listener = self._make_listener()
+        result = listener._extract_event_with_compiled_protos(wrapped)
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "doorbell_pressed"
+        assert data["raw_tag"] == "ring_button_pressed"
+
+    def test_video_ring_button_pressed_resolves_to_doorbell_pressed(self) -> None:
+        # MotionCam Video Doorbell (camera-with-ring-button) fires the same
+        # event tag but inside a VideoEventQualifier — different oneof,
+        # different qualifier wrapper. Pass 4 in `_extract_event_with_
+        # compiled_protos` walks VideoEventQualifier specifically (#119).
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
+            transition_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.video import (  # noqa: E501
+            qualifier_pb2 as video_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.video import (
+            tag_pb2 as video_tag_pb2,
+        )
+
+        qualifier = video_qualifier_pb2.VideoEventQualifier(
+            tag=video_tag_pb2.VideoEventTag(ring_button_pressed=video_tag_pb2.RingButtonPressed()),
+            transition=transition_pb2.EventTransition(
+                impulse=transition_pb2.EventTransition.Impulse()
+            ),
+        )
+        wrapped = self._wrap(qualifier.SerializeToString())
+
+        listener = self._make_listener()
+        result = listener._extract_event_with_compiled_protos(wrapped)
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "doorbell_pressed"
+        assert data["raw_tag"] == "ring_button_pressed"
+
+    def test_video_qualifier_motion_detected_does_not_false_positive(self) -> None:
+        # The Video Doorbell also emits non-doorbell events (motion_detected,
+        # human_detected, etc.). Those are not currently mapped so the parser
+        # must return None for them — not silently mis-fire `doorbell_pressed`.
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
+            transition_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.video import (  # noqa: E501
+            qualifier_pb2 as video_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.video import (
+            tag_pb2 as video_tag_pb2,
+        )
+
+        qualifier = video_qualifier_pb2.VideoEventQualifier(
+            tag=video_tag_pb2.VideoEventTag(motion_detected=video_tag_pb2.MotionDetected()),
+            transition=transition_pb2.EventTransition(
+                triggered=transition_pb2.EventTransition.Triggered()
+            ),
+        )
+        wrapped = self._wrap(qualifier.SerializeToString())
+
+        listener = self._make_listener()
+        result = listener._extract_event_with_compiled_protos(wrapped)
+
+        # `motion_detected` from a video qualifier maps cleanly to "motion"
+        # — same downstream HA event_type the existing motion sensors emit,
+        # no need for a doorbell-only mapping.
+        assert result is not None
+        event_type, _ = result
+        assert event_type == "motion"
+
 
 class TestNotificationDedupe:
     """Issue #80: Ajax dispatches two FCM messages per security transition with


### PR DESCRIPTION
## Summary

Closes the gap that left @Permudious's MotionCam Video Doorbell invisible to HA in #119: the device wasn't registered in `_DEVICE_TYPE_SENSORS`, so no entities were created and no device card appeared even though the Ajax cloud was sending the device in every snapshot. Adds the three MotionCam Video models (`motion_cam_video_doorbell`, `motion_cam_video_indoor`, `motion_cam_video_base`) and wires the actual ring-button event from both possible sources.

## Changes

- **Device-type registration** (`binary_sensor.py`): three new entries with `motion_detected` + `tamper`, mirroring every other MotionCam variant. Standard `signal_strength` / `battery_level` sensors come for free from the device-agnostic `sensor.py` path.
- **Hub-side ring** (`HUB_EVENT_TAG_MAP`): one entry mapping `ring_button_pressed` → `doorbell_pressed`. Covers the standalone Wireless DoorBell SKU (Jeweller ring button paired with the hub) which fires through `HubEventQualifier` — the qualifier walker already covered the path, just needed the map entry.
- **Video-side ring** (`VIDEO_EVENT_TAG_MAP` + Pass 4 in `_extract_event_with_compiled_protos`): MotionCam Video Doorbell fires `RingButtonPressed` inside `VideoEventQualifier` instead, which we weren't parsing. New 4th pass walks `VideoEventQualifier`, with `motion_detected` / `human_detected` mapping to "motion" so video-side motion events flow through the existing per-space `event.aegis_security_event` entity instead of inflating a parallel surface.
- **Logbook + translations**: `doorbell_pressed` description in `logbook.py`, English string in `strings.json`, best-effort translations in all 14 locale files.

## Out of scope

The streaming-camera surface (live video, snapshot-on-demand) for the Video Doorbell. The existing `AjaxCamera` is photo-on-demand only and would silently fail against the doorbell's video pipeline. Permudious's snapshot-on-press automation (use case 1 in the issue) needs a working `camera.<doorbell>` entity to call `camera.snapshot` on, which we don't ship yet — separate follow-up once we work out the streaming protocol. The `event.aegis_security_event` entity at least gives him `event_type: doorbell_pressed` to trigger the TTS automation (use case 2) today.

## Test plan

- [x] 3 new unit tests cover both qualifier paths + the false-positive case (video motion stays "motion", not "doorbell_pressed")
- [x] `make check` inside the dev image — **1121 passed**, coverage **83.90%**
- [x] CI parity verified by rebuilding `aegis-ajax-dev:ci-119` and running checks without volume mount
- [ ] Real-HA validation: pending @Permudious confirming on `1.3.0-beta.3` that (a) the doorbell now appears as a device card, (b) `event_type: doorbell_pressed` fires on ring

Refs #119.