### PR TITLE
fix(doorbell): parse video_edge_channel devices so the doorbell appears

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -396,14 +396,44 @@ class DevicesApi:
                     result[f"valve_ch{channel_id}_stuck"] = True
         return result
 
+    # Map `LightVideoEdgeChannel.video_edge_channel_properties.video_edge_type`
+    # (`About.Type` enum) to a HA-side device_type string parallel to the
+    # `_DEVICE_TYPE_SENSORS` keys. Only the consumer-visible variants are
+    # named — every NVR sub-type collapses to `video_edge_nvr` because users
+    # don't typically wire HA automations off recorder boxes, and the long
+    # tail (TURRET_HL, BULLET_HL_VF, S_TURRET_HL_VF, etc.) collapses to its
+    # base shape. Anything we don't recognise becomes `video_edge_unknown`
+    # so the device still appears as a HA card with the device-agnostic
+    # sensors instead of silently disappearing.
+    _VIDEO_EDGE_TYPE_MAP: dict[int, str] = {
+        2: "video_edge_turret",
+        3: "video_edge_bullet",
+        4: "video_edge_minidome",
+        5: "video_edge_doorbell",  # #119: @Permudious's MotionCam Video Doorbell
+        6: "video_edge_indoor",
+        17: "video_edge_turret",  # TURRET_HL
+        18: "video_edge_turret",  # TURRET_HL_VF
+        19: "video_edge_turret",  # S_TURRET_HL_VF
+        20: "video_edge_bullet",  # BULLET_HL
+        21: "video_edge_bullet",  # BULLET_HL_VF
+        22: "video_edge_bullet",  # S_BULLET_HL_VF
+        23: "video_edge_minidome",  # MINIDOME_HL
+        24: "video_edge_minidome",  # MINIDOME_HL_VF
+        25: "video_edge_minidome",  # S_MINIDOME_HL_VF
+    }
+
     @staticmethod
     def parse_device(proto_light_device: Any) -> Device | None:  # noqa: ANN401
         device_kind = proto_light_device.WhichOneof("device")
-        if device_kind != "hub_device":
-            _LOGGER.debug("Skipping non-hub device type: %s", device_kind)
-            return None
+        if device_kind == "hub_device":
+            return DevicesApi._parse_hub_device(proto_light_device.hub_device)
+        if device_kind == "video_edge_channel":
+            return DevicesApi._parse_video_edge_channel(proto_light_device.video_edge_channel)
+        _LOGGER.debug("Skipping unsupported device type: %s", device_kind)
+        return None
 
-        hub_dev = proto_light_device.hub_device
+    @staticmethod
+    def _parse_hub_device(hub_dev: Any) -> Device | None:  # noqa: ANN401
         common = hub_dev.common_device
         profile = common.profile
 
@@ -423,6 +453,47 @@ class DevicesApi:
             malfunctions=profile.malfunctions,
             bypassed=profile.bypassed,
             statuses=statuses,
+            battery=DevicesApi._parse_battery(profile.statuses),
+        )
+
+    @staticmethod
+    def _parse_video_edge_channel(channel: Any) -> Device | None:  # noqa: ANN401
+        """Parse a `LightVideoEdgeChannel` into a Device (#119).
+
+        Video Edge channels (MotionCam Video Doorbell, Indoor camera, NVR
+        channels, third-party RTSP cameras bridged via VideoEdge) come
+        through their own LightDevice oneof case — distinct from
+        `hub_device` — and don't expose an `object_type` field. The type
+        signal is `video_edge_channel_properties.video_edge_type`, an
+        `About.Type` enum which we map to `_DEVICE_TYPE_SENSORS`-friendly
+        strings like `video_edge_doorbell`.
+        """
+        if not channel.HasField("video_edge_channel_properties"):
+            _LOGGER.debug("video_edge_channel without properties, skipping")
+            return None
+        if not channel.HasField("profile"):
+            _LOGGER.debug("video_edge_channel without profile, skipping")
+            return None
+
+        profile = channel.profile
+        type_value = int(channel.video_edge_channel_properties.video_edge_type)
+        device_type = DevicesApi._VIDEO_EDGE_TYPE_MAP.get(type_value, "video_edge_unknown")
+
+        # No hub_id on the channel side — Ajax models the video bridge
+        # as a sibling of the hub, not a child. Falling back to the
+        # channel's own id keeps the HA device registry happy; entity
+        # routing in the integration is keyed off `device.id` anyway.
+        return Device(
+            id=profile.id,
+            hub_id=profile.id,
+            name=profile.name,
+            device_type=device_type,
+            room_id=profile.room_id if profile.room_id else None,
+            group_id=profile.group_id if profile.group_id else None,
+            state=DevicesApi._parse_device_state(profile.states),
+            malfunctions=profile.malfunctions,
+            bypassed=profile.bypassed,
+            statuses=DevicesApi._parse_statuses(profile.statuses),
             battery=DevicesApi._parse_battery(profile.statuses),
         )
 

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -157,6 +157,20 @@ _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
     "motion_cam_video_base": ["motion_detected", "tamper"],
     "motion_cam_video_doorbell": ["motion_detected", "tamper"],
     "motion_cam_video_indoor": ["motion_detected", "tamper"],
+    # VideoEdge channel devices — third-party / bridged cameras that
+    # arrive on the `video_edge_channel` oneof of LightDevice rather
+    # than `hub_device` (#119, @Permudious's MotionCam Video Doorbell
+    # actually surfaces here, not under `motion_cam_video_*` as we
+    # first guessed in beta.3). They don't carry the Jeweller-side
+    # signal_strength / battery, so the device-agnostic sensors in
+    # `sensor.py` skip themselves naturally; motion / tamper still
+    # surface when the camera exposes them via `LightDeviceStatus`.
+    "video_edge_bullet": ["motion_detected", "tamper"],
+    "video_edge_doorbell": ["motion_detected", "tamper"],
+    "video_edge_indoor": ["motion_detected", "tamper"],
+    "video_edge_minidome": ["motion_detected", "tamper"],
+    "video_edge_turret": ["motion_detected", "tamper"],
+    "video_edge_unknown": ["motion_detected", "tamper"],
     "combi_protect": ["motion_detected", "glass_break", "tamper"],
     "combi_protect_s": ["motion_detected", "glass_break", "tamper"],
     "combi_protect_fibra": ["motion_detected", "glass_break", "tamper"],

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -65,11 +65,131 @@ class TestParseDevice:
         assert device is not None
         assert device.state == DeviceState.OFFLINE
 
-    def test_parse_non_hub_device_returns_none(self) -> None:
+    def test_parse_unsupported_oneof_returns_none(self) -> None:
+        # `video_edge` (the recorder), `smart_lock` (the auxiliary
+        # smart-lock variant) and an unset oneof all fall through to
+        # None — only `hub_device` and `video_edge_channel` are mapped.
         proto_device = MagicMock()
         proto_device.WhichOneof.return_value = "video_edge"
-        result = DevicesApi.parse_device(proto_device)
-        assert result is None
+        assert DevicesApi.parse_device(proto_device) is None
+
+    def test_parse_video_edge_channel_doorbell(self) -> None:
+        # @Permudious in #119: MotionCam Video Doorbell arrives as a
+        # `video_edge_channel` LightDevice oneof case, not `hub_device`,
+        # so it was being skipped entirely. The fix parses the channel
+        # and emits a `video_edge_doorbell` device_type so the existing
+        # `_DEVICE_TYPE_SENSORS` map surfaces motion + tamper entities
+        # and HA renders a device card.
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        about_type_doorbell = 5  # About.Type.DOORBELL
+        light_device = light_device_pb2.LightDevice(
+            video_edge_channel=light_video_edge_pb2.LightVideoEdgeChannel(
+                profile=light_device_profile_pb2.LightDeviceProfile(
+                    id="cam-front-door",
+                    name="Front Door Doorbell",
+                ),
+                video_edge_channel_properties=(
+                    light_video_edge_pb2.LightVideoEdgeChannel.VideoEdgeChannelProperties(
+                        video_edge_type=about_type_doorbell,
+                    )
+                ),
+            )
+        )
+
+        device = DevicesApi.parse_device(light_device)
+        assert device is not None
+        assert device.id == "cam-front-door"
+        assert device.name == "Front Door Doorbell"
+        assert device.device_type == "video_edge_doorbell"
+        assert device.state == DeviceState.ONLINE
+
+    def test_parse_video_edge_channel_indoor_camera(self) -> None:
+        # INDOOR=6 is the indoor variant of the MotionCam Video family;
+        # parser shouldn't pretend it's a doorbell.
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        light_device = light_device_pb2.LightDevice(
+            video_edge_channel=light_video_edge_pb2.LightVideoEdgeChannel(
+                profile=light_device_profile_pb2.LightDeviceProfile(
+                    id="cam-living",
+                    name="Living Room",
+                ),
+                video_edge_channel_properties=(
+                    light_video_edge_pb2.LightVideoEdgeChannel.VideoEdgeChannelProperties(
+                        video_edge_type=6,  # INDOOR
+                    )
+                ),
+            )
+        )
+
+        device = DevicesApi.parse_device(light_device)
+        assert device is not None
+        assert device.device_type == "video_edge_indoor"
+
+    def test_parse_video_edge_channel_unknown_type(self) -> None:
+        # `About.Type` is open-ended; new firmwares can introduce
+        # values we don't know yet. Emit a generic `video_edge_unknown`
+        # so the device still surfaces as a HA card with at least the
+        # device-agnostic sensors (battery, signal_strength). Beats
+        # silently dropping the device.
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        light_device = light_device_pb2.LightDevice(
+            video_edge_channel=light_video_edge_pb2.LightVideoEdgeChannel(
+                profile=light_device_profile_pb2.LightDeviceProfile(
+                    id="cam-mystery", name="Mystery"
+                ),
+                video_edge_channel_properties=(
+                    light_video_edge_pb2.LightVideoEdgeChannel.VideoEdgeChannelProperties(
+                        video_edge_type=999,
+                    )
+                ),
+            )
+        )
+
+        device = DevicesApi.parse_device(light_device)
+        assert device is not None
+        assert device.device_type == "video_edge_unknown"
+
+    def test_parse_video_edge_channel_no_properties_returns_none(self) -> None:
+        # If the channel comes without `video_edge_channel_properties`,
+        # we have no type signal at all. Falling back to None is fine —
+        # it's the same behaviour as today and Ajax has never sent us
+        # such a payload in observed snapshots.
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        light_device = light_device_pb2.LightDevice(
+            video_edge_channel=light_video_edge_pb2.LightVideoEdgeChannel(
+                profile=light_device_profile_pb2.LightDeviceProfile(id="x", name="x"),
+            )
+        )
+
+        assert DevicesApi.parse_device(light_device) is None
 
 
 class TestSpreadPropertiesParser:


### PR DESCRIPTION
## Summary

@Permudious's MotionCam Video Doorbell didn't appear in HA on `1.3.0-beta.3` even after we registered `motion_cam_video_doorbell` in the device-type map (#121). The diagnostic log we added in `beta.4` made the actual gap visible:

```
DEBUG aegis_ajax.api.devices  Skipping non-hub device type: video_edge_channel
```

The Video Doorbell arrives on the `video_edge_channel` oneof of `LightDevice`, not `hub_device` — so the parser dropped it before any device-type map could match. The `motion_cam_video_doorbell` key we guessed at in beta.3 was the right shape but the wrong oneof case.

## Changes

- Split `parse_device` into `_parse_hub_device` (existing path) and `_parse_video_edge_channel` (new) so both oneof cases are handled.
- The new parser reads `video_edge_channel_properties.video_edge_type` (an `About.Type` enum: DOORBELL=5, INDOOR=6, TURRET, BULLET, MINIDOME, plus HL/VF/S- variants and NVR sub-types) and maps it to a clean device-type string (`video_edge_doorbell`, `_indoor`, `_turret`, `_bullet`, `_minidome`, `_unknown`).
- Register all six string keys in `_DEVICE_TYPE_SENSORS` with the same `motion_detected + tamper` set. The device-agnostic sensors (`signal_strength`, `battery_level`) skip themselves naturally for VideoEdge channels.
- `hub_id` set to the channel's own id — VideoEdge bridges aren't children of a Jeweller hub in Ajax's data model — keeps the HA device registry happy without growing the parser signature.
- The `motion_cam_video_*` keys added in `beta.3` stay as harmless dead entries; future-proofing against Ajax reshuffling these models onto the hub_device oneof.

## Test plan

- [x] 4 new unit tests cover doorbell, indoor, unknown-enum, and no-properties paths
- [x] `make check` inside the dev image — **1128 passed**, coverage **84.04%**
- [x] CI parity verified by rebuilding `aegis-ajax-dev:ci-119b` and running checks without volume mount
- [ ] Real-HA validation: pending @Permudious confirming the doorbell now appears as a device card with motion + tamper entities

Refs #119.