### PR TITLE
fix(config_flow): persist FCM credential deletions from options

### DIFF
--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -437,13 +437,22 @@ class AjaxCobrandedOptionsFlow(OptionsFlow):
                 ).hexdigest()
             else:
                 user_input.pop("pin_code", None)
-            # Move FCM credentials into config_entry.data (encrypted storage)
-            fcm_data = {k: user_input.pop(k) for k in _FCM_KEYS if k in user_input}
-            if any(fcm_data.values()):
-                self.hass.config_entries.async_update_entry(
-                    self._entry,
-                    data={**self._entry.data, **fcm_data},
-                )
+            # Move FCM credentials into config_entry.data (encrypted storage).
+            # Empty strings mean "clear this credential", so drop those keys
+            # from entry.data instead of persisting "" (issue #138).
+            fcm_input = {k: user_input.pop(k) for k in _FCM_KEYS if k in user_input}
+            if fcm_input:
+                new_data = {**self._entry.data}
+                for k, v in fcm_input.items():
+                    if v:
+                        new_data[k] = v
+                    else:
+                        new_data.pop(k, None)
+                if new_data != self._entry.data:
+                    self.hass.config_entries.async_update_entry(
+                        self._entry,
+                        data=new_data,
+                    )
             return self.async_create_entry(title="", data=user_input)
         return self.async_show_form(
             step_id="init",

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -547,3 +547,125 @@ class TestOptionsFlow:
         stored_data = flow.async_create_entry.call_args[1]["data"]
         assert "pin_code" not in stored_data
         assert "pin_code_hash" not in stored_data
+
+    @pytest.mark.asyncio
+    async def test_options_flow_fcm_values_persisted_to_entry_data(self) -> None:
+        """Non-empty FCM values move from form input into entry.data."""
+        flow, entry = self._make_flow(data={"email": "x@y"})
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init(
+            {
+                "poll_interval": 60,
+                "use_pin_code": False,
+                "fcm_project_id": "proj",
+                "fcm_app_id": "app",
+                "fcm_api_key": "key",
+                "fcm_sender_id": "123",
+            }
+        )
+
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+        assert new_data["fcm_project_id"] == "proj"
+        assert new_data["fcm_app_id"] == "app"
+        assert new_data["fcm_api_key"] == "key"
+        assert new_data["fcm_sender_id"] == "123"
+        assert new_data["email"] == "x@y"
+        # FCM keys must not leak into options
+        stored_options = flow.async_create_entry.call_args[1]["data"]
+        for k in ("fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id"):
+            assert k not in stored_options
+
+    @pytest.mark.asyncio
+    async def test_options_flow_clearing_all_fcm_fields_removes_from_data(self) -> None:
+        """Empty strings for every FCM field remove them from entry.data (issue #138)."""
+        flow, entry = self._make_flow(
+            data={
+                "email": "x@y",
+                "fcm_project_id": "old_proj",
+                "fcm_app_id": "old_app",
+                "fcm_api_key": "old_key",
+                "fcm_sender_id": "old_sender",
+            }
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init(
+            {
+                "poll_interval": 60,
+                "use_pin_code": False,
+                "fcm_project_id": "",
+                "fcm_app_id": "",
+                "fcm_api_key": "",
+                "fcm_sender_id": "",
+            }
+        )
+
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+        for k in ("fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id"):
+            assert k not in new_data, f"{k} should be removed when cleared"
+        assert new_data["email"] == "x@y"
+
+    @pytest.mark.asyncio
+    async def test_options_flow_clearing_one_fcm_field_keeps_others(self) -> None:
+        """Clearing only one FCM field removes that key while keeping the rest."""
+        flow, entry = self._make_flow(
+            data={
+                "fcm_project_id": "old_proj",
+                "fcm_app_id": "old_app",
+                "fcm_api_key": "old_key",
+                "fcm_sender_id": "old_sender",
+            }
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init(
+            {
+                "poll_interval": 60,
+                "use_pin_code": False,
+                "fcm_project_id": "new_proj",
+                "fcm_app_id": "new_app",
+                "fcm_api_key": "",
+                "fcm_sender_id": "new_sender",
+            }
+        )
+
+        new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+        assert new_data["fcm_project_id"] == "new_proj"
+        assert new_data["fcm_app_id"] == "new_app"
+        assert "fcm_api_key" not in new_data
+        assert new_data["fcm_sender_id"] == "new_sender"
+
+    @pytest.mark.asyncio
+    async def test_options_flow_clearing_fcm_also_strips_legacy_options(self) -> None:
+        """Legacy installs kept FCM in entry.options; clearing must also drop them there."""
+        flow, entry = self._make_flow(
+            options={
+                "fcm_project_id": "legacy_proj",
+                "fcm_app_id": "legacy_app",
+                "fcm_api_key": "legacy_key",
+                "fcm_sender_id": "legacy_sender",
+            }
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init(
+            {
+                "poll_interval": 60,
+                "use_pin_code": False,
+                "fcm_project_id": "",
+                "fcm_app_id": "",
+                "fcm_api_key": "",
+                "fcm_sender_id": "",
+            }
+        )
+
+        stored_options = flow.async_create_entry.call_args[1]["data"]
+        for k in ("fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id"):
+            assert k not in stored_options


### PR DESCRIPTION
## Summary

- Empty FCM fields in the options form were silently dropped instead of clearing `entry.data`, so reopening the form repopulated the credentials and there was no way to remove them through the UI (#138).
- Treat an empty submitted FCM field as an explicit deletion: drop the key from `entry.data`. Mixed submissions (some cleared, some changed) keep the changed values and drop the cleared ones in a single update.
- No UI / Repair / wire-protocol changes; pure options-flow persistence fix.

Refs #138.

## Test plan

- [x] `make check` green inside Docker (rebuilt image without volume mount): 1202 tests pass, 85.41% coverage.
- [x] New `TestOptionsFlow` cases cover: non-empty FCM persisted to `entry.data` (not options), clearing all four fields removes them from `entry.data`, clearing one field removes only that one and keeps the rest, legacy installs with FCM under `entry.options` get the keys stripped on save.
- [ ] CI matrix (Python 3.12 + 3.13, hassfest, HACS validate, CodeQL) on the pushed branch.
- [ ] Real-HA confirmation in the next beta: configure FCM, clear all four fields, save, reopen options → fields show empty; the `fcm_not_configured` Repair is raised again on next start.