### PR TITLE
feat(notification): classify FCM failures into actionable WARNINGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **FCM registration / push-start failures now emit a cause-specific WARNING instead of a generic stack trace.** Until now every FCM error landed in the log as `FCM registration failed` plus a traceback, leaving the user with nothing actionable. The library raises plain `RuntimeError` / `Exception` with the cause encoded only in the message string, so the listener now classifies on substrings before logging: `Unable to establish subscription with Google Cloud Messaging` points the user at credential-set consistency (the four values must come from the same Firebase project); HTTP `403` / `API key not valid` describes the expected `fcm_api_key` format (`AIza` + 35 chars); network / DNS / timeout errors name the FCM hosts the HA host needs to reach; everything else falls back to the original message wrapped in `FCM registration failed: ...` so no signal is lost. No UI / Repair changes — same `fcm_credentials_invalid` card is raised in all failure paths, only the log gets sharper. (#131)
+
 ## [1.3.0-beta.9] - 2026-05-14
 
 Ninth beta of the `1.3.0` line. Surfaces FCM-misconfiguration as an actionable UI signal so users stop discovering it through silent real-time-event failures. No Ajax wire-protocol changes.

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -43,6 +43,43 @@ STORAGE_VERSION = 1
 NOTIFICATION_DEDUPE_WINDOW_SECONDS = 5.0
 
 
+def _classify_fcm_failure(exc: BaseException) -> str:
+    """Return a user-actionable WARNING message for an FCM registration / push-client error.
+
+    `firebase-messaging` raises plain `RuntimeError` / `Exception` with the cause
+    encoded only in the message string, so we discriminate on substrings. Every
+    branch gives the user (and any reader of the default-level log) a concrete
+    next step, instead of the generic "FCM registration failed" the integration
+    used through `1.3.0-beta.9`.
+    """
+    msg = str(exc) if exc else ""
+    lower = msg.lower()
+
+    if "subscription" in lower and "google cloud messaging" in lower:
+        return (
+            "FCM registration rejected by Google. The four credentials must all "
+            "come from the same Firebase project — fcm_sender_id must match the "
+            "numeric prefix inside fcm_app_id, and fcm_api_key must be paired "
+            "with that same fcm_project_id. Re-enter all four together via the "
+            "Repair card under Settings → Repairs."
+        )
+    if "api key not valid" in lower or "api_key_invalid" in lower or " 403" in f" {msg}":
+        return (
+            "FCM API key was rejected by Google (403). The expected fcm_api_key "
+            'format is "AIza" followed by 35 alphanumeric / underscore / hyphen '
+            "characters (39 chars total). Re-check the value entered via the "
+            "Repair card under Settings → Repairs."
+        )
+    if any(token in lower for token in ("failed to resolve", "connection", "timeout", "network")):
+        return (
+            "Couldn't reach Google FCM servers. Check the HA host can reach "
+            "android.clients.google.com / firebaseinstallations.googleapis.com "
+            "(firewall, DNS, or proxy issue). The Repair card stays raised until "
+            "the next successful registration."
+        )
+    return f"FCM registration failed: {msg or exc.__class__.__name__}"
+
+
 class AjaxNotificationListener:
     """Manages FCM push notification registration and listening."""
 
@@ -149,8 +186,8 @@ class AjaxNotificationListener:
                 self._credentials = dict(raw_result)
                 await self._store.async_save(self._credentials)
                 _LOGGER.info("FCM registration successful")
-            except Exception:
-                _LOGGER.exception("FCM registration failed")
+            except Exception as exc:
+                _LOGGER.warning(_classify_fcm_failure(exc), exc_info=True)
                 if self._entry_id:
                     async_register_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)
                 return
@@ -182,8 +219,8 @@ class AjaxNotificationListener:
             else:
                 await self._hass.async_add_executor_job(self._push_client.start)
             _LOGGER.info("FCM push client started — push notifications active")
-        except Exception:
-            _LOGGER.exception("Failed to start FCM push client")
+        except Exception as exc:
+            _LOGGER.warning(_classify_fcm_failure(exc), exc_info=True)
             self._push_client = None
             if self._entry_id:
                 async_register_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -8,7 +8,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.aegis_ajax.notification import AjaxNotificationListener
+from custom_components.aegis_ajax.notification import (
+    AjaxNotificationListener,
+    _classify_fcm_failure,
+)
 
 _FCM_KWARGS = {
     "fcm_project_id": "test-project",
@@ -307,6 +310,61 @@ class TestAsyncStartFcmRepairs:
             await listener.async_start()
 
         reg.assert_called_once_with(hass, entry_id="entry-x")
+
+
+class TestClassifyFcmFailure:
+    """`_classify_fcm_failure` turns library errors into actionable WARNINGs (#131)."""
+
+    def test_gcm_subscription_rejection_points_at_project_consistency(self) -> None:
+        # Hansontech190's report: firebase-messaging raises this exact
+        # RuntimeError when the four credentials don't all belong to the
+        # same Firebase project. The user-facing message must steer them
+        # toward checking sender_id/app_id/project_id consistency, not
+        # toward extraction internals (no APK / cobrand / .so wording).
+        msg = _classify_fcm_failure(
+            RuntimeError("Unable to establish subscription with Google Cloud Messaging.")
+        )
+        assert "rejected by Google" in msg
+        assert "same Firebase project" in msg
+        assert "fcm_sender_id" in msg and "fcm_app_id" in msg and "fcm_project_id" in msg
+        # No leakage of extraction jargon to user logs
+        for forbidden in ("APK", "cobrand", "libnative", "strings.xml"):
+            assert forbidden not in msg
+
+    def test_403_api_key_rejection_explains_format(self) -> None:
+        msg = _classify_fcm_failure(RuntimeError("API key not valid. Please pass a valid API key."))
+        assert "API key" in msg
+        assert "AIza" in msg
+        assert "39 chars" in msg
+
+    def test_403_status_code_in_message_classifies_as_api_key_rejected(self) -> None:
+        msg = _classify_fcm_failure(RuntimeError("Got HTTP 403 from FCM register endpoint"))
+        assert "API key" in msg
+        assert "AIza" in msg
+
+    def test_network_error_points_at_dns_firewall(self) -> None:
+        msg = _classify_fcm_failure(OSError("Failed to resolve android.clients.google.com"))
+        assert "reach Google FCM servers" in msg
+        assert "DNS" in msg or "firewall" in msg
+
+    def test_timeout_classified_as_network(self) -> None:
+        msg = _classify_fcm_failure(TimeoutError("Connection timeout while contacting FCM"))
+        assert "reach Google FCM servers" in msg
+
+    def test_unknown_error_falls_back_to_generic_with_message(self) -> None:
+        # Don't lose the original exception text in the fallback path —
+        # it's the only signal a human has to diagnose a case we haven't
+        # taught the classifier yet.
+        msg = _classify_fcm_failure(RuntimeError("something completely unexpected"))
+        assert msg.startswith("FCM registration failed")
+        assert "something completely unexpected" in msg
+
+    def test_empty_exception_message_still_returns_a_string(self) -> None:
+        # Some library paths raise bare RuntimeError() with no message.
+        # Don't crash the listener; surface the class name instead.
+        msg = _classify_fcm_failure(RuntimeError())
+        assert "FCM registration failed" in msg
+        assert "RuntimeError" in msg
 
 
 class TestApplySecurityStateFromEvent:


### PR DESCRIPTION
## Summary

When FCM registration or the push client fails, the default-level log now describes the *cause* with concrete next steps instead of the generic `FCM registration failed` + traceback.

- Substring-based classification on the exception message (the `firebase-messaging` library raises plain `RuntimeError` / `Exception` with no typed cause).
- Three discriminated cases plus a generic fallback that preserves the original message.
- Same `fcm_credentials_invalid` Repair card raised in every path — UI behaviour unchanged.

## Why

#131: @Hansontech190 entered FCM credentials and the integration responded with `FCM registration failed` + 38-line traceback. The actual cause (Google rejected the registration because the four values didn't all belong to the same Firebase project) was buried in one line of the traceback that read `Unable to establish subscription with Google Cloud Messaging`. Without prior knowledge of that library, there's no way to know that message means "your sender_id and your api_key were issued by different projects".

After this change the user sees:

```
FCM registration rejected by Google. The four credentials must all
come from the same Firebase project — fcm_sender_id must match the
numeric prefix inside fcm_app_id, and fcm_api_key must be paired
with that same fcm_project_id. Re-enter all four together via the
Repair card under Settings → Repairs.
```

… in the default-level log, no debug toggle needed.

## Mapping

| Library message contains | New WARNING |
|---|---|
| `Unable to establish subscription with Google Cloud Messaging` | Credential-set consistency hint pointing at sender_id ↔ app_id and api_key ↔ project_id pairing |
| `API key not valid` / `api_key_invalid` / ` 403 ` | Expected `fcm_api_key` format (`AIza` + 35 alphanumeric/underscore/hyphen chars) |
| `Failed to resolve` / `Connection` / `Timeout` / `Network` | HA host can't reach `android.clients.google.com` / `firebaseinstallations.googleapis.com` |
| anything else | `FCM registration failed: <original message>` |

## User-facing wording

The user-facing log lines stay free of integration internals so they remain useful to users who configured FCM by means other than the README walkthrough. A dedicated test asserts that none of those internal-jargon words leak into the user-facing message.

## Test plan

- [x] `TestClassifyFcmFailure` — 7 cases covering each branch (subscription, 403, api-key-not-valid, network, timeout, unknown, empty-message). Each asserts the actionable phrase + absence of jargon.