### PR TITLE
fix(diagnostics): promote silent HTS/FCM startup logs to WARNING/INFO

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -370,6 +370,19 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # Start HTS for hub network data (non-blocking, graceful degradation)
                 await self._start_hts()
                 self._last_update_success_time = dt_util.utcnow()
+                # One-line INFO summary so users debugging "HTS streams: 0/1" or
+                # "FCM clients: 0/1" reports (#111) can see at a glance which
+                # surfaces are coming up at startup. The HTS path is async —
+                # `_start_hts` schedules the lifecycle task and returns, so we
+                # report whether the task was scheduled here, not whether
+                # `connect()` already succeeded. The actual `HTS connected, N
+                # hub(s)` line lands once the task's connect awaits returns.
+                _LOGGER.info(
+                    "Aegis startup: device streams %d/%d started, HTS lifecycle %s",
+                    len([t for t in self._stream_tasks if not t.done()]),
+                    len(self.spaces),
+                    "scheduled" if self._hts_task is not None else "skipped",
+                )
                 return {"spaces": self.spaces, "devices": self.devices}
 
             # Skip device snapshot if all persistent streams are alive
@@ -416,7 +429,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             session = self._client.session
             token_hex = session.session_token
             if not token_hex:
-                _LOGGER.debug("No session token, skipping HTS")
+                _LOGGER.warning(
+                    "HTS startup skipped — no Ajax session token available. "
+                    "Hub network sensors will stay unavailable until authentication "
+                    "succeeds. Look earlier in the log for the authentication failure."
+                )
                 return
             # Pre-create SSL context in executor to avoid blocking event loop
             if HtsClient._ssl_ctx is None:
@@ -431,8 +448,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 device_id=session.device_id,
                 app_label=session.app_label,
             )
-        except Exception:
-            _LOGGER.debug("HTS pre-connect setup failed", exc_info=True)
+        except Exception as exc:
+            _LOGGER.warning(
+                "HTS pre-connect setup failed (%s) — hub network sensors unavailable",
+                exc.__class__.__name__,
+                exc_info=True,
+            )
             self._hts_client = None
             return
         self._hts_task = asyncio.create_task(self._run_hts_lifecycle())
@@ -447,8 +468,18 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.info("HTS connected, %d hub(s)", len(result.hubs))
             self._clear_hts_chronic_failure()
             await self._hts_client.listen(on_state_update=self._on_hts_update)
-        except Exception:
-            _LOGGER.debug("HTS connection failed (network sensors unavailable)", exc_info=True)
+        except Exception as exc:
+            # Surface at WARNING (#111) — a silent DEBUG made these failures
+            # invisible to users debugging "HTS streams: 0/1" reports. The
+            # previous behaviour required reproducing with custom debug
+            # logging on multiple modules. Keep `exc_info=True` so the full
+            # traceback still lands when DEBUG is enabled.
+            _LOGGER.warning(
+                "HTS connection failed (%s) — hub network sensors will be unavailable. "
+                "The integration will retry on the next poll cycle.",
+                exc.__class__.__name__,
+                exc_info=True,
+            )
             self._hts_client = None
 
     def _on_hts_update(self, hub_id: str, state: HubNetworkState) -> None:

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -100,7 +100,10 @@ class AjaxNotificationListener:
         if self._entry_id:
             async_clear_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)
         if not self._fcm_api_key:
-            _LOGGER.debug("FCM credentials not configured, push notifications disabled")
+            _LOGGER.info(
+                "FCM credentials not configured — push notifications disabled. "
+                "Configure them in the integration's Options to enable real-time pushes."
+            )
             return
 
         try:
@@ -110,7 +113,10 @@ class AjaxNotificationListener:
                 FcmRegisterConfig,
             )
         except ImportError:
-            _LOGGER.debug("firebase_messaging not installed, push notifications disabled")
+            _LOGGER.warning(
+                "firebase_messaging package not installed — push notifications disabled. "
+                "This is unexpected; reinstall the integration via HACS."
+            )
             return
 
         # Load or create FCM credentials
@@ -135,7 +141,7 @@ class AjaxNotificationListener:
                     raw_result = await self._hass.async_add_executor_job(registerer.register)
                 self._credentials = dict(raw_result)
                 await self._store.async_save(self._credentials)
-                _LOGGER.debug("FCM registration successful")
+                _LOGGER.info("FCM registration successful")
             except Exception:
                 _LOGGER.exception("FCM registration failed")
                 if self._entry_id:
@@ -150,7 +156,12 @@ class AjaxNotificationListener:
             _LOGGER.debug("FCM token obtained, registering with Ajax servers")
             await self._register_push_token(str(fcm_token))
         else:
-            _LOGGER.debug("No FCM token found in credentials")
+            _LOGGER.warning(
+                "FCM registration returned no token — push delivery will not work. "
+                "Most often caused by malformed FCM credentials (project_id / app_id / "
+                "api_key / sender_id mismatch). Re-extract the four values per the "
+                "integration README and re-enter them in Options."
+            )
 
         # Start push client
         try:
@@ -163,7 +174,7 @@ class AjaxNotificationListener:
                 await self._push_client.start()
             else:
                 await self._hass.async_add_executor_job(self._push_client.start)
-            _LOGGER.debug("FCM push client started for Ajax")
+            _LOGGER.info("FCM push client started — push notifications active")
         except Exception:
             _LOGGER.exception("Failed to start FCM push client")
             self._push_client = None
@@ -195,9 +206,12 @@ class AjaxNotificationListener:
             if response.HasField("success"):
                 _LOGGER.debug("Push token registered with Ajax servers")
             else:
-                _LOGGER.debug("Failed to register push token with Ajax servers")
+                _LOGGER.warning(
+                    "Ajax server rejected the push-token registration — push delivery "
+                    "may be silent. Response did not carry a `success` field."
+                )
         except Exception:
-            _LOGGER.exception("Error registering push token")
+            _LOGGER.exception("Error registering push token with Ajax servers")
 
     def _on_notification(
         self,

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -969,6 +969,44 @@ class TestStreamHandlers:
 
         assert coordinator._hts_task is existing_task
 
+    @pytest.mark.asyncio
+    async def test_start_hts_logs_warning_when_session_token_missing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Regression for #111 — affected users reported "HTS streams: 0/1"
+        # with empty `notification.py` and `api/hts/client.py` logs even
+        # under DEBUG. The silent skip when the session token is missing
+        # is the most common cause; promote it to WARNING so the reason
+        # is visible at default log level.
+        coordinator = self._make_coordinator_with_stream()
+        coordinator._client.session.session_token = ""
+
+        with caplog.at_level("WARNING"):
+            await coordinator._start_hts()
+
+        assert "HTS startup skipped" in caplog.text
+        assert "no Ajax session token" in caplog.text
+        assert coordinator._hts_task is None
+
+    @pytest.mark.asyncio
+    async def test_run_hts_lifecycle_logs_warning_on_connect_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Regression for #111 — `connect()` failures used to be DEBUG only,
+        # so HTS connection collapses were invisible in the user's log.
+        # Now WARNING with the exception class name + traceback (under
+        # DEBUG) for fast triage.
+        coordinator = self._make_coordinator_with_stream()
+        coordinator._hts_client = MagicMock()
+        coordinator._hts_client.connect = AsyncMock(side_effect=ConnectionRefusedError("refused"))
+
+        with caplog.at_level("WARNING"):
+            await coordinator._run_hts_lifecycle()
+
+        assert "HTS connection failed" in caplog.text
+        assert "ConnectionRefusedError" in caplog.text
+        assert coordinator._hts_client is None
+
     def test_handle_hts_task_done_clears_state(self) -> None:
         coordinator = self._make_coordinator_with_stream()
         coordinator.hub_network["hub-1"] = HubNetworkState(ethernet_connected=True)
@@ -1236,3 +1274,22 @@ class TestCachedSnapshotStart:
         # ~1080-test suite doesn't need a giant rewrite.
         coordinator = _make_coordinator()
         assert coordinator._devices_cache is None
+
+    @pytest.mark.asyncio
+    async def test_first_refresh_emits_startup_summary(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Diagnostic INFO line for #111: at the end of the first refresh
+        # we want a single summary that says "device streams N/N started,
+        # HTS lifecycle scheduled" so users debugging "0/1" reports can
+        # see at a glance which surfaces are coming up at startup.
+        coordinator = self._coordinator_with_cache(cached={"d1": _make_device("d1")})
+        coordinator._stream_tasks = [MagicMock(done=lambda: False)]
+        coordinator._hts_task = MagicMock(done=lambda: False)
+
+        with caplog.at_level("INFO"):
+            await coordinator._async_update_data()
+
+        assert "Aegis startup" in caplog.text
+        assert "device streams 1/1" in caplog.text
+        assert "HTS lifecycle scheduled" in caplog.text


### PR DESCRIPTION
## Summary

Refs #111. @Hansontech190 and other affected users reported \"HTS streams: 0/1\" / \"FCM clients: 0/1\" on the System Health card, with empty \`notification.py\` and \`api/hts/client.py\` logs even after enabling the documented DEBUG loggers. Root cause: the most diagnostic-relevant failure paths in the listener startup sequence were buried at DEBUG level, so the actual reason a listener never came up was invisible at default verbosity.

This PR doesn't fix the connection itself — we still don't know what's failing on the affected installs, that's exactly what the diagnostic is for. It makes the failures visible so the next round of bug-reporters can paste a useful log.

## Changes

**coordinator.py**
- \`_run_hts_lifecycle\`: HTS \`connect()\` failure now WARNING with exception class name; \`exc_info=True\` preserves the full traceback under DEBUG.
- \`_start_hts\`: missing session token now WARNING (the most common cause of \"HTS streams: 0/1\" — points users at the earlier auth failure). Pre-connect setup exceptions also promoted.
- \`_async_update_data\` first-refresh: one-line INFO summary at the end — \`Aegis startup: device streams N/M started, HTS lifecycle scheduled/skipped\` — so it's a single grep to see what the integration brought up.

**notification.py**
- \`async_start\`: success paths (\`FCM registration successful\`, \`FCM push client started — push notifications active\`) now INFO so they're visible; missing credentials INFO with hint; \`firebase_messaging\` not installed WARNING; no-token-after-register WARNING with re-extraction hint; Ajax server rejection of the push-token register also WARNING.

## Test plan

- [x] 3 new unit tests cover the new log levels + startup summary
- [x] \`make check\` inside the dev image — 1124 passed, coverage 84.02%
- [x] CI parity verified by rebuilding \`aegis-ajax-dev:ci-111\` and running checks without volume mount
- [ ] Diagnostic value validated by @Hansontech190 on the next beta — his next log capture should now include a clear reason next to the \"0/1\" symptom

Refs #111.