### PR TITLE
docs(roadmap): drop 'unknown app label' Repair entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,6 @@ If a specific group of sensors stops working:
 - [ ] Firmware update platform
 - [ ] Number/Select platforms for device settings (sensitivity, brightness)
 - [ ] SpaceControl (keyfob) event support
-- [ ] "Unknown app label" Repair card (#99)
 
 ## Push Notifications (Optional)
 


### PR DESCRIPTION
## Summary

Closes #99 by dropping its roadmap entry. An empirical probe against the real backend shows the failure mode #99 was scoped against does not exist.

5-case probe against `mobile-gw.prod.ajax.systems` with the `+ha` test account:

| Case | `app_label` | login | `list_spaces` |
| --- | --- | --- | --- |
| 1 | `Protegim_alarma` (good) | OK | OK |
| 2 | `definitely_not_a_label_xyz_123` (nonsense) | **OK** | **OK** |
| 3 | bad password hash | `Invalid email or password` | — |
| 4 | `""` (empty) | `Login failed: bad_request` | — |
| 5 | `Ajax` (other valid co-brand, not the account's) | **OK** | **OK** |

The server treats `application-label` as opaque branding / telemetry. There is no "rejected by backend" signature to discriminate, and the only label-related failure (`""`) already falls through the existing `AuthenticationError` path. Implementing the Repair as scoped in #99 would be dead code that never fires.

`KNOWN_APP_LABELS` + `SelectSelector(custom_value=True)` stays as-is — it is UX ergonomics (autocomplete from the catalogue, allow custom strings), not a server contract.

## Test plan

- [ ] Render README on GitHub, confirm the Roadmap section reads cleanly without the dropped bullet.