### PR TITLE
fix(parser): wifi_signal_level_status sub-message TypeError on video_edge_channel

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -301,10 +301,14 @@ class DevicesApi:
             elif which == "interference_detected":
                 result["interference"] = True
             elif which == "wifi_signal_level_status":
+                # `wifi_signal_level_status` is a sub-message wrapping the
+                # actual enum, not a plain int (#119, surfaced when video-
+                # edge channels added in beta.5 started hitting this path).
+                # `int(sub_message)` blew up with TypeError and killed the
+                # device-stream loop in a reconnect cycle.
+                sub = getattr(status, "wifi_signal_level_status", None)
                 result["wifi_signal_level"] = (
-                    int(status.wifi_signal_level_status)
-                    if hasattr(status, "wifi_signal_level_status")
-                    else 0
+                    int(getattr(sub, "wifi_signal_level", 0)) if sub is not None else 0
                 )
             elif which == "smart_lock":
                 # The status oneof carries the LockStatus enum directly (not a
@@ -658,7 +662,14 @@ class DevicesApi:
                                                 else True
                                             )
                                         elif status_name == "wifi_signal_level_status":
-                                            payload["value"] = int(status.wifi_signal_level_status)
+                                            # Sub-message wrapping the enum,
+                                            # not a plain int (#119).
+                                            sub = getattr(status, "wifi_signal_level_status", None)
+                                            payload["value"] = (
+                                                int(getattr(sub, "wifi_signal_level", 0))
+                                                if sub is not None
+                                                else 0
+                                            )
                                         elif status_name == "smart_lock":
                                             payload["value"] = _SMART_LOCK_STATE_MAP.get(
                                                 int(status.smart_lock), "unknown"

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -738,10 +738,24 @@ class TestStatusParser:
         result = DevicesApi._parse_statuses([status])
         assert result.get("interference") is True
 
-    def test_wifi_signal_level_status(self) -> None:
-        status = MagicMock()
-        status.WhichOneof.return_value = "wifi_signal_level_status"
-        status.wifi_signal_level_status = 4
+    def test_wifi_signal_level_status_real_proto(self) -> None:
+        # Regression for the TypeError @Permudious hit on beta.5 (#119): the
+        # MagicMock version above silently allowed `int(status.wifi_signal_
+        # level_status)` to pass even though the real proto field is a
+        # sub-message (`WifiSignalLevelStatus`) with a nested
+        # `wifi_signal_level` enum — the actual int lives one level deeper.
+        # Use a real proto instance so the parser exercises the same shape
+        # the wire delivers.
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_status_pb2,
+        )
+
+        status = light_device_status_pb2.LightDeviceStatus(
+            wifi_signal_level_status=(
+                light_device_status_pb2.LightDeviceStatus.WifiSignalLevelStatus(wifi_signal_level=4)
+            )
+        )
+
         result = DevicesApi._parse_statuses([status])
         assert result.get("wifi_signal_level") == 4
 


### PR DESCRIPTION
## Summary

Refs #119. @Permudious's MotionCam Video Doorbell crashed the device stream in a reconnect loop on `beta.5` with:

```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'WifiSignalLevelStatus'
File "api/devices.py", line 305, in _parse_statuses
    int(status.wifi_signal_level_status)
```

The bug pre-existed: `wifi_signal_level_status` is a sub-message wrapping a `wifi_signal_level` enum, not a plain int. It never fired because the `hub_device` path didn't surface this status on most installs. Adding `_parse_video_edge_channel` in `beta.5` (#124) exposed a new device kind that does emit it, and the cascading exception killed the whole device-stream task on every reconnect.

## Changes

- Read the int from the nested `.wifi_signal_level` enum field (with `getattr` fallbacks) in both occurrences of `wifi_signal_level_status` in `devices.py` (`_parse_statuses` + the persistent stream handler).
- Replace the previous `MagicMock`-based test with a real `LightDeviceStatus` proto — the test was silently letting `int(MagicMock)` pass, exactly the pattern documented in `feedback_proto_test_realism.md`.

## Hardening planned for a follow-up PR

This fix is the minimal targeted patch to unblock @Permudious. The broader hardening identified during triage — sweeping every `_parse_statuses` branch from `MagicMock` to real-proto tests, and wrapping `_run_stream`'s per-device parse in a try/except so one bad device doesn't kill the whole stream — comes in a separate PR. Tracked in `docs/TODO-improvements.md`.

## Test plan

- [x] `make check` inside the dev image — 1128 passed, coverage 84.03%
- [x] CI parity verified (`aegis-ajax-dev:ci-119c`, no volume mount)
- [ ] @Permudious confirms the doorbell appears and the device stream no longer logs the TypeError loop on beta.6

Refs #119.