### PR TITLE
feat(hts): WallSwitch / Socket electrical readings as HA sensors

### DIFF
--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -52,6 +52,14 @@ HTS_HOST = "hts.prod.ajax.systems"
 HTS_PORT = 443
 PING_INTERVAL = 30
 READ_TIMEOUT = 40
+# Period of the background REQUEST_FULL_STATUS refresh that keeps
+# per-device electrical readings (#123) and any other status-only
+# fields fresh. STATUS_BODY is otherwise only emitted on boot; sub-key
+# 11 deltas are deliberately dropped (#111). 60s matches HA's
+# `MIN_POLL_INTERVAL` floor — small enough to feel live on the Energy
+# dashboard, large enough to leave hub bandwidth headroom (each
+# refresh is ~2.7 KB encrypted).
+STATUS_REFRESH_INTERVAL = 60
 # Bound the full 4-step auth handshake. Without this, a server that keeps the
 # TCP connection alive but feeds bytes slowly can keep `_receive_message()`'s
 # per-chunk reads under READ_TIMEOUT forever, so the coroutine never resolves.
@@ -105,10 +113,16 @@ class HtsClient:
 
         self._ping_task: asyncio.Task[None] | None = None
         self._data_request_task: asyncio.Task[None] | None = None
+        self._status_refresh_task: asyncio.Task[None] | None = None
         self._read_buf = bytearray()
         self._consecutive_read_timeouts = 0
         self._hub_states: dict[str, HubNetworkState] = {}
         self._on_state_update: Callable[[str, HubNetworkState], None] | None = None
+        # Per-device kv callback wired by the coordinator for #123. The
+        # client itself does not know which devices emit electrical
+        # readings — it just forwards every non-hub kv block from a
+        # STATUS/SETTINGS body and lets the coordinator filter by type.
+        self._on_device_kv: Callable[[str, str, dict[int, bytes]], None] | None = None
         self._refresh_tasks: dict[str, asyncio.Task[None]] = {}
 
     # ------------------------------------------------------------------
@@ -416,13 +430,31 @@ class HtsClient:
     # ------------------------------------------------------------------
 
     async def request_hub_data(self, hub_id: str) -> None:
-        """Send REQUEST_SETTINGS_ID, REQUEST_FULL_SETTINGS, and REQUEST_FULL_STATUS."""
-        hub_id_int = int(hub_id, 16)
+        """Send REQUEST_FULL_SETTINGS *and* REQUEST_FULL_STATUS.
+
+        Used at startup / after the unknown-update fallback path. The
+        periodic refresh loop (#123) uses the lighter
+        `_send_request_full_status` alone — SETTINGS is ~6 KB and only
+        carries config that does not change at runtime, so requesting
+        it every 60s would be pure waste.
+        """
+        await self._send_request_full_settings(hub_id)
+        await self._send_request_full_status(hub_id)
+
+    async def _send_request_full_settings(self, hub_id: str) -> None:
+        """REQUEST_FULL_SETTINGS (sub-key=3) — heavy, ~6 KB response."""
+        await self._send_request_payload(hub_id, sub_key=3, label="REQUEST_FULL_SETTINGS")
+
+    async def _send_request_full_status(self, hub_id: str) -> None:
+        """REQUEST_FULL_STATUS (sub-key=7) — lighter, ~2.7 KB response with live readings."""
+        await self._send_request_payload(hub_id, sub_key=7, label="REQUEST_FULL_STATUS")
+
+    async def _send_request_payload(self, hub_id: str, *, sub_key: int, label: str) -> None:
+        """Generic 3-param REQUEST sender shared by SETTINGS and STATUS variants."""
         if self._writer is None:
             raise HtsConnectionError("Not connected")
-
-        # REQUEST_FULL_SETTINGS (sub-key=3)
-        settings_payload = tlv_encode([bytes([3]), bytes([1]), bytes([1])])
+        hub_id_int = int(hub_id, 16)
+        payload = tlv_encode([bytes([sub_key]), bytes([1]), bytes([1])])
         msg = HtsMessage(
             sender=self._sender_id,
             receiver=hub_id_int,
@@ -430,7 +462,7 @@ class HtsClient:
             link=10,
             flags=0,
             msg_type=MsgType.UPDATES,
-            payload=settings_payload,
+            payload=payload,
         )
         raw = build_message(msg)
         padded = pad16(raw)
@@ -440,39 +472,29 @@ class HtsClient:
             raise HtsConnectionError("Not connected")
         self._writer.write(frame)
         await self._writer.drain()
-        _LOGGER.debug("Sent REQUEST_FULL_SETTINGS to %s", hub_id)
-
-        # REQUEST_FULL_STATUS (sub-key=7)
-        status_payload = tlv_encode([bytes([7]), bytes([1]), bytes([1])])
-        msg2 = HtsMessage(
-            sender=self._sender_id,
-            receiver=hub_id_int,
-            seq_num=self._next_seq(),
-            link=10,
-            flags=0,
-            msg_type=MsgType.UPDATES,
-            payload=status_payload,
-        )
-        raw2 = build_message(msg2)
-        padded2 = pad16(raw2)
-        encrypted2 = encrypt(padded2)
-        frame2 = encode_frame(encrypted2)
-        self._writer.write(frame2)
-        await self._writer.drain()
-        _LOGGER.debug("Sent REQUEST_FULL_STATUS to %s", hub_id)
+        _LOGGER.debug("Sent %s to %s", label, hub_id)
 
     async def listen(
         self,
         on_state_update: Callable[[str, HubNetworkState], None] | None = None,
+        on_device_kv: Callable[[str, str, dict[int, bytes]], None] | None = None,
     ) -> None:
         """Main receive loop: ACK messages and dispatch UPDATES.
 
         Args:
             on_state_update: Optional callback invoked with (hub_id, state) whenever
                              a hub state changes.
+            on_device_kv: Optional callback invoked with (hub_id, device_id_hex, kv)
+                          once per non-hub device row contained in a STATUS_BODY or
+                          SETTINGS_BODY message. `device_id_hex` is upper-case to
+                          match `coordinator.devices` keys. The coordinator decides
+                          which device types consume the kv (#123 electrical
+                          readings live here).
         """
         self._on_state_update = on_state_update
+        self._on_device_kv = on_device_kv
         self._ping_task = asyncio.create_task(self._ping_loop())
+        self._status_refresh_task = asyncio.create_task(self._status_refresh_loop())
 
         # Request hub data immediately (connection is stable now)
         async def _request_data() -> None:
@@ -566,18 +588,35 @@ class HtsClient:
                 return
             hub_id_bytes = bytes.fromhex(hub_id)
             kv = self._extract_device_kv(params, hub_id_bytes)
-            # Probe for #123: surface what sub-keys non-hub devices carry
-            # in the same body. We don't parse those rows yet — this log
-            # is the empirical baseline ahead of mapping sub-keys (e.g.
-            # WallSwitch 0x42 current_ma / 0x43 power_wth) to sensors.
-            # DEBUG-only, so default-level installs pay nothing.
+            # Walk every device row in the body once. Two consumers:
+            #   1. #123 readings — emit each non-hub kv via on_device_kv
+            #      so the coordinator can parse it as `DeviceReadings`
+            #      (current_ma / power_consumed_wh for WallSwitch and
+            #      the Socket family). The client itself stays
+            #      device-type-agnostic.
+            #   2. DEBUG probe — log the sub-keys per device when
+            #      DEBUG logging is on for this module, so the post-
+            #      mortem of an unfamiliar device family is one log
+            #      sample away. Default-level installs pay nothing.
+            non_hub: list[tuple[bytes, dict[int, bytes]]] = [
+                (did, kvs)
+                for did, kvs in self._extract_all_devices_kv(params)
+                if did != hub_id_bytes
+            ]
+            if self._on_device_kv is not None:
+                for did, kvs in non_hub:
+                    if not kvs:
+                        continue
+                    try:
+                        self._on_device_kv(hub_id, did.hex().upper(), kvs)
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.exception(
+                            "on_device_kv callback raised for hub %s device %s",
+                            hub_id,
+                            did.hex().upper(),
+                        )
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 body_label = "SETTINGS_BODY" if sub_key == 5 else "STATUS_BODY"
-                non_hub = [
-                    (did, kvs)
-                    for did, kvs in self._extract_all_devices_kv(params)
-                    if did != hub_id_bytes
-                ]
                 if non_hub:
                     summary = ", ".join(
                         f"{did.hex().upper()}=["
@@ -789,6 +828,30 @@ class HtsClient:
                     self._connected = False
                     break
 
+    async def _status_refresh_loop(self) -> None:
+        """Periodically pull STATUS_BODY so device readings stay live (#123).
+
+        Phase A revealed STATUS_BODY only arrives on connect — sub-key
+        11 deltas are silently dropped (#111). For per-device electrical
+        sensors (WallSwitch / Socket current and energy meters) to feel
+        live, we re-request STATUS every `STATUS_REFRESH_INTERVAL`
+        seconds. Failures are logged and treated as transient: the
+        next tick retries; only an actual disconnect aborts the loop.
+        """
+        while self._connected:
+            await asyncio.sleep(STATUS_REFRESH_INTERVAL)
+            if not self._connected:
+                break
+            for hub in list(self._hubs):
+                try:
+                    await self._send_request_full_status(hub.hub_id)
+                except Exception:  # noqa: BLE001
+                    _LOGGER.debug(
+                        "Periodic STATUS refresh failed for hub %s",
+                        hub.hub_id,
+                        exc_info=True,
+                    )
+
     # ------------------------------------------------------------------
     # Close
     # ------------------------------------------------------------------
@@ -812,6 +875,11 @@ class HtsClient:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._ping_task
             self._ping_task = None
+        if self._status_refresh_task is not None:
+            self._status_refresh_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._status_refresh_task
+            self._status_refresh_task = None
         if self._writer is not None:
             with contextlib.suppress(Exception):
                 self._writer.close()

--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -52,14 +52,6 @@ HTS_HOST = "hts.prod.ajax.systems"
 HTS_PORT = 443
 PING_INTERVAL = 30
 READ_TIMEOUT = 40
-# Period of the background REQUEST_FULL_STATUS refresh that keeps
-# per-device electrical readings (#123) and any other status-only
-# fields fresh. STATUS_BODY is otherwise only emitted on boot; sub-key
-# 11 deltas are deliberately dropped (#111). 60s matches HA's
-# `MIN_POLL_INTERVAL` floor — small enough to feel live on the Energy
-# dashboard, large enough to leave hub bandwidth headroom (each
-# refresh is ~2.7 KB encrypted).
-STATUS_REFRESH_INTERVAL = 60
 # Bound the full 4-step auth handshake. Without this, a server that keeps the
 # TCP connection alive but feeds bytes slowly can keep `_receive_message()`'s
 # per-chunk reads under READ_TIMEOUT forever, so the coroutine never resolves.
@@ -113,7 +105,6 @@ class HtsClient:
 
         self._ping_task: asyncio.Task[None] | None = None
         self._data_request_task: asyncio.Task[None] | None = None
-        self._status_refresh_task: asyncio.Task[None] | None = None
         self._read_buf = bytearray()
         self._consecutive_read_timeouts = 0
         self._hub_states: dict[str, HubNetworkState] = {}
@@ -494,7 +485,6 @@ class HtsClient:
         self._on_state_update = on_state_update
         self._on_device_kv = on_device_kv
         self._ping_task = asyncio.create_task(self._ping_loop())
-        self._status_refresh_task = asyncio.create_task(self._status_refresh_loop())
 
         # Request hub data immediately (connection is stable now)
         async def _request_data() -> None:
@@ -662,14 +652,58 @@ class HtsClient:
                 self._on_state_update(hub_id, new_state)
             return
 
-        # Sub-key 11 is the hub-network delta channel. The longer variants
-        # (~50 bytes) carry the anchor keys we recognise and are handled
-        # above. Shorter variants (~34 bytes) appear every few seconds on
-        # some firmwares and only carry fields we don't surface. Falling
-        # through to `_schedule_hub_refresh` here meant a `REQUEST_FULL_
-        # SETTINGS + REQUEST_FULL_STATUS` round-trip on every heartbeat
-        # (#111) — same parser, same keys, no new information. Drop it. (#111)
-        if sub_key == 11:
+        # Sub-keys 11 (STATUS_UPDATE) and 12 (SETTINGS_UPDATE) are the
+        # hub's per-device push channels: the hub emits one of these
+        # whenever any single device's status (11) or settings (12)
+        # change. Payload shape is identical to one device's row inside
+        # a body — `[sub_key, device_id_4b, k1, v1, k2, v2, ...]` — so
+        # the same `_extract_all_devices_kv` walker pulls out the
+        # device id + kv block. Routed through `on_device_kv` so the
+        # coordinator's existing per-device handler (#123) consumes
+        # both the boot-time STATUS_BODY snapshot and these live pushes
+        # via one code path.
+        #
+        # Bandwidth note: longer hub-network variants of these sub-keys
+        # (~50 bytes) were previously diverted to `_extract_direct_kv`
+        # above. That path still fires before this one and handles
+        # hub-network deltas. Anything reaching here is a per-device
+        # delta; if `kvs` is empty (e.g. firmware-internal heartbeat)
+        # the helper just skips. This subsumes the #111 `sub_key == 11
+        # return` drop — the issue there was firing `_schedule_hub_
+        # refresh` on every heartbeat (~8.6 KB round-trip), not the
+        # silent drop itself. Now we read the delta in-place.
+        if sub_key in (11, 12) and hub_id:
+            non_hub = [
+                (did, kvs)
+                for did, kvs in self._extract_all_devices_kv(params)
+                if did != bytes.fromhex(hub_id)
+            ]
+            if self._on_device_kv is not None:
+                for did, kvs in non_hub:
+                    if not kvs:
+                        continue
+                    try:
+                        self._on_device_kv(hub_id, did.hex().upper(), kvs)
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.exception(
+                            "on_device_kv callback raised for hub %s device %s",
+                            hub_id,
+                            did.hex().upper(),
+                        )
+            if _LOGGER.isEnabledFor(logging.DEBUG) and non_hub:
+                update_label = "STATUS_UPDATE" if sub_key == 11 else "SETTINGS_UPDATE"
+                summary = ", ".join(
+                    f"{did.hex().upper()}=["
+                    + ",".join(f"0x{k:02x}({len(kvs[k])}b)" for k in sorted(kvs))
+                    + "]"
+                    for did, kvs in non_hub
+                )
+                _LOGGER.debug(
+                    "Hub %s: %s push (#123): %s",
+                    hub_id,
+                    update_label,
+                    summary,
+                )
             return
 
         self._schedule_hub_refresh(hub_id, f"unknown update sub-key {sub_key}")
@@ -828,30 +862,6 @@ class HtsClient:
                     self._connected = False
                     break
 
-    async def _status_refresh_loop(self) -> None:
-        """Periodically pull STATUS_BODY so device readings stay live (#123).
-
-        Phase A revealed STATUS_BODY only arrives on connect — sub-key
-        11 deltas are silently dropped (#111). For per-device electrical
-        sensors (WallSwitch / Socket current and energy meters) to feel
-        live, we re-request STATUS every `STATUS_REFRESH_INTERVAL`
-        seconds. Failures are logged and treated as transient: the
-        next tick retries; only an actual disconnect aborts the loop.
-        """
-        while self._connected:
-            await asyncio.sleep(STATUS_REFRESH_INTERVAL)
-            if not self._connected:
-                break
-            for hub in list(self._hubs):
-                try:
-                    await self._send_request_full_status(hub.hub_id)
-                except Exception:  # noqa: BLE001
-                    _LOGGER.debug(
-                        "Periodic STATUS refresh failed for hub %s",
-                        hub.hub_id,
-                        exc_info=True,
-                    )
-
     # ------------------------------------------------------------------
     # Close
     # ------------------------------------------------------------------
@@ -875,11 +885,6 @@ class HtsClient:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._ping_task
             self._ping_task = None
-        if self._status_refresh_task is not None:
-            self._status_refresh_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._status_refresh_task
-            self._status_refresh_task = None
         if self._writer is not None:
             with contextlib.suppress(Exception):
                 self._writer.close()

--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -566,6 +566,31 @@ class HtsClient:
                 return
             hub_id_bytes = bytes.fromhex(hub_id)
             kv = self._extract_device_kv(params, hub_id_bytes)
+            # Probe for #123: surface what sub-keys non-hub devices carry
+            # in the same body. We don't parse those rows yet — this log
+            # is the empirical baseline ahead of mapping sub-keys (e.g.
+            # WallSwitch 0x42 current_ma / 0x43 power_wth) to sensors.
+            # DEBUG-only, so default-level installs pay nothing.
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                body_label = "SETTINGS_BODY" if sub_key == 5 else "STATUS_BODY"
+                non_hub = [
+                    (did, kvs)
+                    for did, kvs in self._extract_all_devices_kv(params)
+                    if did != hub_id_bytes
+                ]
+                if non_hub:
+                    summary = ", ".join(
+                        f"{did.hex().upper()}=["
+                        + ",".join(f"0x{k:02x}({len(kvs[k])}b)" for k in sorted(kvs))
+                        + "]"
+                        for did, kvs in non_hub
+                    )
+                    _LOGGER.debug(
+                        "Hub %s: %s non-hub devices (#123 probe): %s",
+                        hub_id,
+                        body_label,
+                        summary,
+                    )
             if kv:
                 _LOGGER.debug(
                     "Hub %s: parsed %d keys from %s",
@@ -699,6 +724,54 @@ class HtsClient:
             # Skip 2-byte keys (extended keys we don't need yet)
             i += 2
         return kv
+
+    @staticmethod
+    def _extract_all_devices_kv(
+        params: list[bytes],
+    ) -> list[tuple[bytes, dict[int, bytes]]]:
+        """Walk the whole body and emit per-device kv tuples.
+
+        Generalises `_extract_device_kv`, which only returns the section
+        belonging to one specific device id. The full body is a flat
+        list shaped as
+
+            [sub_key, marker_A, k1, v1, k2, v2, ..., marker_B, k1, v1, ...]
+
+        where every 4-byte param is a device id marker and the 1-byte
+        params between markers are sub-keys (with the next param as the
+        value). 2-byte extended keys are skipped on purpose — same rule
+        as `_extract_device_kv`. Orphan params before the first marker
+        (the leading sub_key byte, malformed prefixes) are skipped too.
+
+        Returns a list preserving the body's encounter order so callers
+        can distinguish the hub's section (always first today) from
+        per-device sections.
+        """
+        result: list[tuple[bytes, dict[int, bytes]]] = []
+        current_id: bytes | None = None
+        current_kv: dict[int, bytes] = {}
+        i = 0
+        while i < len(params):
+            p = params[i]
+            if len(p) == 4:
+                if current_id is not None:
+                    result.append((current_id, current_kv))
+                current_id = p
+                current_kv = {}
+                i += 1
+                continue
+            if current_id is None:
+                i += 1
+                continue
+            if i + 1 >= len(params):
+                break
+            val_p = params[i + 1]
+            if len(p) == 1:
+                current_kv[p[0]] = val_p
+            i += 2
+        if current_id is not None:
+            result.append((current_id, current_kv))
+        return result
 
     # ------------------------------------------------------------------
     # Ping

--- a/custom_components/aegis_ajax/api/hts/hub_state.py
+++ b/custom_components/aegis_ajax/api/hts/hub_state.py
@@ -130,6 +130,91 @@ def _ip_val(val: bytes) -> str:
     return _int_to_ip(ip_int)
 
 
+def _int_be_val(val: bytes | None) -> int | None:
+    """Parse a big-endian unsigned integer of arbitrary length (1-4 bytes).
+
+    Returns None when the input is missing or empty. The Ajax hub sends
+    integers with the smallest length that fits (1 byte while readings
+    are zero, 2-4 bytes once the WallSwitch has measurable draw), so
+    `len(val)` is not fixed across messages — `int.from_bytes` handles
+    any length the same way.
+    """
+    if not val:
+        return None
+    return int.from_bytes(val, "big")
+
+
+# ---------------------------------------------------------------------------
+# Per-device TLV keys (WallSwitch / Socket family)
+# ---------------------------------------------------------------------------
+#
+# Distinct from the hub-level keys above: same numeric sub-key carries
+# different meaning depending on which device's row of the body it
+# belongs to. For the hub, 0x42 is `wifi_ip`; for a WallSwitch row, 0x42
+# is `current_ma`. The Ajax mobile app reads them through a separate TLV
+# container (`poz0` in Ajax PRO 2.47 smali) — see #123 for the audit
+# trail.
+
+DEVICE_KEY_CURRENT_MA = 0x42
+DEVICE_KEY_POWER_CONSUMED_WH = 0x43
+
+# device_type strings (as produced by `DevicesApi`) that emit the
+# electrical-reading sub-keys. Mirrors SWITCH_DEVICE_TYPES in switch.py
+# minus the light-switch variants whose firmware doesn't measure current
+# (those are dry-contact relays, not load-meters). When a new
+# electrical-reading-capable device family appears, add it here and to
+# SWITCH_DEVICE_TYPES.
+ELECTRICAL_DEVICE_TYPES: frozenset[str] = frozenset(
+    {
+        "wall_switch",
+        "relay",
+        "relay_fibra_base",
+        "socket",
+        "socket_b",
+        "socket_g",
+        "socket_outlet_type_e",
+        "socket_outlet_type_f",
+        "socket_type_g_plus",
+    }
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class DeviceReadings:
+    """Immutable snapshot of a single device's electrical readings.
+
+    `current_ma` and `power_consumed_wh` are `None` when the device does
+    not emit them, when the body simply hadn't been refreshed yet, or
+    when the sub-key was missing on a body that did include the device.
+    Consumers should treat any `None` as "no measurement available" and
+    render the entity as `unknown` rather than zero.
+    """
+
+    current_ma: int | None = None
+    power_consumed_wh: int | None = None
+
+
+def parse_device_readings(
+    device_type: str,
+    kv: dict[int, bytes],
+) -> DeviceReadings | None:
+    """Map a per-device TLV kv block to `DeviceReadings`.
+
+    Returns `None` when the device type does not emit electrical
+    readings (so callers can early-out and avoid creating empty
+    snapshots). For an electrical-capable device the return is always
+    a `DeviceReadings` instance, even if both sub-keys are absent from
+    the kv block — the empty case is still useful for callers to know
+    the device was *present* in the body.
+    """
+    if device_type not in ELECTRICAL_DEVICE_TYPES:
+        return None
+    return DeviceReadings(
+        current_ma=_int_be_val(kv.get(DEVICE_KEY_CURRENT_MA)),
+        power_consumed_wh=_int_be_val(kv.get(DEVICE_KEY_POWER_CONSUMED_WH)),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Parser
 # ---------------------------------------------------------------------------

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -42,7 +42,10 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
     from custom_components.aegis_ajax.api.client import AjaxGrpcClient
-    from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
+    from custom_components.aegis_ajax.api.hts.hub_state import (
+        DeviceReadings,
+        HubNetworkState,
+    )
     from custom_components.aegis_ajax.api.models import Device, Room, Space
     from custom_components.aegis_ajax.notification import AjaxNotificationListener
 
@@ -124,6 +127,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._hts_client: HtsClient | None = None
         self._hts_task: asyncio.Task[None] | None = None
         self.hub_network: dict[str, HubNetworkState] = {}
+        # Per-device electrical readings (current_ma / power_consumed_wh)
+        # populated from HTS STATUS_BODY rows of WallSwitch / Socket
+        # family devices (#123). Keyed by upper-case 8-char device id
+        # (same shape as `self.devices` keys). Empty dict = no readings
+        # snapshotted yet OR no electrical devices in the install.
+        self.device_readings: dict[str, DeviceReadings] = {}
         # Per-space monotonic timestamp of when the hub first reported
         # offline (cleared on the first ONLINE poll). Drives the
         # `hub_offline_24h` Repair surfaced after sustained downtime.
@@ -467,7 +476,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result = await self._hts_client.connect()
             _LOGGER.info("HTS connected, %d hub(s)", len(result.hubs))
             self._clear_hts_chronic_failure()
-            await self._hts_client.listen(on_state_update=self._on_hts_update)
+            await self._hts_client.listen(
+                on_state_update=self._on_hts_update,
+                on_device_kv=self._on_hts_device_kv,
+            )
         except Exception as exc:
             # Surface at WARNING (#111) — a silent DEBUG made these failures
             # invisible to users debugging "HTS streams: 0/1" reports. The
@@ -487,6 +499,33 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.hub_network[hub_id] = state
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
+    def _on_hts_device_kv(self, hub_id: str, device_id_hex: str, kv: dict[int, bytes]) -> None:
+        """Translate a per-device HTS kv block into `DeviceReadings` (#123).
+
+        Called once per non-hub device row inside a STATUS_BODY or
+        SETTINGS_BODY. Looks up the device's type from the snapshot the
+        gRPC stream populated; non-electrical types are filtered out by
+        `parse_device_readings` returning `None`. When a new reading
+        arrives that differs from the cached one, mutates
+        `coordinator.device_readings` and fires `async_set_updated_data`
+        so the sensor entities pick the change up immediately.
+        """
+        from custom_components.aegis_ajax.api.hts.hub_state import (  # noqa: PLC0415
+            parse_device_readings,
+        )
+
+        device = self.devices.get(device_id_hex)
+        if device is None:
+            return
+        readings = parse_device_readings(device.device_type, kv)
+        if readings is None:
+            return
+        if self.device_readings.get(device_id_hex) == readings:
+            return
+        self.device_readings[device_id_hex] = readings
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+        _ = hub_id  # currently unused; kept in the signature for symmetry with on_state_update
+
     def _handle_hts_task_done(self, task: asyncio.Task[None]) -> None:
         """Clear stale HTS state when the listen task exits."""
         if task.cancelled():
@@ -499,8 +538,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Drop stale HTS state so hub network entities become unavailable."""
         self._hts_task = None
         self._hts_client = None
-        if self.hub_network:
+        if self.hub_network or self.device_readings:
             self.hub_network.clear()
+            self.device_readings.clear()
             self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         # Track the first failure of an otherwise-healthy run so we can
         # raise a Repair after a sustained outage. Successful reconnect

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -7,12 +7,26 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
-from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
+from homeassistant.const import (
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from custom_components.aegis_ajax.api.hts.hub_state import ELECTRICAL_DEVICE_TYPES
 from custom_components.aegis_ajax.api.models import MonitoringCompanyStatus
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 from custom_components.aegis_ajax.entity import build_device_info
+
+# Nominal grid voltage assumed when deriving instantaneous power from
+# current (#123). The Ajax mobile app does the same — the device card
+# shows "230 V" as a fixed label, then renders Power = V × A. The
+# WallSwitch firmware does not report measured voltage on the wire.
+NOMINAL_GRID_VOLTAGE_V = 230.0
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -144,6 +158,13 @@ async def async_setup_entry(
             entities.append(AjaxHubEthernetDnsSensor(coordinator, space.hub_id))
             entities.append(AjaxHubCellularSignalSensor(coordinator, space.hub_id))
             entities.append(AjaxHubCellularNetworkSensor(coordinator, space.hub_id))
+
+    # Per-device electrical sensors for WallSwitch / Socket family (#123)
+    for device_id, device in coordinator.devices.items():
+        if device.device_type in ELECTRICAL_DEVICE_TYPES:
+            entities.append(AjaxDeviceCurrentSensor(coordinator, device_id))
+            entities.append(AjaxDeviceEnergyConsumedSensor(coordinator, device_id))
+            entities.append(AjaxDeviceDerivedPowerSensor(coordinator, device_id))
 
     async_add_entities(entities)
 
@@ -446,3 +467,115 @@ class AjaxHubCellularNetworkSensor(_HubNetworkSensor):
     def native_value(self) -> str | None:
         state = self.coordinator.hub_network.get(self._hub_id)
         return state.gsm_network_type if state else None
+
+
+# ---------------------------------------------------------------------------
+# Per-device electrical sensors (WallSwitch / Socket family, #123)
+# ---------------------------------------------------------------------------
+
+
+class _AjaxDeviceReadingsBase(CoordinatorEntity[AjaxCobrandedCoordinator], SensorEntity):
+    """Shared scaffold for the current / energy / power triplet.
+
+    Each subclass picks its own translation_key, device_class, state_class
+    and unit. All three pull from `coordinator.device_readings[device_id]`
+    which is populated by the HTS path (see `_on_hts_device_kv`).
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator)
+        self._device_id = device_id
+        device = coordinator.devices.get(device_id)
+        if device:
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
+
+    @property
+    def available(self) -> bool:
+        device = self.coordinator.devices.get(self._device_id)
+        if device is None or not device.is_online:
+            return False
+        # No reading has arrived yet — entity stays unavailable instead of
+        # rendering 0.0, otherwise the Energy dashboard would integrate a
+        # phantom zero baseline before the hub's first STATUS_BODY.
+        return self._device_id in self.coordinator.device_readings
+
+
+class AjaxDeviceCurrentSensor(_AjaxDeviceReadingsBase):
+    """Live current draw of a WallSwitch / Socket-family device (A)."""
+
+    _attr_translation_key = "current"
+    _attr_device_class = SensorDeviceClass.CURRENT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+    _attr_suggested_display_precision = 2
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = f"aegis_ajax_{device_id}_current"
+
+    @property
+    def native_value(self) -> float | None:
+        readings = self.coordinator.device_readings.get(self._device_id)
+        if readings is None or readings.current_ma is None:
+            return None
+        return readings.current_ma / 1000.0
+
+
+class AjaxDeviceEnergyConsumedSensor(_AjaxDeviceReadingsBase):
+    """Cumulative electric energy consumed by the device (kWh).
+
+    `total_increasing` ties the entity into HA's Energy dashboard. The
+    Ajax PRO app exposes a "reset consumption meter" button on the same
+    device card; if the user presses it, the meter restarts from zero
+    and HA treats that as a meter reset rather than negative
+    consumption, which is exactly the `total_increasing` contract.
+    """
+
+    _attr_translation_key = "energy_consumed"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_suggested_display_precision = 3
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = f"aegis_ajax_{device_id}_energy_consumed"
+
+    @property
+    def native_value(self) -> float | None:
+        readings = self.coordinator.device_readings.get(self._device_id)
+        if readings is None or readings.power_consumed_wh is None:
+            return None
+        return readings.power_consumed_wh / 1000.0
+
+
+class AjaxDeviceDerivedPowerSensor(_AjaxDeviceReadingsBase):
+    """Instantaneous power derived from current × nominal grid voltage (W).
+
+    The WallSwitch firmware does not measure voltage; the Ajax mobile
+    app shows the nominal grid voltage (230 V) as a constant label and
+    derives "Power" from `current × 230`. We mirror that behaviour so
+    the HA sensor value matches what the user sees in the official app.
+    `NOMINAL_GRID_VOLTAGE_V` is module-level for grep-ability if a
+    future PR turns it into a configuration option.
+    """
+
+    _attr_translation_key = "power_derived"
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_entity_registry_enabled_default = False
+    _attr_suggested_display_precision = 1
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = f"aegis_ajax_{device_id}_power_derived"
+
+    @property
+    def native_value(self) -> float | None:
+        readings = self.coordinator.device_readings.get(self._device_id)
+        if readings is None or readings.current_ma is None:
+            return None
+        return (readings.current_ma / 1000.0) * NOMINAL_GRID_VOLTAGE_V

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -317,6 +317,15 @@
             },
             "cellular_network": {
                 "name": "Cellular network"
+            },
+            "current": {
+                "name": "Current"
+            },
+            "energy_consumed": {
+                "name": "Electric energy consumed"
+            },
+            "power_derived": {
+                "name": "Power (derived)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Xarxa cel·lular"
+            },
+            "current": {
+                "name": "Corrent"
+            },
+            "energy_consumed": {
+                "name": "Energia elèctrica consumida"
+            },
+            "power_derived": {
+                "name": "Potència (derivada)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Mobilní síť"
+            },
+            "current": {
+                "name": "Proud"
+            },
+            "energy_consumed": {
+                "name": "Spotřebovaná elektrická energie"
+            },
+            "power_derived": {
+                "name": "Výkon (odvozený)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Mobilfunknetz"
+            },
+            "current": {
+                "name": "Strom"
+            },
+            "energy_consumed": {
+                "name": "Verbrauchte elektrische Energie"
+            },
+            "power_derived": {
+                "name": "Leistung (berechnet)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -343,6 +343,15 @@
             },
             "cellular_network": {
                 "name": "Cellular network"
+            },
+            "current": {
+                "name": "Current"
+            },
+            "energy_consumed": {
+                "name": "Electric energy consumed"
+            },
+            "power_derived": {
+                "name": "Power (derived)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -343,6 +343,15 @@
             },
             "cellular_network": {
                 "name": "Red celular"
+            },
+            "current": {
+                "name": "Corriente"
+            },
+            "energy_consumed": {
+                "name": "Energía eléctrica consumida"
+            },
+            "power_derived": {
+                "name": "Potencia (derivada)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Réseau cellulaire"
+            },
+            "current": {
+                "name": "Courant"
+            },
+            "energy_consumed": {
+                "name": "Énergie électrique consommée"
+            },
+            "power_derived": {
+                "name": "Puissance (calculée)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Rete cellulare"
+            },
+            "current": {
+                "name": "Corrente"
+            },
+            "energy_consumed": {
+                "name": "Energia elettrica consumata"
+            },
+            "power_derived": {
+                "name": "Potenza (derivata)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Mobiel netwerk"
+            },
+            "current": {
+                "name": "Stroom"
+            },
+            "energy_consumed": {
+                "name": "Verbruikte elektrische energie"
+            },
+            "power_derived": {
+                "name": "Vermogen (afgeleid)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Sieć komórkowa"
+            },
+            "current": {
+                "name": "Prąd"
+            },
+            "energy_consumed": {
+                "name": "Zużyta energia elektryczna"
+            },
+            "power_derived": {
+                "name": "Moc (obliczona)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Rede celular"
+            },
+            "current": {
+                "name": "Corrente"
+            },
+            "energy_consumed": {
+                "name": "Energia elétrica consumida"
+            },
+            "power_derived": {
+                "name": "Potência (derivada)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Rede celular"
+            },
+            "current": {
+                "name": "Corrente"
+            },
+            "energy_consumed": {
+                "name": "Energia elétrica consumida"
+            },
+            "power_derived": {
+                "name": "Potência (derivada)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Rețea celulară"
+            },
+            "current": {
+                "name": "Curent"
+            },
+            "energy_consumed": {
+                "name": "Energie electrică consumată"
+            },
+            "power_derived": {
+                "name": "Putere (derivată)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Hücresel ağ"
+            },
+            "current": {
+                "name": "Akım"
+            },
+            "energy_consumed": {
+                "name": "Tüketilen elektrik enerjisi"
+            },
+            "power_derived": {
+                "name": "Güç (türetilmiş)"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -327,6 +327,15 @@
             },
             "cellular_network": {
                 "name": "Мобільна мережа"
+            },
+            "current": {
+                "name": "Струм"
+            },
+            "energy_consumed": {
+                "name": "Спожита електроенергія"
+            },
+            "power_derived": {
+                "name": "Потужність (розрахована)"
             }
         },
         "switch": {

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -627,6 +627,115 @@ class TestHandleUpdateNonHubProbe:
         assert "0x43" in text
 
     @pytest.mark.asyncio
+    async def test_on_device_kv_fires_once_per_non_hub_device(self) -> None:
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        captured: list[tuple[str, str, dict[int, bytes]]] = []
+        client._on_device_kv = lambda hub_id, did, kv: captured.append((hub_id, did, kv))
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x09",
+                    bytes.fromhex("12345678"),
+                    b"\x48",
+                    b"\x02",
+                    bytes.fromhex("311B058D"),
+                    b"\x42",
+                    b"\x00\x28",
+                    b"\x43",
+                    b"\x00\x09",
+                    bytes.fromhex("AABBCCDD"),
+                    b"\x05",
+                    b"\x01",
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        assert captured == [
+            ("12345678", "311B058D", {0x42: b"\x00\x28", 0x43: b"\x00\x09"}),
+            ("12345678", "AABBCCDD", {0x05: b"\x01"}),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_on_device_kv_skips_empty_device_rows(self) -> None:
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        captured: list[tuple[str, str, dict[int, bytes]]] = []
+        client._on_device_kv = lambda hub_id, did, kv: captured.append((hub_id, did, kv))
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x09",
+                    bytes.fromhex("12345678"),
+                    b"\x48",
+                    b"\x02",
+                    # Lone device marker without any kv pairs — must not
+                    # emit (otherwise the coordinator wakes up for nothing).
+                    bytes.fromhex("AABBCCDD"),
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_on_device_kv_callback_exception_doesnt_break_loop(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging as _logging
+
+        caplog.set_level(_logging.ERROR, logger="custom_components.aegis_ajax.api.hts.client")
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+
+        def _raises(hub_id: str, did: str, kv: dict[int, bytes]) -> None:
+            raise RuntimeError("synthetic")
+
+        client._on_device_kv = _raises
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x09",
+                    bytes.fromhex("12345678"),
+                    b"\x48",
+                    b"\x02",
+                    bytes.fromhex("311B058D"),
+                    b"\x42",
+                    b"\x00\x28",
+                ]
+            ),
+        )
+
+        # Must not raise out of _handle_update — the listen loop has to
+        # survive a buggy coordinator callback (#108 / parser hardening
+        # mindset). The error must be logged with exc_info though.
+        await client._handle_update(msg)
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert any("on_device_kv callback raised" in r.getMessage() for r in errors)
+
+    @pytest.mark.asyncio
     async def test_probe_silent_when_only_hub_row_present(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -649,6 +758,69 @@ class TestHandleUpdateNonHubProbe:
 
         probe_lines = [r for r in caplog.records if "#123 probe" in r.getMessage()]
         assert probe_lines == []
+
+
+class TestStatusRefreshLoop:
+    """Periodic REQUEST_FULL_STATUS keeps device-level readings live (#123)."""
+
+    @pytest.mark.asyncio
+    async def test_loop_calls_send_request_full_status_for_each_hub(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.aegis_ajax.api.hts.client.STATUS_REFRESH_INTERVAL",
+            0,
+        )
+        client = _make_client()
+        client._connected = True
+        client._hubs = [
+            MagicMock(hub_id="11111111"),
+            MagicMock(hub_id="22222222"),
+        ]
+        send = AsyncMock()
+        client._send_request_full_status = send  # type: ignore[method-assign]
+
+        async def _stop_after_first_tick() -> None:
+            await asyncio.sleep(0)
+            client._connected = False
+
+        stop_task = asyncio.create_task(_stop_after_first_tick())
+        await client._status_refresh_loop()
+        await stop_task
+
+        # First tick must have fanned out to both hubs.
+        assert send.await_args_list[0].args == ("11111111",)
+        assert send.await_args_list[1].args == ("22222222",)
+
+    @pytest.mark.asyncio
+    async def test_loop_swallows_send_errors_without_terminating(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging as _logging
+
+        caplog.set_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.hts.client")
+        monkeypatch.setattr(
+            "custom_components.aegis_ajax.api.hts.client.STATUS_REFRESH_INTERVAL",
+            0,
+        )
+        client = _make_client()
+        client._connected = True
+        client._hubs = [MagicMock(hub_id="11111111")]
+        send = AsyncMock(side_effect=[OSError("transient"), None])
+        client._send_request_full_status = send  # type: ignore[method-assign]
+
+        async def _stop_after_two_ticks() -> None:
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            client._connected = False
+
+        stop_task = asyncio.create_task(_stop_after_two_ticks())
+        await client._status_refresh_loop()
+        await stop_task
+
+        # Second tick should have run despite the first one raising.
+        assert send.await_count >= 1
+        assert any("Periodic STATUS refresh failed" in r.getMessage() for r in caplog.records)
 
 
 class TestPingLoop:

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -760,67 +760,138 @@ class TestHandleUpdateNonHubProbe:
         assert probe_lines == []
 
 
-class TestStatusRefreshLoop:
-    """Periodic REQUEST_FULL_STATUS keeps device-level readings live (#123)."""
+class TestStatusUpdatePush:
+    """STATUS_UPDATE (sub-key 11) / SETTINGS_UPDATE (12) push deltas.
+
+    These are emitted by the hub on its own cadence — no client-side
+    subscribe is needed (the audit on PRO 2.47 showed both the single
+    and bulk subscribe msg-types are deprecated and uncalled). The
+    handler must route the per-device kv payload through the same
+    `on_device_kv` callback used for the boot-time STATUS_BODY snapshot,
+    so the coordinator side stays a single code path.
+    """
 
     @pytest.mark.asyncio
-    async def test_loop_calls_send_request_full_status_for_each_hub(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(
-            "custom_components.aegis_ajax.api.hts.client.STATUS_REFRESH_INTERVAL",
-            0,
-        )
+    async def test_status_update_routes_through_on_device_kv(self) -> None:
         client = _make_client()
-        client._connected = True
-        client._hubs = [
-            MagicMock(hub_id="11111111"),
-            MagicMock(hub_id="22222222"),
+        client._hubs = [MagicMock(hub_id="12345678")]
+        captured: list[tuple[str, str, dict[int, bytes]]] = []
+        client._on_device_kv = lambda hub_id, did, kv: captured.append((hub_id, did, kv))
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x0b",  # STATUS_UPDATE
+                    bytes.fromhex("311B058D"),
+                    b"\x42",
+                    b"\x00\x28",
+                    b"\x43",
+                    b"\x00\x09",
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        assert captured == [
+            ("12345678", "311B058D", {0x42: b"\x00\x28", 0x43: b"\x00\x09"}),
         ]
-        send = AsyncMock()
-        client._send_request_full_status = send  # type: ignore[method-assign]
-
-        async def _stop_after_first_tick() -> None:
-            await asyncio.sleep(0)
-            client._connected = False
-
-        stop_task = asyncio.create_task(_stop_after_first_tick())
-        await client._status_refresh_loop()
-        await stop_task
-
-        # First tick must have fanned out to both hubs.
-        assert send.await_args_list[0].args == ("11111111",)
-        assert send.await_args_list[1].args == ("22222222",)
 
     @pytest.mark.asyncio
-    async def test_loop_swallows_send_errors_without_terminating(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        import logging as _logging
-
-        caplog.set_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.hts.client")
-        monkeypatch.setattr(
-            "custom_components.aegis_ajax.api.hts.client.STATUS_REFRESH_INTERVAL",
-            0,
-        )
+    async def test_settings_update_routes_through_on_device_kv(self) -> None:
+        # Same routing for sub-key 0x0c. We don't currently consume
+        # settings-only sub-keys but the coordinator's electrical-type
+        # filter is the single gate; emitting them keeps the surface
+        # area uniform.
         client = _make_client()
-        client._connected = True
-        client._hubs = [MagicMock(hub_id="11111111")]
-        send = AsyncMock(side_effect=[OSError("transient"), None])
-        client._send_request_full_status = send  # type: ignore[method-assign]
+        client._hubs = [MagicMock(hub_id="12345678")]
+        captured: list[tuple[str, str, dict[int, bytes]]] = []
+        client._on_device_kv = lambda hub_id, did, kv: captured.append((hub_id, did, kv))
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x0c",  # SETTINGS_UPDATE
+                    bytes.fromhex("311B058D"),
+                    b"\x40",
+                    b"\x01",
+                ]
+            ),
+        )
 
-        async def _stop_after_two_ticks() -> None:
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            client._connected = False
+        await client._handle_update(msg)
 
-        stop_task = asyncio.create_task(_stop_after_two_ticks())
-        await client._status_refresh_loop()
-        await stop_task
+        assert captured == [("12345678", "311B058D", {0x40: b"\x01"})]
 
-        # Second tick should have run despite the first one raising.
-        assert send.await_count >= 1
-        assert any("Periodic STATUS refresh failed" in r.getMessage() for r in caplog.records)
+    @pytest.mark.asyncio
+    async def test_status_update_with_hub_marker_is_ignored(self) -> None:
+        # Same shape but the device id IS the hub — hub-level deltas
+        # are owned by the `_extract_direct_kv` / `parse_hub_params`
+        # path above; do not double-route them through on_device_kv.
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        captured: list[tuple[str, str, dict[int, bytes]]] = []
+        client._on_device_kv = lambda hub_id, did, kv: captured.append((hub_id, did, kv))
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x0b",
+                    bytes.fromhex("12345678"),
+                    b"\x05",
+                    b"\x01",
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_status_update_no_longer_schedules_full_refresh(self) -> None:
+        # Pre-#111 behaviour was a full snapshot round-trip on every
+        # sub-key 11 (every few seconds — the original WallSwitch
+        # bandwidth bug). Confirm the new path consumes the delta
+        # without firing `_schedule_hub_refresh`.
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        client._schedule_hub_refresh = MagicMock()  # type: ignore[method-assign]
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x0b",
+                    bytes.fromhex("311B058D"),
+                    b"\x42",
+                    b"\x00\x28",
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        client._schedule_hub_refresh.assert_not_called()
 
 
 class TestPingLoop:

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -497,6 +497,161 @@ class TestHandleUpdate:
         assert client._receive_message.await_count == MAX_CONSECUTIVE_READ_TIMEOUTS
         assert client._consecutive_read_timeouts == MAX_CONSECUTIVE_READ_TIMEOUTS
 
+
+class TestExtractAllDevicesKv:
+    """Per-device kv extraction for the #123 probe.
+
+    Generalises `_extract_device_kv` (which returns kv for one specific
+    device) to walk the entire body and emit one (device_id, kv) tuple
+    per device marker. DEBUG-only consumer today — wired in
+    `_handle_update` to surface what sub-keys non-hub devices carry,
+    ahead of mapping them to sensors.
+    """
+
+    def test_empty_params_yields_empty_list(self) -> None:
+        assert HtsClient._extract_all_devices_kv([]) == []
+
+    def test_sub_key_without_markers_yields_empty_list(self) -> None:
+        # `params[0]` is the sub-key byte; if there is no 4-byte device
+        # marker afterwards, nothing should be reported.
+        assert HtsClient._extract_all_devices_kv([b"\x09"]) == []
+
+    def test_single_device_returns_its_kvs(self) -> None:
+        hub_id = bytes.fromhex("12345678")
+        result = HtsClient._extract_all_devices_kv(
+            [
+                b"\x09",  # sub_key (STATUS_BODY)
+                hub_id,
+                b"\x48",
+                b"\x02",
+                b"\x37",
+                b"\xab\xcd",
+            ]
+        )
+        assert result == [(hub_id, {0x48: b"\x02", 0x37: b"\xab\xcd"})]
+
+    def test_two_devices_separated_correctly(self) -> None:
+        hub_id = bytes.fromhex("12345678")
+        wallswitch_id = bytes.fromhex("311B058D")
+        result = HtsClient._extract_all_devices_kv(
+            [
+                b"\x09",
+                hub_id,
+                b"\x48",
+                b"\x02",
+                wallswitch_id,
+                b"\x42",
+                b"\x00\x28",  # current_ma = 40
+                b"\x43",
+                b"\x00\x09",  # power_wth = 9
+            ]
+        )
+        assert result == [
+            (hub_id, {0x48: b"\x02"}),
+            (wallswitch_id, {0x42: b"\x00\x28", 0x43: b"\x00\x09"}),
+        ]
+
+    def test_two_byte_keys_are_skipped(self) -> None:
+        # Same rule as `_extract_device_kv`: 1-byte keys only, 2-byte
+        # extended keys are intentionally not surfaced.
+        hub_id = bytes.fromhex("12345678")
+        result = HtsClient._extract_all_devices_kv(
+            [
+                b"\x09",
+                hub_id,
+                b"\xff\xee",  # 2-byte extended key
+                b"\x01",
+                b"\x37",
+                b"\xab",
+            ]
+        )
+        assert result == [(hub_id, {0x37: b"\xab"})]
+
+    def test_orphan_params_before_first_marker_are_skipped(self) -> None:
+        # Garbage / unexpected leading params (no preceding device id)
+        # should not crash and should not associate with any device.
+        hub_id = bytes.fromhex("12345678")
+        result = HtsClient._extract_all_devices_kv(
+            [
+                b"\x09",
+                b"\x99",  # orphan single byte before any marker
+                hub_id,
+                b"\x48",
+                b"\x02",
+            ]
+        )
+        assert result == [(hub_id, {0x48: b"\x02"})]
+
+
+class TestHandleUpdateNonHubProbe:
+    """DEBUG probe for non-hub device sub-keys in STATUS / SETTINGS bodies (#123)."""
+
+    @pytest.mark.asyncio
+    async def test_non_hub_device_subkeys_are_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        caplog.set_level(logging.DEBUG, logger="custom_components.aegis_ajax.api.hts.client")
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x09",
+                    bytes.fromhex("12345678"),
+                    b"\x48",
+                    b"\x02",
+                    bytes.fromhex("311B058D"),
+                    b"\x42",
+                    b"\x00\x28",
+                    b"\x43",
+                    b"\x00\x09",
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        probe_lines = [r for r in caplog.records if "#123 probe" in r.getMessage()]
+        assert probe_lines, "expected one #123 probe DEBUG line"
+        text = probe_lines[0].getMessage()
+        assert "311B058D" in text
+        assert "0x42" in text
+        assert "0x43" in text
+
+    @pytest.mark.asyncio
+    async def test_probe_silent_when_only_hub_row_present(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        caplog.set_level(logging.DEBUG, logger="custom_components.aegis_ajax.api.hts.client")
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode([b"\x09", bytes.fromhex("12345678"), b"\x48", b"\x02"]),
+        )
+
+        await client._handle_update(msg)
+
+        probe_lines = [r for r in caplog.records if "#123 probe" in r.getMessage()]
+        assert probe_lines == []
+
+
+class TestPingLoop:
     @pytest.mark.asyncio
     async def test_ping_loop_marks_disconnected_on_send_failure(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -317,3 +317,97 @@ class TestHelpers:
 
     def test_ip_val_too_short_returns_empty(self) -> None:
         assert _ip_val(bytes([192, 168])) == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-device readings (WallSwitch / Socket family, #123)
+# ---------------------------------------------------------------------------
+
+from custom_components.aegis_ajax.api.hts.hub_state import (  # noqa: E402
+    DEVICE_KEY_CURRENT_MA,
+    DEVICE_KEY_POWER_CONSUMED_WH,
+    ELECTRICAL_DEVICE_TYPES,
+    DeviceReadings,
+    _int_be_val,
+    parse_device_readings,
+)
+
+
+class TestIntBeVal:
+    def test_returns_none_for_none_or_empty(self) -> None:
+        assert _int_be_val(None) is None
+        assert _int_be_val(b"") is None
+
+    def test_single_byte(self) -> None:
+        assert _int_be_val(b"\x28") == 40
+
+    def test_two_bytes_be(self) -> None:
+        assert _int_be_val(b"\x01\x00") == 256
+
+    def test_four_bytes_be(self) -> None:
+        assert _int_be_val(b"\x00\x00\x09\x69") == 0x969  # 2409
+
+
+class TestDeviceReadingsDefaults:
+    def test_defaults_none(self) -> None:
+        r = DeviceReadings()
+        assert r.current_ma is None
+        assert r.power_consumed_wh is None
+
+    def test_is_frozen(self) -> None:
+        r = DeviceReadings(current_ma=40, power_consumed_wh=2411)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            r.current_ma = 99  # type: ignore[misc]
+
+
+class TestParseDeviceReadings:
+    def test_non_electrical_type_returns_none(self) -> None:
+        # MotionProtect-family detectors don't emit current_ma / power_wh.
+        assert (
+            parse_device_readings(
+                "motion_protect",
+                {DEVICE_KEY_CURRENT_MA: b"\x28", DEVICE_KEY_POWER_CONSUMED_WH: b"\x09"},
+            )
+            is None
+        )
+
+    def test_wall_switch_full(self) -> None:
+        r = parse_device_readings(
+            "wall_switch",
+            {
+                DEVICE_KEY_CURRENT_MA: b"\x00\x00\x00\x28",  # 40 mA
+                DEVICE_KEY_POWER_CONSUMED_WH: b"\x00\x00\x09\x69",  # 2409 Wh
+            },
+        )
+        assert r == DeviceReadings(current_ma=40, power_consumed_wh=2409)
+
+    def test_socket_partial_only_current(self) -> None:
+        # Power-consumed sub-key may be absent on a freshly-installed device.
+        r = parse_device_readings(
+            "socket",
+            {DEVICE_KEY_CURRENT_MA: b"\x05"},
+        )
+        assert r == DeviceReadings(current_ma=5, power_consumed_wh=None)
+
+    def test_electrical_type_with_empty_kv(self) -> None:
+        # The device's row was in the body but it carried no readings —
+        # returns a DeviceReadings with both fields None, not None.
+        r = parse_device_readings("relay_fibra_base", {})
+        assert r == DeviceReadings(current_ma=None, power_consumed_wh=None)
+
+    def test_known_electrical_types(self) -> None:
+        # Sanity-check: every type the switch platform treats as a
+        # power-controllable relay that *should* emit readings is in
+        # ELECTRICAL_DEVICE_TYPES.
+        for dt in (
+            "wall_switch",
+            "relay",
+            "relay_fibra_base",
+            "socket",
+            "socket_b",
+            "socket_g",
+            "socket_outlet_type_e",
+            "socket_outlet_type_f",
+            "socket_type_g_plus",
+        ):
+            assert dt in ELECTRICAL_DEVICE_TYPES, dt

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -103,6 +103,10 @@ class TestCoordinatorInit:
         coordinator = _make_coordinator()
         assert coordinator.hub_network == {}
 
+    def test_device_readings_initially_empty(self) -> None:
+        coordinator = _make_coordinator()
+        assert coordinator.device_readings == {}
+
     def test_rooms_initially_empty(self) -> None:
         coordinator = _make_coordinator()
         assert coordinator.rooms == {}
@@ -1293,3 +1297,101 @@ class TestCachedSnapshotStart:
         assert "Aegis startup" in caplog.text
         assert "device streams 1/1" in caplog.text
         assert "HTS lifecycle scheduled" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Per-device readings via HTS (#123)
+# ---------------------------------------------------------------------------
+
+
+class TestOnHtsDeviceKv:
+    """Coordinator translates HTS per-device kv into DeviceReadings."""
+
+    def _make_electrical_device(
+        self, device_id: str = "311B058D", device_type: str = "wall_switch"
+    ) -> Device:
+        return Device(
+            id=device_id,
+            hub_id="hub-1",
+            name="Relay",
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    def test_wall_switch_readings_stored_and_event_fired(self) -> None:
+        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+
+        coordinator = _make_coordinator()
+        coordinator.devices["311B058D"] = self._make_electrical_device()
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv(
+            "002B1A51",
+            "311B058D",
+            {0x42: b"\x00\x00\x00\x28", 0x43: b"\x00\x00\x09\x69"},
+        )
+
+        assert coordinator.device_readings["311B058D"] == DeviceReadings(
+            current_ma=40, power_consumed_wh=2409
+        )
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_unknown_device_id_is_ignored(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("002B1A51", "DEADBEEF", {0x42: b"\x00\x28"})
+
+        assert coordinator.device_readings == {}
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_non_electrical_device_type_is_ignored(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.devices["311B058D"] = self._make_electrical_device(device_type="door_protect")
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("002B1A51", "311B058D", {0x42: b"\x00\x28"})
+
+        assert coordinator.device_readings == {}
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_unchanged_readings_dont_trigger_refresh(self) -> None:
+        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+
+        coordinator = _make_coordinator()
+        coordinator.devices["311B058D"] = self._make_electrical_device()
+        coordinator.device_readings["311B058D"] = DeviceReadings(
+            current_ma=40, power_consumed_wh=2409
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv(
+            "002B1A51",
+            "311B058D",
+            {0x42: b"\x00\x00\x00\x28", 0x43: b"\x00\x00\x09\x69"},
+        )
+
+        # Same values — no entity refresh needed.
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_hts_disconnect_clears_device_readings(self) -> None:
+        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+
+        coordinator = _make_coordinator()
+        coordinator.device_readings["311B058D"] = DeviceReadings(
+            current_ma=40, power_consumed_wh=2409
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._handle_hts_disconnect(reconnect=False)
+
+        assert coordinator.device_readings == {}
+        # Both hub_network and device_readings clear in the same call,
+        # so async_set_updated_data fires exactly once.
+        coordinator.async_set_updated_data.assert_called_once()

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -6,6 +6,8 @@ import json
 from dataclasses import replace
 from unittest.mock import MagicMock
 
+import pytest
+
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
 from custom_components.aegis_ajax.api.hub_object import SimCardInfo
 from custom_components.aegis_ajax.api.models import (
@@ -530,3 +532,128 @@ class TestHubMonitoringCompanySensor:
         sensor = AjaxHubMonitoringCompanySensor(coordinator, "space-1", "hub-1")
 
         assert sensor.available is False
+
+
+# ---------------------------------------------------------------------------
+# Per-device electrical sensors (#123)
+# ---------------------------------------------------------------------------
+
+
+class TestAjaxDeviceElectricalSensors:
+    """Current / energy / derived-power sensors for WallSwitch / Socket."""
+
+    @staticmethod
+    def _make_coordinator(
+        device_type: str = "wall_switch",
+        online: bool = True,
+        current_ma: int | None = 40,
+        power_consumed_wh: int | None = 2409,
+    ) -> MagicMock:
+        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+        from custom_components.aegis_ajax.api.models import Device
+
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        device = Device(
+            id="311B058D",
+            hub_id="002B1A51",
+            name="Relay",
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE if online else DeviceState.OFFLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+        coordinator.devices = {"311B058D": device}
+        if current_ma is not None or power_consumed_wh is not None:
+            coordinator.device_readings = {
+                "311B058D": DeviceReadings(
+                    current_ma=current_ma,
+                    power_consumed_wh=power_consumed_wh,
+                )
+            }
+        else:
+            coordinator.device_readings = {}
+        return coordinator
+
+    def test_current_sensor_scales_milliamps_to_amps(self) -> None:
+        from custom_components.aegis_ajax.sensor import AjaxDeviceCurrentSensor
+
+        coordinator = self._make_coordinator(current_ma=40)
+        sensor = AjaxDeviceCurrentSensor(coordinator, "311B058D")
+        assert sensor.native_value == 0.04
+
+    def test_current_sensor_none_when_no_reading_yet(self) -> None:
+        from custom_components.aegis_ajax.sensor import AjaxDeviceCurrentSensor
+
+        coordinator = self._make_coordinator(current_ma=None, power_consumed_wh=None)
+        sensor = AjaxDeviceCurrentSensor(coordinator, "311B058D")
+        assert sensor.native_value is None
+
+    def test_current_sensor_unavailable_when_no_reading_yet(self) -> None:
+        from custom_components.aegis_ajax.sensor import AjaxDeviceCurrentSensor
+
+        coordinator = self._make_coordinator(current_ma=None, power_consumed_wh=None)
+        sensor = AjaxDeviceCurrentSensor(coordinator, "311B058D")
+        assert sensor.available is False
+
+    def test_current_sensor_unavailable_when_device_offline(self) -> None:
+        from custom_components.aegis_ajax.sensor import AjaxDeviceCurrentSensor
+
+        coordinator = self._make_coordinator(online=False)
+        sensor = AjaxDeviceCurrentSensor(coordinator, "311B058D")
+        assert sensor.available is False
+
+    def test_energy_sensor_scales_watthours_to_kwh(self) -> None:
+        from custom_components.aegis_ajax.sensor import AjaxDeviceEnergyConsumedSensor
+
+        coordinator = self._make_coordinator(power_consumed_wh=2409)
+        sensor = AjaxDeviceEnergyConsumedSensor(coordinator, "311B058D")
+        assert sensor.native_value == 2.409
+
+    def test_energy_sensor_state_class_is_total_increasing(self) -> None:
+        # Required for HA Energy dashboard integration with a cumulative meter
+        # (so a meter-reset is treated as a reset, not negative consumption).
+        from homeassistant.components.sensor import SensorStateClass
+
+        from custom_components.aegis_ajax.sensor import AjaxDeviceEnergyConsumedSensor
+
+        coordinator = self._make_coordinator()
+        sensor = AjaxDeviceEnergyConsumedSensor(coordinator, "311B058D")
+        assert sensor.state_class is SensorStateClass.TOTAL_INCREASING
+
+    def test_derived_power_uses_nominal_voltage(self) -> None:
+        # PRO renders 9W from 0.04A × 230V; we mirror that exactly.
+        from custom_components.aegis_ajax.sensor import AjaxDeviceDerivedPowerSensor
+
+        coordinator = self._make_coordinator(current_ma=40)
+        sensor = AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")
+        assert sensor.native_value == pytest.approx(9.2)
+
+    def test_derived_power_disabled_by_default(self) -> None:
+        # The current+energy pair are the load-bearing entities; the
+        # derived power is opt-in to avoid surfacing 3 sensors per relay
+        # for the common case where users only want the consumption meter.
+        from custom_components.aegis_ajax.sensor import AjaxDeviceDerivedPowerSensor
+
+        coordinator = self._make_coordinator()
+        sensor = AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")
+        assert sensor.entity_registry_enabled_default is False
+
+    def test_unique_ids_distinct_across_three_entities(self) -> None:
+        from custom_components.aegis_ajax.sensor import (
+            AjaxDeviceCurrentSensor,
+            AjaxDeviceDerivedPowerSensor,
+            AjaxDeviceEnergyConsumedSensor,
+        )
+
+        coordinator = self._make_coordinator()
+        uids = {
+            AjaxDeviceCurrentSensor(coordinator, "311B058D")._attr_unique_id,
+            AjaxDeviceEnergyConsumedSensor(coordinator, "311B058D")._attr_unique_id,
+            AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")._attr_unique_id,
+        }
+        assert len(uids) == 3


### PR DESCRIPTION
## Summary

Surfaces the live electrical readings the official Ajax app shows on the device card of every WallSwitch and Socket-family device — current, cumulative energy, and a derived instantaneous power — as native HA sensors. Closes the largest gap in #123.

Two steps in the branch history:

1. Initial pass: parser + sensor entities + 60 s periodic full-status polling. Functional but bandwidth-wasteful and 60 s-laggy.
2. Refactor to push-driven: drops the periodic polling, wires per-device delta-push handlers. Matches what the official app does.

## Why push, not polling

The hub fires per-device status deltas every 5-10 s without any explicit subscription — the protocol's existing per-device delta push channel is what the official app rides. @brunovdw68's debug log on #123 confirms these deltas arrive on installs that never subscribe explicitly. Conclusion: the auth handshake is the implicit subscribe; we just have to listen.

The payload shape of a delta push is identical to a single device's row inside the periodic full snapshot, so the same per-device walker handles both.

## What changes

**Parser** (`hub_state.py`)
- `DeviceReadings` dataclass + `parse_device_readings(device_type, kv)`.
- `ELECTRICAL_DEVICE_TYPES` whitelists `wall_switch`, `relay`, `relay_fibra_base`, plus the Socket family.

**HTS client** (`api/hts/client.py`)
- New per-device walker that yields one record per device from the body.
- `on_device_kv` callback fired for both periodic body snapshots and live delta pushes. Same routing, same coordinator code path.
- The #111 silent-drop of the heartbeat channel is subsumed: the issue was firing a snapshot refresh on every heartbeat, not the drop itself. We now read the delta in-place and never schedule a refresh from it.

**Coordinator** (`coordinator.py`)
- `device_readings: dict[str, DeviceReadings]`, populated via `_on_hts_device_kv`. Unchanged readings short-circuit `async_set_updated_data` so entities only re-render on a real change. Cleared on HTS disconnect.

**Sensor entities** (`sensor.py`)
- `AjaxDeviceCurrentSensor` (A, `device_class=current`)
- `AjaxDeviceEnergyConsumedSensor` (kWh, `device_class=energy`, `state_class=total_increasing`)
- `AjaxDeviceDerivedPowerSensor` (W, `device_class=power`, disabled by default)

Translations in all 14 locales.

## Test plan

- [x] `make check` green inside Docker (rebuilt image without volume mount).
- [x] New `TestParseDeviceReadings`, `TestExtractAllDevicesKv`, `TestStatusUpdatePush`, `TestOnHtsDeviceKv`, `TestAjaxDeviceElectricalSensors` cover parser + push handler + coordinator routing + sensor entity surface.
- [ ] CI matrix (Python 3.12 + 3.13, hassfest, HACS validate, CodeQL) on the pushed branch.
- [ ] Real-HA confirmation in the next beta against @brunovdw68's install: current / energy / power sensors appear and follow the WallSwitch load.