### PR TITLE
fix(hts): stop forcing a snapshot refresh on every sub-key 11 heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **HTS `sub-key 11` heartbeats no longer trigger a full snapshot refresh on every tick.** @Hansontech190 and @b0arkz observed `Hub <id>: requesting fresh HTS snapshot after unknown update sub-key 11` firing every few seconds, each time pulling a `REQUEST_FULL_SETTINGS + REQUEST_FULL_STATUS` round-trip (~8.6 KB) from the Ajax cloud. Sub-key 11 is the hub-network delta channel: longer variants (~50 byte payload) carry the anchor keys we already parse, shorter variants (~34 byte payload) only carry fields we don't surface. Both flow through the same `parse_hub_params`, so the refresh round-trip could not learn anything the next long-form delta wouldn't carry on its own. The handler now drops the short variants silently and only escalates to a snapshot refresh on genuinely unknown sub-keys. Net effect on affected installs: zero behaviour change for hub-network sensors, large drop in HTS traffic and idle CPU. (#111)
+
 ## [1.3.0-beta.7] - 2026-05-13
 
 Seventh beta of the `1.3.0` line. Hardening pass on top of `beta.6`. No Ajax wire-protocol changes; no entity-level behaviour change for healthy installs.

--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -598,6 +598,16 @@ class HtsClient:
                 self._on_state_update(hub_id, new_state)
             return
 
+        # Sub-key 11 is the hub-network delta channel. The longer variants
+        # (~50 bytes) carry the anchor keys we recognise and are handled
+        # above. Shorter variants (~34 bytes) appear every few seconds on
+        # some firmwares and only carry fields we don't surface. Falling
+        # through to `_schedule_hub_refresh` here meant a `REQUEST_FULL_
+        # SETTINGS + REQUEST_FULL_STATUS` round-trip on every heartbeat
+        # (#111) — same parser, same keys, no new information. Drop it. (#111)
+        if sub_key == 11:
+            return
+
         self._schedule_hub_refresh(hub_id, f"unknown update sub-key {sub_key}")
 
     def _hub_id_from_message(self, msg: HtsMessage) -> str | None:

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -392,6 +392,77 @@ class TestHandleUpdate:
         client.request_hub_data.assert_awaited_once_with("12345678")
 
     @pytest.mark.asyncio
+    async def test_subkey_11_with_anchor_keys_updates_state_without_refresh(self) -> None:
+        # Regression for #111: short deltas on sub-key 11 carry no anchor
+        # keys and used to fire a full-snapshot refresh on every heartbeat.
+        # The long-form variant (50 byte payload with anchor keys) must
+        # still parse and update hub state — that's the path real
+        # network changes flow through.
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        client._hub_states["12345678"] = HubNetworkState(ethernet_connected=True)
+        client._on_state_update = MagicMock()
+        client.request_hub_data = AsyncMock()
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x0b",  # sub-key 11
+                    b"\x48",  # KEY_ACTIVE_CHANNELS — anchor key, marks as network delta
+                    b"\x02",  # wifi bit set
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        state = client.hub_states["12345678"]
+        assert state.wifi_connected is True
+        client._on_state_update.assert_called_once_with("12345678", state)
+        client.request_hub_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_subkey_11_without_anchor_keys_drops_silently(self) -> None:
+        # Regression for #111: Hansontech190 and b0arkz reported sub-key
+        # 11 messages every few seconds with a 34-byte payload that
+        # contained no anchor keys. The handler used to fall through to
+        # `_schedule_hub_refresh` and trigger a full settings+status
+        # round-trip per heartbeat. Now the handler drops these without
+        # firing a refresh — the same parser would not learn anything
+        # new from the snapshot, so the round-trip is pure stress on the
+        # Ajax cloud and HA's event loop.
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        client._on_state_update = MagicMock()
+        client.request_hub_data = AsyncMock()
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x0b",  # sub-key 11
+                    b"\x99",  # unknown key
+                    b"\x01",  # opaque value
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+        await asyncio.sleep(0)
+
+        client.request_hub_data.assert_not_called()
+        client._on_state_update.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_listen_keeps_connection_open_on_idle_read_timeout(self) -> None:
         client = _make_client()
         client._connected = True


### PR DESCRIPTION
## Summary

- Drops sub-key 11 short deltas silently instead of triggering a `REQUEST_FULL_SETTINGS + REQUEST_FULL_STATUS` round-trip on every heartbeat.
- Long-form sub-key 11 deltas (with anchor keys) keep parsing as before — no behaviour change for hub-network sensors.
- Other genuinely unknown sub-keys still trigger one refresh, since that path remains useful as a first-time discovery signal.

## Why

@Hansontech190 and @b0arkz reported on #111 that their HA installs were spamming the Ajax cloud every few seconds:

```
Hub <id>: requesting fresh HTS snapshot after unknown update sub-key 11
Sent REQUEST_FULL_SETTINGS to <id>
Sent REQUEST_FULL_STATUS to <id>
```

The diagnostic log shows the same sub-key 11 behaving two ways on the same hub:

- `payload=50b` → `parsed 4 keys from delta sub-key 11` ✓
- `payload=34b` → `unknown update sub-key 11` → full snapshot refresh

Both flow through the same `parse_hub_params`. The short variant only carries fields we don't surface today, so the round-trip cannot learn anything the next long-form delta wouldn't carry. The refresh was pure stress on the Ajax cloud (~8.6 KB per heartbeat per hub) and HA's event loop.

## Test plan

- [x] New `test_subkey_11_with_anchor_keys_updates_state_without_refresh` — long-form path keeps updating state and never calls `request_hub_data`.
- [x] New `test_subkey_11_without_anchor_keys_drops_silently` — short-form path drops with no state update and no refresh.
- [x] `test_unknown_hub_update_requests_refresh_once` still passes — other unknown sub-keys still trigger one refresh.
- [x] Full unit suite: 1135 passed, 84% coverage.
- [x] `make check` clean inside Docker without volume mount (ruff, ruff format, mypy, vulture).
- [ ] @Hansontech190 / @b0arkz validation on `1.3.0-beta.8` — `Hub <id>: requesting fresh HTS snapshot after unknown update sub-key 11` should be absent from their logs after upgrading.

Refs #111