### PR TITLE
fix(notification): rewrite FCM classifier against real library strings

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -46,11 +46,29 @@ NOTIFICATION_DEDUPE_WINDOW_SECONDS = 5.0
 def _classify_fcm_failure(exc: BaseException) -> str:
     """Return a user-actionable WARNING message for an FCM registration / push-client error.
 
-    `firebase-messaging` raises plain `RuntimeError` / `Exception` with the cause
-    encoded only in the message string, so we discriminate on substrings. Every
-    branch gives the user (and any reader of the default-level log) a concrete
-    next step, instead of the generic "FCM registration failed" the integration
-    used through `1.3.0-beta.9`.
+    `firebase-messaging` 0.4.5 raises plain `RuntimeError` with one of three
+    fixed message strings, hiding any HTTP status and aiohttp cause behind
+    internal `_logger` calls — so `__cause__` / `__context__` are always None
+    and the only signal we get is the literal `str(exc)`.
+
+    The three branches below were measured empirically (probe against real FCM
+    endpoints with deliberate credential corruptions + a DNS block of the FCM
+    hosts), not inferred from the source:
+
+      * "Unable to establish subscription with Google Cloud Messaging."
+        — dominant failure mode for any credential-set error (bad sender_id,
+        api_key, project_id, or app_id with valid shape). Hansontech190's
+        case lands here.
+
+      * "Unable to register with fcm"
+        — fires only when the app_id is malformed enough that the Firebase
+        Installation API rejects it with HTTP 400. The shape `1:<sender>:
+        <platform>:<hex>` is what Firebase parses.
+
+      * "Unable to register and check in to gcm"
+        — the four credentials are not used in the GCM checkin step, so this
+        string only appears when the FCM hosts are unreachable (DNS, firewall,
+        proxy). aiohttp errors are swallowed by the library's retry loop.
     """
     msg = str(exc) if exc else ""
     lower = msg.lower()
@@ -63,14 +81,14 @@ def _classify_fcm_failure(exc: BaseException) -> str:
             "with that same fcm_project_id. Re-enter all four together via the "
             "Repair card under Settings → Repairs."
         )
-    if "api key not valid" in lower or "api_key_invalid" in lower or " 403" in f" {msg}":
+    if "unable to register with fcm" in lower:
         return (
-            "FCM API key was rejected by Google (403). The expected fcm_api_key "
-            'format is "AIza" followed by 35 alphanumeric / underscore / hyphen '
-            "characters (39 chars total). Re-check the value entered via the "
+            "Firebase rejected the app credentials. Most likely fcm_app_id has "
+            'an invalid format — the expected shape is "1:<numeric sender>:'
+            '<platform>:<hex suffix>". Re-check the value entered via the '
             "Repair card under Settings → Repairs."
         )
-    if any(token in lower for token in ("failed to resolve", "connection", "timeout", "network")):
+    if "unable to register and check in to gcm" in lower:
         return (
             "Couldn't reach Google FCM servers. Check the HA host can reach "
             "android.clients.google.com / firebaseinstallations.googleapis.com "

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -313,48 +313,54 @@ class TestAsyncStartFcmRepairs:
 
 
 class TestClassifyFcmFailure:
-    """`_classify_fcm_failure` turns library errors into actionable WARNINGs (#131)."""
+    """`_classify_fcm_failure` turns library errors into actionable WARNINGs.
+
+    Each branch corresponds to one of the three literal `RuntimeError` strings
+    `firebase-messaging` 0.4.5 actually emits. The mapping was verified by an
+    empirical probe (deliberate credential corruptions + DNS block of FCM
+    hosts) — not by reading the library source — so the substrings here are
+    guaranteed to be the ones the listener observes in production.
+    """
 
     def test_gcm_subscription_rejection_points_at_project_consistency(self) -> None:
-        # Hansontech190's report: firebase-messaging raises this exact
-        # RuntimeError when the four credentials don't all belong to the
-        # same Firebase project. The user-facing message must steer them
-        # toward checking sender_id/app_id/project_id consistency, not
-        # toward extraction internals (no APK / cobrand / .so wording).
+        # Probe result: emitted for ANY credential-set error (bad sender_id,
+        # api_key with or without AIza prefix, project_id, app_id with valid
+        # shape). Hansontech190's case (#131) lands here. Message must steer
+        # the user toward checking the four-value consistency, not toward
+        # extraction internals (no APK / cobrand / .so wording).
         msg = _classify_fcm_failure(
             RuntimeError("Unable to establish subscription with Google Cloud Messaging.")
         )
         assert "rejected by Google" in msg
         assert "same Firebase project" in msg
         assert "fcm_sender_id" in msg and "fcm_app_id" in msg and "fcm_project_id" in msg
-        # No leakage of extraction jargon to user logs
         for forbidden in ("APK", "cobrand", "libnative", "strings.xml"):
             assert forbidden not in msg
 
-    def test_403_api_key_rejection_explains_format(self) -> None:
-        msg = _classify_fcm_failure(RuntimeError("API key not valid. Please pass a valid API key."))
-        assert "API key" in msg
-        assert "AIza" in msg
-        assert "39 chars" in msg
+    def test_fcm_install_failure_points_at_app_id_format(self) -> None:
+        # Probe result: emitted when the Firebase Installation API rejects the
+        # request with HTTP 400 INVALID_ARGUMENT, which empirically only fires
+        # when `fcm_app_id` is malformed enough that Firebase cannot parse it.
+        # Other shapes (bad api_key, wrong project_id) surface as the
+        # subscription branch above.
+        msg = _classify_fcm_failure(RuntimeError("Unable to register with fcm"))
+        assert "fcm_app_id" in msg
+        assert "1:" in msg and "sender" in msg  # the format hint
+        assert "Repair card" in msg
 
-    def test_403_status_code_in_message_classifies_as_api_key_rejected(self) -> None:
-        msg = _classify_fcm_failure(RuntimeError("Got HTTP 403 from FCM register endpoint"))
-        assert "API key" in msg
-        assert "AIza" in msg
-
-    def test_network_error_points_at_dns_firewall(self) -> None:
-        msg = _classify_fcm_failure(OSError("Failed to resolve android.clients.google.com"))
+    def test_gcm_checkin_failure_points_at_network(self) -> None:
+        # Probe result: emitted exclusively on network failure (DNS / firewall
+        # / FCM hosts unreachable). The four credentials are not used by the
+        # GCM checkin step, so this string is an unambiguous network signal.
+        msg = _classify_fcm_failure(RuntimeError("Unable to register and check in to gcm"))
         assert "reach Google FCM servers" in msg
-        assert "DNS" in msg or "firewall" in msg
-
-    def test_timeout_classified_as_network(self) -> None:
-        msg = _classify_fcm_failure(TimeoutError("Connection timeout while contacting FCM"))
-        assert "reach Google FCM servers" in msg
+        assert "android.clients.google.com" in msg
+        assert "firewall" in msg or "DNS" in msg
 
     def test_unknown_error_falls_back_to_generic_with_message(self) -> None:
-        # Don't lose the original exception text in the fallback path —
-        # it's the only signal a human has to diagnose a case we haven't
-        # taught the classifier yet.
+        # Future-proofing: if firebase-messaging changes its error strings or
+        # a different exception slips through (aiohttp leak, etc.), preserve
+        # the original message so a human reading the log can still diagnose.
         msg = _classify_fcm_failure(RuntimeError("something completely unexpected"))
         assert msg.startswith("FCM registration failed")
         assert "something completely unexpected" in msg

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -354,7 +354,11 @@ class TestClassifyFcmFailure:
         # GCM checkin step, so this string is an unambiguous network signal.
         msg = _classify_fcm_failure(RuntimeError("Unable to register and check in to gcm"))
         assert "reach Google FCM servers" in msg
-        assert "android.clients.google.com" in msg
+        # Both FCM hosts must be named so the user knows exactly what to
+        # whitelist in their firewall / DNS. The full slash-separated pair
+        # is asserted as a single substring so CodeQL's URL-sanitization
+        # heuristic doesn't misread this as a partial-URL match guard.
+        assert "android.clients.google.com / firebaseinstallations.googleapis.com" in msg
         assert "firewall" in msg or "DNS" in msg
 
     def test_unknown_error_falls_back_to_generic_with_message(self) -> None:


### PR DESCRIPTION
## Summary

- Rewrites `_classify_fcm_failure` so each branch matches a `RuntimeError` string `firebase-messaging` 0.4.5 actually raises from its public `register()` entrypoint.
- Adds branches for the two failure modes beta.10 missed: malformed `fcm_app_id` and FCM-hosts-unreachable.
- Removes two branches that cannot fire in production (the library never surfaces `"API key not valid"` / HTTP 403 substrings, nor generic network tokens — those details are kept inside the library's internal logger).
- No UI / Repair / wire-protocol changes; same `fcm_credentials_invalid` card raised in every failure path, only the log line gets sharper.

Refs #133, #131, #132.

## Test plan

- [x] `make check` green inside Docker: 1143 tests pass, 84.13% coverage.
- [x] Same after rebuilding the dev image without volume mount.
- [x] `TestClassifyFcmFailure` reduced to the five paths that can actually occur: the three library strings + generic fallback + bare `RuntimeError()`.
- [ ] CI matrix (Python 3.12 + 3.13, hassfest, HACS validate, CodeQL) on the pushed branch.
- [ ] Real-HA confirmation after merge + beta.11 cut: healthy install stays log-silent (no FCM WARNING), Hansontech190's #131 retry still lands in the subscription branch.