### PR TITLE
feat(repairs): surface 'FCM not configured' as a fixable Repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Repair card when FCM credentials are missing.** Surfaces under **Settings → Repairs** as "Push notifications not configured — real-time events disabled" with a one-click fix flow that re-uses the existing `fcm_credentials_invalid` form (Project ID / App ID / API Key / Sender ID). Real-time events (doorbell ring, arm/disarm pushes, alarm) require FCM, but until now an unconfigured install was completely silent — the only log line was at INFO level, which HA hides by default. The repair is raised on every integration start when no `fcm_api_key` is set and cleared on the first successful FCM start. Translations in all 14 locales. (#119, #129)
+
+### Changed
+- **"FCM credentials not configured" log promoted from INFO to WARNING.** Now visible in HA's default log level without enabling the integration's debug logger. Healthy installs (FCM configured and registered) remain log-silent during normal operation, so the rule becomes: no FCM line at WARNING = FCM is OK. (#119, #129)
+
 ## [1.3.0-beta.8] - 2026-05-13
 
 Eighth beta of the `1.3.0` line. Targeted HTS-traffic fix on top of `beta.7`. No Ajax wire-protocol changes; no entity-level behaviour change for healthy installs.

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -21,7 +21,9 @@ from custom_components.aegis_ajax.const import (
 )
 from custom_components.aegis_ajax.repairs import (
     async_clear_fcm_credentials_invalid,
+    async_clear_fcm_not_configured,
     async_register_fcm_credentials_invalid,
+    async_register_fcm_not_configured,
 )
 
 if TYPE_CHECKING:
@@ -99,11 +101,16 @@ class AjaxNotificationListener:
         # credentials roundtrip can re-raise it from a clean slate.
         if self._entry_id:
             async_clear_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)
+            async_clear_fcm_not_configured(self._hass, entry_id=self._entry_id)
         if not self._fcm_api_key:
-            _LOGGER.info(
-                "FCM credentials not configured — push notifications disabled. "
-                "Configure them in the integration's Options to enable real-time pushes."
+            _LOGGER.warning(
+                "FCM credentials not configured — push notifications disabled, "
+                "real-time events (doorbell ring, arm/disarm, alarm) will not reach HA. "
+                "Configure them in Settings → Devices & Services → Aegis for Ajax → Configure, "
+                "or open the Repair card surfaced under Settings → Repairs."
             )
+            if self._entry_id:
+                async_register_fcm_not_configured(self._hass, entry_id=self._entry_id)
             return
 
         try:

--- a/custom_components/aegis_ajax/repairs.py
+++ b/custom_components/aegis_ajax/repairs.py
@@ -35,6 +35,7 @@ DOCS_BASE_URL = "https://github.com/bvis/aegis-hass#"
 ISSUE_HUB_OFFLINE_24H = "hub_offline_24h"
 ISSUE_HTS_CHRONIC_FAILURE = "hts_chronic_failure"
 ISSUE_FCM_CREDENTIALS_INVALID = "fcm_credentials_invalid"
+ISSUE_FCM_NOT_CONFIGURED = "fcm_not_configured"
 ISSUE_GRPCIO_VERSION_MISMATCH = "grpcio_version_mismatch"
 
 # Floor below which the integration's gRPC calls have historically failed
@@ -125,6 +126,31 @@ def async_register_fcm_credentials_invalid(hass: HomeAssistant, *, entry_id: str
 
 def async_clear_fcm_credentials_invalid(hass: HomeAssistant, *, entry_id: str) -> None:
     ir.async_delete_issue(hass, DOMAIN, _issue_id(ISSUE_FCM_CREDENTIALS_INVALID, entry_id))
+
+
+def async_register_fcm_not_configured(hass: HomeAssistant, *, entry_id: str) -> None:
+    """FCM credentials are not set on this entry, so real-time pushes are off.
+
+    Distinct from `fcm_credentials_invalid` (which means keys were tried and
+    rejected): this fires when the four FCM fields are empty. Real-time
+    events (doorbell ring, arm/disarm pushes, alarm) won't reach HA until
+    keys are entered. Fixable in-place via `FcmCredentialsRepairFlow`,
+    same form as the invalid-credentials repair.
+    """
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        _issue_id(ISSUE_FCM_NOT_CONFIGURED, entry_id),
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=ISSUE_FCM_NOT_CONFIGURED,
+        data={"entry_id": entry_id},
+        learn_more_url=f"{DOCS_BASE_URL}push-notifications-fcm",
+    )
+
+
+def async_clear_fcm_not_configured(hass: HomeAssistant, *, entry_id: str) -> None:
+    ir.async_delete_issue(hass, DOMAIN, _issue_id(ISSUE_FCM_NOT_CONFIGURED, entry_id))
 
 
 def _parse_version(value: str) -> tuple[int, ...]:
@@ -242,9 +268,10 @@ async def async_create_fix_flow(
     data: dict[str, str | int | float | None] | None,
 ) -> RepairsFlow:
     """HA discovery hook — returns the right flow for each fixable issue."""
-    if issue_id.startswith(f"{ISSUE_FCM_CREDENTIALS_INVALID}:"):
-        entry_id = (data or {}).get("entry_id") or issue_id.split(":", 1)[1]
-        return FcmCredentialsRepairFlow(str(entry_id))
+    for prefix in (ISSUE_FCM_CREDENTIALS_INVALID, ISSUE_FCM_NOT_CONFIGURED):
+        if issue_id.startswith(f"{prefix}:"):
+            entry_id = (data or {}).get("entry_id") or issue_id.split(":", 1)[1]
+            return FcmCredentialsRepairFlow(str(entry_id))
     # Fall back: HA's built-in confirm-only flow. Should not be hit since
     # we only mark FCM as fixable today.
     from homeassistant.components.repairs import ConfirmRepairFlow  # noqa: PLC0415

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Notificacions push desactivades: credencials FCM rebutjades",
             "description": "El registre a Firebase Cloud Messaging ha fallat per a aquest compte. Probablement, el FCM Project ID / App ID / API Key / Sender ID configurats no es corresponen amb la teva app Ajax co-branded, o la API key s'ha revocat. Les funcions que depenen del push (estat instantani d'armat/desarmat, entitat security_event, URL de fotos de MotionCam) cauran a polling mes lent fins que es corregeixi. Obre el menu Configurar de la integracio per reintroduir les credencials FCM - consulta la seccio 'How to obtain FCM credentials' del README."
+        },
+        "fcm_not_configured": {
+            "title": "Notificacions push no configurades — esdeveniments en temps real desactivats",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Configurar credencials FCM d'Aegis",
+                        "description": "Les credencials FCM no s'han configurat mai per a aquest compte, de manera que els esdeveniments en temps real d'Ajax (timbre, armat/desarmat, alarma) no poden arribar a Home Assistant — la integracio recau en el sondeig cada 5 minuts. Introdueix els quatre valors FCM de la teva app Ajax co-branded a continuacio i la integracio es recarregara. Consulta la seccio 'How to obtain FCM credentials' del README.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "El compte d'Aegis per al qual s'ha generat aquest Repair ja no esta configurat. No hi ha res a reparar."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Push oznameni vypnuta - prihlasovaci udaje FCM odmitnuty",
             "description": "Registrace Firebase Cloud Messaging selhala pro tento ucet. Konfigurovane hodnoty FCM Project ID / App ID / API Key / Sender ID pravdepodobne neodpovidaji vasi co-brandove aplikaci Ajax, nebo byl API klic zneplatnen. Funkce zavisle na pushi (okamzity stav armed/disarmed, entita security_event, URL fotek z MotionCam) prejdou na pomalejsi polling, dokud to nenapravite. Otevrete nabidku Konfigurovat integrace a zadejte znovu prihlasovaci udaje FCM - viz sekce 'How to obtain FCM credentials' v README."
+        },
+        "fcm_not_configured": {
+            "title": "Push notifikace nejsou nakonfigurovany — udalosti v realnem case zakazany",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Nakonfigurovat FCM prihlasovaci udaje pro Aegis",
+                        "description": "FCM prihlasovaci udaje nikdy nebyly pro tento ucet nastaveny, takze udalosti v realnem case od Ajax (zvoneni dvernich zvonku, zapnuti/vypnuti alarmu, alarm) nemohou dorazit do Home Assistant — integrace se vraci k pollingu kazdych 5 minut. Nize zadejte ctyri hodnoty FCM pro vasi co-brandovou aplikaci Ajax a integrace se znovu nacte. Postup ziskani najdete v sekci 'How to obtain FCM credentials' v README.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Ajaxsky ucet, pro ktery byl tento Repair vyvolan, jiz neni nakonfigurovan. Neni co opravovat."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Push-Benachrichtigungen deaktiviert - FCM-Anmeldedaten abgelehnt",
             "description": "Die Firebase-Cloud-Messaging-Registrierung ist fuer dieses Konto fehlgeschlagen. Die konfigurierten Werte FCM Project ID / App ID / API Key / Sender ID passen vermutlich nicht zu Ihrer Co-Branding-Ajax-App oder der API-Schluessel wurde widerrufen. Push-basierte Funktionen (sofortiger Arm/Disarm-Status, security_event-Entitaet, Foto-URLs von MotionCam) fallen auf langsameres Polling zurueck, bis dies behoben ist. Oeffnen Sie das Konfigurationsmenue der Integration und geben Sie die FCM-Anmeldedaten erneut ein - siehe Abschnitt 'How to obtain FCM credentials' in der README."
+        },
+        "fcm_not_configured": {
+            "title": "Push-Benachrichtigungen nicht konfiguriert — Echtzeit-Ereignisse deaktiviert",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Aegis FCM-Zugangsdaten konfigurieren",
+                        "description": "Fur dieses Konto wurden nie FCM-Zugangsdaten festgelegt, daher koennen Echtzeit-Ereignisse von Ajax (Tuerklingel, Aktivieren/Deaktivieren, Alarm) Home Assistant nicht erreichen — die Integration faellt auf Abfragen alle 5 Minuten zurueck. Gib unten die vier FCM-Werte fuer deine Co-Brand-Ajax-App ein und die Integration wird neu geladen. Siehe den Abschnitt 'How to obtain FCM credentials' im README zum Auslesen.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Das Aegis-Konto, fuer das diese Reparatur ausgeloest wurde, ist nicht mehr konfiguriert. Nichts zu reparieren."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -174,6 +174,26 @@
                 }
             }
         },
+        "fcm_not_configured": {
+            "title": "Push notifications not configured — real-time events disabled",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Configure Aegis FCM credentials",
+                        "description": "FCM credentials have never been set for this account, so real-time events from Ajax (doorbell ring, arm/disarm pushes, alarm) cannot reach Home Assistant — the integration falls back to polling every 5 minutes. Enter the four FCM values for your co-branded Ajax app below and the integration will reload. See the README's 'How to obtain FCM credentials' section for how to extract them from your Ajax app.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "The Aegis account this Repair was raised for is no longer configured. Nothing to fix."
+                }
+            }
+        },
         "grpcio_version_mismatch": {
             "title": "Aegis needs grpcio {required} or newer (found {current})",
             "description": "Aegis depends on `grpcio` for the gRPC channel that talks to the Ajax cloud, and your Home Assistant install ships `grpcio` {current}. Login can fail with cryptic HTTP/2 errors below {required}. On Home Assistant Core or Container the integration manifest pins the version on install, but on Home Assistant OS the runtime ships system-wide grpcio that this manifest cannot influence — you'll typically need to upgrade Home Assistant OS to a build that includes a newer grpcio. The Repair clears automatically on the next reload once the version crosses {required}."

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -174,6 +174,26 @@
                 }
             }
         },
+        "fcm_not_configured": {
+            "title": "Notificaciones push sin configurar: eventos en tiempo real desactivados",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Configurar credenciales FCM de Aegis",
+                        "description": "Las credenciales FCM nunca se han configurado para esta cuenta, por lo que los eventos en tiempo real de Ajax (timbre, armado/desarmado, alarma) no llegan a Home Assistant — la integracion cae a polling cada 5 minutos. Introduce abajo los cuatro valores FCM de tu app Ajax co-branded y la integracion se recargara. Consulta la seccion 'How to obtain FCM credentials' del README para extraerlos.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "La cuenta de Aegis para la que se levanto este Repair ya no esta configurada. No hay nada que reparar."
+                }
+            }
+        },
         "grpcio_version_mismatch": {
             "title": "Aegis necesita grpcio {required} o superior (encontrado {current})",
             "description": "Aegis depende de `grpcio` para el canal gRPC que habla con la nube de Ajax, y tu instalacion de Home Assistant trae `grpcio` {current}. Por debajo de {required} el login puede fallar con errores HTTP/2 poco descriptivos. En Home Assistant Core o Container el manifest de la integracion fija la version al instalar, pero en Home Assistant OS el runtime trae un grpcio del sistema que este manifest no puede tocar — normalmente toca actualizar Home Assistant OS a una build que incluya un grpcio mas reciente. La incidencia se cierra automaticamente en la siguiente recarga cuando la version cruce {required}."

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Notifications push desactivees - identifiants FCM rejetes",
             "description": "L'enregistrement Firebase Cloud Messaging a echoue pour ce compte. Les valeurs FCM Project ID / App ID / API Key / Sender ID configurees ne correspondent probablement pas a votre application Ajax co-brandee, ou la cle API a ete revoquee. Les fonctions dependantes du push (etat instantane d'armement/desarmement, entite security_event, URLs de photos de MotionCam) basculent vers un polling plus lent jusqu'a correction. Ouvrez le menu Configurer de l'integration pour ressaisir les identifiants FCM - voir la section 'How to obtain FCM credentials' du README."
+        },
+        "fcm_not_configured": {
+            "title": "Notifications push non configurees — evenements temps reel desactives",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Configurer les identifiants FCM d'Aegis",
+                        "description": "Les identifiants FCM n'ont jamais ete renseignes pour ce compte, donc les evenements temps reel d'Ajax (sonnette, armement/desarmement, alarme) ne peuvent pas atteindre Home Assistant — l'integration retombe sur du polling toutes les 5 minutes. Saisis ci-dessous les quatre valeurs FCM de ton application Ajax co-brandee et l'integration sera rechargee. Voir la section 'How to obtain FCM credentials' du README pour les extraire de ton application Ajax.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Le compte Aegis pour lequel ce Repair a ete declenche n'est plus configure. Rien a reparer."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Notifiche push disabilitate - credenziali FCM rifiutate",
             "description": "La registrazione Firebase Cloud Messaging non e riuscita per questo account. I valori FCM Project ID / App ID / API Key / Sender ID configurati probabilmente non corrispondono alla tua app Ajax co-branded, oppure la API key e stata revocata. Le funzionalita basate sul push (stato istantaneo di armato/disarmato, entita security_event, URL delle foto da MotionCam) ripiegheranno su polling piu lento finche non viene corretto. Apri il menu Configura dell'integrazione per reinserire le credenziali FCM - consulta la sezione 'How to obtain FCM credentials' del README."
+        },
+        "fcm_not_configured": {
+            "title": "Notifiche push non configurate — eventi in tempo reale disattivati",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Configurare le credenziali FCM di Aegis",
+                        "description": "Le credenziali FCM non sono mai state impostate per questo account, quindi gli eventi in tempo reale di Ajax (campanello, armo/disarmo, allarme) non possono raggiungere Home Assistant — l'integrazione ripiega sul polling ogni 5 minuti. Inserisci sotto i quattro valori FCM per la tua app Ajax co-brandizzata e l'integrazione verra ricaricata. Consulta la sezione 'How to obtain FCM credentials' del README per estrarli dalla tua app Ajax.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "L'account Aegis per cui e stato sollevato questo Repair non e piu configurato. Niente da riparare."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Pushmeldingen uitgeschakeld - FCM-inloggegevens afgewezen",
             "description": "Firebase Cloud Messaging-registratie is voor dit account mislukt. De ingestelde FCM Project ID / App ID / API Key / Sender ID komen waarschijnlijk niet overeen met je co-branded Ajax-app, of de API-sleutel is ingetrokken. Push-afhankelijke functies (directe arm/disarm-status, security_event-entiteit, foto-URL's van MotionCam) vallen terug op langzamere polling totdat dit is opgelost. Open het menu Configureren van de integratie om de FCM-inloggegevens opnieuw in te voeren - zie de sectie 'How to obtain FCM credentials' in de README."
+        },
+        "fcm_not_configured": {
+            "title": "Pushmeldingen niet geconfigureerd — realtime gebeurtenissen uitgeschakeld",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Aegis FCM-inloggegevens configureren",
+                        "description": "Voor dit account zijn nooit FCM-inloggegevens ingesteld, dus realtime gebeurtenissen van Ajax (deurbel, in/uit schakelen, alarm) kunnen Home Assistant niet bereiken — de integratie valt terug op pollen elke 5 minuten. Vul hieronder de vier FCM-waarden van je co-branded Ajax-app in en de integratie wordt opnieuw geladen. Zie de sectie 'How to obtain FCM credentials' in de README voor instructies om ze uit te lezen.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Het Aegis-account waarvoor deze Repair is aangemaakt, is niet meer geconfigureerd. Niets te repareren."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Powiadomienia push wylaczone - dane FCM odrzucone",
             "description": "Rejestracja Firebase Cloud Messaging nie powiodla sie dla tego konta. Skonfigurowane wartosci FCM Project ID / App ID / API Key / Sender ID najprawdopodobniej nie odpowiadaja Twojej co-brandowej aplikacji Ajax lub klucz API zostal uniewazniony. Funkcje zalezne od push (natychmiastowy stan uzbrojenia/rozbrojenia, encja security_event, URL zdjec z MotionCam) przejda na wolniejszy polling do czasu naprawy. Otworz menu Konfiguruj integracji, aby ponownie wpisac dane FCM - zobacz sekcje 'How to obtain FCM credentials' w README."
+        },
+        "fcm_not_configured": {
+            "title": "Powiadomienia push nie skonfigurowane — zdarzenia w czasie rzeczywistym wylaczone",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Skonfiguruj poswiadczenia FCM dla Aegis",
+                        "description": "Poswiadczenia FCM nigdy nie zostaly ustawione dla tego konta, wiec zdarzenia w czasie rzeczywistym z Ajax (dzwonek do drzwi, uzbrajanie/rozbrajanie, alarm) nie moga dotrzec do Home Assistant — integracja korzysta z pollingu co 5 minut. Wprowadz ponizej cztery wartosci FCM dla swojej aplikacji Ajax co-brand i integracja zostanie ponownie zaladowana. Zobacz sekcje 'How to obtain FCM credentials' w README jak je wyodrebnic.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Konto Aegis, dla ktorego utworzono ten Repair, nie jest juz skonfigurowane. Nie ma czego naprawiac."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Notificacoes push desativadas - credenciais FCM rejeitadas",
             "description": "O registro no Firebase Cloud Messaging falhou para esta conta. Os valores configurados de FCM Project ID / App ID / API Key / Sender ID provavelmente nao correspondem ao seu aplicativo Ajax co-branded, ou a chave da API foi revogada. Os recursos baseados em push (estado instantaneo de armar/desarmar, entidade security_event, URLs de fotos do MotionCam) farao fallback para polling mais lento ate a correcao. Abra o menu Configurar da integracao para inserir novamente as credenciais FCM - consulte a secao 'How to obtain FCM credentials' do README."
+        },
+        "fcm_not_configured": {
+            "title": "Notificacoes push nao configuradas — eventos em tempo real desativados",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Configurar credenciais FCM do Aegis",
+                        "description": "As credenciais FCM nunca foram definidas para esta conta, entao os eventos em tempo real do Ajax (campainha, armar/desarmar, alarme) nao chegam ao Home Assistant — a integracao recorre ao polling a cada 5 minutos. Informe abaixo os quatro valores FCM para o seu app Ajax co-brand e a integracao sera recarregada. Veja a secao 'How to obtain FCM credentials' no README para extrai-los.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "A conta Aegis para a qual este Repair foi criado nao esta mais configurada. Nada a reparar."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Notificacoes push desativadas - credenciais FCM rejeitadas",
             "description": "O registo no Firebase Cloud Messaging falhou para esta conta. Os valores configurados de FCM Project ID / App ID / API Key / Sender ID provavelmente nao correspondem a sua aplicacao Ajax co-branded, ou a chave da API foi revogada. As funcionalidades baseadas em push (estado instantaneo de armar/desarmar, entidade security_event, URLs de fotos do MotionCam) caem para polling mais lento ate a correcao. Abra o menu Configurar da integracao para introduzir novamente as credenciais FCM - consulte a seccao 'How to obtain FCM credentials' do README."
+        },
+        "fcm_not_configured": {
+            "title": "Notificacoes push nao configuradas — eventos em tempo real desativados",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Configurar credenciais FCM do Aegis",
+                        "description": "As credenciais FCM nunca foram definidas para esta conta, por isso os eventos em tempo real do Ajax (campainha, armar/desarmar, alarme) nao chegam ao Home Assistant — a integracao recorre a polling a cada 5 minutos. Introduz abaixo os quatro valores FCM para a tua app Ajax co-brand e a integracao sera recarregada. Consulta a seccao 'How to obtain FCM credentials' do README para os extrair.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "A conta Aegis para a qual este Repair foi gerado ja nao esta configurada. Nada a reparar."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Notificarile push dezactivate - credentiale FCM respinse",
             "description": "Inregistrarea Firebase Cloud Messaging a esuat pentru acest cont. Valorile configurate FCM Project ID / App ID / API Key / Sender ID probabil nu corespund aplicatiei tale Ajax co-branded, sau cheia API a fost revocata. Functionalitatile bazate pe push (stare instantanee armat/dezarmat, entitatea security_event, URL-uri de fotografii de la MotionCam) vor cadea pe polling mai lent pana la corectare. Deschide meniul Configureaza al integrarii pentru a reintroduce credentialele FCM - consulta sectiunea 'How to obtain FCM credentials' din README."
+        },
+        "fcm_not_configured": {
+            "title": "Notificarile push nu sunt configurate — evenimente in timp real dezactivate",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Configureaza credentialele FCM pentru Aegis",
+                        "description": "Credentialele FCM nu au fost niciodata setate pentru acest cont, asa ca evenimentele in timp real de la Ajax (sonerie, armare/dezarmare, alarma) nu pot ajunge la Home Assistant — integrarea cade pe polling la fiecare 5 minute. Introdu mai jos cele patru valori FCM pentru aplicatia ta Ajax co-brand si integrarea va fi reincarcata. Consulta sectiunea 'How to obtain FCM credentials' din README pentru a le extrage.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Contul Aegis pentru care a fost generat acest Repair nu mai este configurat. Nu este nimic de reparat."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Push bildirimleri devre disi - FCM kimlik bilgileri reddedildi",
             "description": "Bu hesap icin Firebase Cloud Messaging kaydi basarisiz oldu. Yapilandirilmis FCM Project ID / App ID / API Key / Sender ID degerleri buyuk olasilikla co-branded Ajax uygulamaniza karsilik gelmiyor veya API anahtari iptal edilmis. Push'a bagimli ozellikler (anlik armed/disarmed durumu, security_event varligi, MotionCam'den foto URL'leri) bu duzeltilene kadar daha yavas polling'e dusecektir. FCM kimlik bilgilerini yeniden girmek icin entegrasyonun Yapilandir menusunu acin - README'deki 'How to obtain FCM credentials' bolumune bakin."
+        },
+        "fcm_not_configured": {
+            "title": "Push bildirimleri yapilandirilmadi — gercek zamanli olaylar devre disi",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Aegis FCM kimlik bilgilerini yapilandir",
+                        "description": "Bu hesap icin FCM kimlik bilgileri hic ayarlanmadi, bu yuzden Ajax'tan gelen gercek zamanli olaylar (kapi zili, kurma/devre disi birakma, alarm) Home Assistant'a ulasamiyor — entegrasyon her 5 dakikada bir polling'e duser. Asagida co-brand Ajax uygulamaniz icin dort FCM degerini girin ve entegrasyon yeniden yuklenecek. Bunlari uygulamanizdan cikarmak icin README'deki 'How to obtain FCM credentials' bolumune bakin.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Bu Repair'in olusturuldugu Aegis hesabi artik yapilandirilmadi. Onarilacak bir sey yok."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -161,6 +161,26 @@
         "fcm_credentials_invalid": {
             "title": "Push-сповіщення вимкнено — облікові дані FCM відхилено",
             "description": "Реєстрація Firebase Cloud Messaging не вдалась для цього облікового запису. Налаштовані FCM Project ID / App ID / API Key / Sender ID, ймовірно, не відповідають вашому co-branded додатку Ajax, або API-ключ було відкликано. Функції, що залежать від push (миттєвий стан armed/disarmed, сутність security_event, URL-адреси фото з MotionCam), повернуться до повільнішого polling, доки це не буде виправлено. Відкрийте меню Налаштувати інтеграції, щоб повторно ввести облікові дані FCM — див. розділ 'How to obtain FCM credentials' у README."
+        },
+        "fcm_not_configured": {
+            "title": "Push-povidomlennia ne nalashtovano — podii v realnomu chasi vimkneno",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Nalashtuvaty FCM-poslidninnia dlia Aegis",
+                        "description": "FCM-poslidninnia nikoli ne buly nalashtovani dlia tsoho oblikovoho zapisu, tomu podii v realnomu chasi vid Ajax (dzvinok, armuvannia/rozarmuvannia, alarm) ne mozhut dosiahty Home Assistant — intehratsiia perekhodyt na opytuvannia kozhni 5 khvylyn. Vvedit nyzhche chotyry znachennia FCM dlia vashoho co-brand dodatka Ajax, i intehratsiia bude perezavantazhena. Dyvit sektsiiu 'How to obtain FCM credentials' u README, shchob yikh vydobuty.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Oblikovyi zapys Aegis, dlia yakoho bulo stvoreno tsei Repair, bilshe ne nalashtovanyi. Nichoho remontuvaty."
+                }
+            }
         }
     },
     "entity": {

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -239,8 +239,11 @@ class TestAsyncStartFcmRepairs:
     """The FCM listener raises a Repair when registration / push start fails."""
 
     @pytest.mark.asyncio
-    async def test_no_repair_when_fcm_unconfigured(self) -> None:
-        """No api_key → no Repair (push is just opt-out, not broken)."""
+    async def test_not_configured_repair_raised_when_fcm_unconfigured(self) -> None:
+        """No api_key → raise `fcm_not_configured` repair so the user gets a
+        visible nudge to enter keys via the Repair card, plus a WARNING log
+        line (instead of the previous silent INFO). `fcm_credentials_invalid`
+        is left alone — it's a different state (keys present but rejected)."""
         hass = MagicMock()
         coordinator = MagicMock()
         listener = AjaxNotificationListener(
@@ -256,15 +259,25 @@ class TestAsyncStartFcmRepairs:
         with (
             patch(
                 "custom_components.aegis_ajax.notification.async_register_fcm_credentials_invalid"
-            ) as reg,
+            ) as reg_invalid,
             patch(
                 "custom_components.aegis_ajax.notification.async_clear_fcm_credentials_invalid"
-            ) as clr,
+            ) as clr_invalid,
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_not_configured"
+            ) as reg_missing,
+            patch(
+                "custom_components.aegis_ajax.notification.async_clear_fcm_not_configured"
+            ) as clr_missing,
         ):
             await listener.async_start()
 
-        reg.assert_not_called()
-        clr.assert_called_once_with(hass, entry_id="entry-x")
+        reg_invalid.assert_not_called()
+        clr_invalid.assert_called_once_with(hass, entry_id="entry-x")
+        # Cleared once at the top of async_start (start with a clean slate)
+        # then re-registered after the missing-api-key check fires.
+        clr_missing.assert_called_once_with(hass, entry_id="entry-x")
+        reg_missing.assert_called_once_with(hass, entry_id="entry-x")
 
     @pytest.mark.asyncio
     async def test_register_failure_raises_repair(self) -> None:
@@ -287,6 +300,8 @@ class TestAsyncStartFcmRepairs:
                 "custom_components.aegis_ajax.notification.async_register_fcm_credentials_invalid"
             ) as reg,
             patch("custom_components.aegis_ajax.notification.async_clear_fcm_credentials_invalid"),
+            patch("custom_components.aegis_ajax.notification.async_register_fcm_not_configured"),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_not_configured"),
             patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
         ):
             await listener.async_start()

--- a/tests/unit/test_repairs.py
+++ b/tests/unit/test_repairs.py
@@ -9,6 +9,7 @@ import pytest
 from custom_components.aegis_ajax.const import DOMAIN
 from custom_components.aegis_ajax.repairs import (
     ISSUE_FCM_CREDENTIALS_INVALID,
+    ISSUE_FCM_NOT_CONFIGURED,
     ISSUE_GRPCIO_VERSION_MISMATCH,
     ISSUE_HTS_CHRONIC_FAILURE,
     ISSUE_HUB_OFFLINE_24H,
@@ -17,10 +18,12 @@ from custom_components.aegis_ajax.repairs import (
     _parse_version,
     async_check_grpcio_version,
     async_clear_fcm_credentials_invalid,
+    async_clear_fcm_not_configured,
     async_clear_hts_chronic_failure,
     async_clear_hub_offline,
     async_create_fix_flow,
     async_register_fcm_credentials_invalid,
+    async_register_fcm_not_configured,
     async_register_hts_chronic_failure,
     async_register_hub_offline,
 )
@@ -96,6 +99,31 @@ class TestFcmCredentialsRepair:
         kwargs = create.call_args.kwargs
         assert kwargs["is_fixable"] is True
         assert kwargs["data"] == {"entry_id": "entry-abc"}
+
+
+class TestFcmNotConfiguredRepair:
+    def test_register_per_entry(self) -> None:
+        hass = MagicMock()
+        with patch("custom_components.aegis_ajax.repairs.ir.async_create_issue") as create:
+            async_register_fcm_not_configured(hass, entry_id="entry-abc")
+
+        create.assert_called_once()
+        args, kwargs = create.call_args
+        assert args[2] == f"{ISSUE_FCM_NOT_CONFIGURED}:entry-abc"
+        # `not configured` is a WARNING — feature missing, not an error. `invalid`
+        # stays ERROR because the user actively configured wrong values.
+        from homeassistant.helpers import issue_registry as ir  # noqa: PLC0415
+
+        assert kwargs["severity"] == ir.IssueSeverity.WARNING
+        assert kwargs["is_fixable"] is True
+        assert kwargs["data"] == {"entry_id": "entry-abc"}
+
+    def test_clear_per_entry(self) -> None:
+        hass = MagicMock()
+        with patch("custom_components.aegis_ajax.repairs.ir.async_delete_issue") as delete:
+            async_clear_fcm_not_configured(hass, entry_id="entry-abc")
+
+        delete.assert_called_once_with(hass, DOMAIN, f"{ISSUE_FCM_NOT_CONFIGURED}:entry-abc")
 
 
 class TestParseVersion:
@@ -277,6 +305,16 @@ class TestAsyncCreateFixFlow:
         flow = await async_create_fix_flow(hass, f"{ISSUE_FCM_CREDENTIALS_INVALID}:entry-xyz", None)
         assert isinstance(flow, FcmCredentialsRepairFlow)
         assert flow._entry_id == "entry-xyz"
+
+    @pytest.mark.asyncio
+    async def test_returns_fcm_flow_for_not_configured_issue(self) -> None:
+        """`fcm_not_configured` uses the same form as `fcm_credentials_invalid`."""
+        hass = MagicMock()
+        flow = await async_create_fix_flow(
+            hass, f"{ISSUE_FCM_NOT_CONFIGURED}:entry-abc", {"entry_id": "entry-abc"}
+        )
+        assert isinstance(flow, FcmCredentialsRepairFlow)
+        assert flow._entry_id == "entry-abc"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_confirm_flow_for_unknown_issue(self) -> None:


### PR DESCRIPTION
## Summary

Add a new fixable Repair card that fires when FCM credentials are not set on an Aegis entry, and promote the corresponding log line from INFO to WARNING so it's visible at HA's default log level.

- New `fcm_not_configured` Repair (WARNING, `is_fixable=True`) raised on every start when `fcm_api_key` is empty, cleared on first successful FCM start.
- Re-uses the existing `FcmCredentialsRepairFlow` for the fix form. `async_create_fix_flow` now routes both `fcm_credentials_invalid` and `fcm_not_configured` issue prefixes to it.
- `_LOGGER.info("FCM credentials not configured...")` → `_LOGGER.warning(...)` with an expanded message that also points to the Repair card.
- Translations in all 14 locales (`ca, cs, de, en, es, fr, it, nl, pl, pt, pt-BR, ro, tr, uk`).

## Why

Real-time events from Ajax (doorbell ring, arm/disarm pushes, alarm) only reach HA via FCM. The integration ships without FCM keys — they're per-cobrand and have to be entered manually under Options. Until this PR an install that skipped that step was indistinguishable from a healthy one: no warning in the default log, no UI signal, only a silent 5-minute polling fallback. Both #119 (Permudious) and #129 (ArshSoni) turned out to be exactly this state — neither of them could see anything was missing.

After this change:

- Default HA log shows a WARNING with a one-line explanation and pointer to the Repair card.
- Settings → Repairs shows a fixable card; clicking it opens the same FCM form as the existing `fcm_credentials_invalid` repair.
- Healthy installs (FCM configured) remain log-silent during normal operation. The rule for users becomes: **no FCM line at WARNING = FCM is OK**.

## Test plan

- [x] `TestFcmNotConfiguredRepair` — register/clear helpers, severity = WARNING, fixable, entry_id in data.
- [x] `test_returns_fcm_flow_for_not_configured_issue` — `async_create_fix_flow` routes new prefix to the same form class.
- [x] `test_not_configured_repair_raised_when_fcm_unconfigured` — listener registers the repair when api_key empty, clears it at start.
- [x] Existing `test_register_failure_raises_repair` extended with the new patch points.
- [x] `make check` clean inside Docker without volume mount: 1138 passed (+3), 84.09% coverage, lint/format/typecheck/vulture all green.
- [x] `hassfest` local: 0 invalid integrations.
- [ ] Behaviour validation against #119 / #129 once `1.3.0-beta.9` is published — Permudious and ArshSoni should both see the new Repair card on their installs and confirm FCM was never configured.

Refs #119, #129