### PR TITLE
fix(123): retain readings on partial update + real WallSwitch voltage

### DIFF
--- a/custom_components/aegis_ajax/api/hts/hub_state.py
+++ b/custom_components/aegis_ajax/api/hts/hub_state.py
@@ -197,21 +197,39 @@ class DeviceReadings:
 def parse_device_readings(
     device_type: str,
     kv: dict[int, bytes],
+    existing: DeviceReadings | None = None,
 ) -> DeviceReadings | None:
     """Map a per-device TLV kv block to `DeviceReadings`.
 
     Returns `None` when the device type does not emit electrical
     readings (so callers can early-out and avoid creating empty
     snapshots). For an electrical-capable device the return is always
-    a `DeviceReadings` instance, even if both sub-keys are absent from
-    the kv block — the empty case is still useful for callers to know
-    the device was *present* in the body.
+    a `DeviceReadings` instance.
+
+    If *existing* is provided only fields whose sub-keys are present in
+    *kv* are updated; all other fields retain their values from
+    *existing*. This is the same merge semantics `parse_hub_params`
+    uses, and matters because the hub pushes per-device deltas
+    (`STATUS_UPDATE`) that frequently carry just one of the two
+    electrical sub-keys — or neither — alongside e.g. the relay
+    state byte. Without the merge, every relay toggle would null out
+    the cached current / energy readings and the sensor would render
+    `unknown` until the next full snapshot (#123 regression).
     """
     if device_type not in ELECTRICAL_DEVICE_TYPES:
         return None
+    base = existing if existing is not None else DeviceReadings()
     return DeviceReadings(
-        current_ma=_int_be_val(kv.get(DEVICE_KEY_CURRENT_MA)),
-        power_consumed_wh=_int_be_val(kv.get(DEVICE_KEY_POWER_CONSUMED_WH)),
+        current_ma=(
+            _int_be_val(kv[DEVICE_KEY_CURRENT_MA])
+            if DEVICE_KEY_CURRENT_MA in kv
+            else base.current_ma
+        ),
+        power_consumed_wh=(
+            _int_be_val(kv[DEVICE_KEY_POWER_CONSUMED_WH])
+            if DEVICE_KEY_POWER_CONSUMED_WH in kv
+            else base.power_consumed_wh
+        ),
     )
 
 

--- a/custom_components/aegis_ajax/api/hts/hub_state.py
+++ b/custom_components/aegis_ajax/api/hts/hub_state.py
@@ -155,6 +155,7 @@ def _int_be_val(val: bytes | None) -> int | None:
 # container (`poz0` in Ajax PRO 2.47 smali) — see #123 for the audit
 # trail.
 
+DEVICE_KEY_VOLTAGE_V = 0x35
 DEVICE_KEY_CURRENT_MA = 0x42
 DEVICE_KEY_POWER_CONSUMED_WH = 0x43
 
@@ -183,15 +184,22 @@ ELECTRICAL_DEVICE_TYPES: frozenset[str] = frozenset(
 class DeviceReadings:
     """Immutable snapshot of a single device's electrical readings.
 
-    `current_ma` and `power_consumed_wh` are `None` when the device does
-    not emit them, when the body simply hadn't been refreshed yet, or
-    when the sub-key was missing on a body that did include the device.
-    Consumers should treat any `None` as "no measurement available" and
-    render the entity as `unknown` rather than zero.
+    All three fields are `None` when the device does not emit them,
+    when the body simply hadn't been refreshed yet, or when the
+    sub-key was missing on a body that did include the device.
+    Consumers should treat any `None` as "no measurement available"
+    and render the entity as `unknown` rather than zero.
+
+    `voltage_v` is a signed short straight from the wire (sub-key
+    0x35, named `voltage` in Ajax PRO 2.47's `poz0` TLV container);
+    units are volts as the device reports them, no scaling. Older
+    WallSwitch firmwares omit the sub-key entirely — power-derived
+    callers must fall back to a nominal voltage in that case.
     """
 
     current_ma: int | None = None
     power_consumed_wh: int | None = None
+    voltage_v: int | None = None
 
 
 def parse_device_readings(
@@ -229,6 +237,9 @@ def parse_device_readings(
             _int_be_val(kv[DEVICE_KEY_POWER_CONSUMED_WH])
             if DEVICE_KEY_POWER_CONSUMED_WH in kv
             else base.power_consumed_wh
+        ),
+        voltage_v=(
+            _int_be_val(kv[DEVICE_KEY_VOLTAGE_V]) if DEVICE_KEY_VOLTAGE_V in kv else base.voltage_v
         ),
     )
 

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -517,7 +517,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device = self.devices.get(device_id_hex)
         if device is None:
             return
-        readings = parse_device_readings(device.device_type, kv)
+        readings = parse_device_readings(
+            device.device_type,
+            kv,
+            existing=self.device_readings.get(device_id_hex),
+        )
         if readings is None:
             return
         if self.device_readings.get(device_id_hex) == readings:

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
     UnitOfElectricCurrent,
+    UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfTemperature,
@@ -22,10 +23,11 @@ from custom_components.aegis_ajax.api.models import MonitoringCompanyStatus
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 from custom_components.aegis_ajax.entity import build_device_info
 
-# Nominal grid voltage assumed when deriving instantaneous power from
-# current (#123). The Ajax mobile app does the same — the device card
-# shows "230 V" as a fixed label, then renders Power = V × A. The
-# WallSwitch firmware does not report measured voltage on the wire.
+# Fallback voltage used to derive instantaneous power when the device
+# hasn't reported a real voltage reading yet (#123). Recent WallSwitch
+# firmwares emit `voltage` on HTS sub-key 0x35 (signed short, volts);
+# older firmwares omit the field, so we land on this nominal value the
+# Ajax mobile app uses as its labelled "230 V" baseline.
 NOMINAL_GRID_VOLTAGE_V = 230.0
 
 if TYPE_CHECKING:
@@ -163,6 +165,7 @@ async def async_setup_entry(
     for device_id, device in coordinator.devices.items():
         if device.device_type in ELECTRICAL_DEVICE_TYPES:
             entities.append(AjaxDeviceCurrentSensor(coordinator, device_id))
+            entities.append(AjaxDeviceVoltageSensor(coordinator, device_id))
             entities.append(AjaxDeviceEnergyConsumedSensor(coordinator, device_id))
             entities.append(AjaxDeviceDerivedPowerSensor(coordinator, device_id))
 
@@ -523,6 +526,33 @@ class AjaxDeviceCurrentSensor(_AjaxDeviceReadingsBase):
         return readings.current_ma / 1000.0
 
 
+class AjaxDeviceVoltageSensor(_AjaxDeviceReadingsBase):
+    """Live line voltage reported by a WallSwitch / Socket-family device (V).
+
+    Comes straight from HTS sub-key 0x35 of the device's TLV block,
+    no scaling. Older firmwares (pre-WallSwitch PRO 2.47 era) don't
+    emit the sub-key — the entity then stays `unknown` until the
+    device reports one.
+    """
+
+    _attr_translation_key = "voltage"
+    _attr_device_class = SensorDeviceClass.VOLTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    _attr_suggested_display_precision = 0
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = f"aegis_ajax_{device_id}_voltage"
+
+    @property
+    def native_value(self) -> float | None:
+        readings = self.coordinator.device_readings.get(self._device_id)
+        if readings is None or readings.voltage_v is None:
+            return None
+        return float(readings.voltage_v)
+
+
 class AjaxDeviceEnergyConsumedSensor(_AjaxDeviceReadingsBase):
     """Cumulative electric energy consumed by the device (kWh).
 
@@ -552,14 +582,13 @@ class AjaxDeviceEnergyConsumedSensor(_AjaxDeviceReadingsBase):
 
 
 class AjaxDeviceDerivedPowerSensor(_AjaxDeviceReadingsBase):
-    """Instantaneous power derived from current × nominal grid voltage (W).
+    """Instantaneous power derived from current × voltage (W).
 
-    The WallSwitch firmware does not measure voltage; the Ajax mobile
-    app shows the nominal grid voltage (230 V) as a constant label and
-    derives "Power" from `current × 230`. We mirror that behaviour so
-    the HA sensor value matches what the user sees in the official app.
-    `NOMINAL_GRID_VOLTAGE_V` is module-level for grep-ability if a
-    future PR turns it into a configuration option.
+    Uses the device's reported voltage when present (HTS sub-key 0x35);
+    falls back to `NOMINAL_GRID_VOLTAGE_V` only for firmwares that don't
+    emit it. The Ajax mobile app renders the Power line on the device
+    card the same way — `current × voltage` — so the HA value matches
+    what the user sees in the official app.
     """
 
     _attr_translation_key = "power_derived"
@@ -578,4 +607,9 @@ class AjaxDeviceDerivedPowerSensor(_AjaxDeviceReadingsBase):
         readings = self.coordinator.device_readings.get(self._device_id)
         if readings is None or readings.current_ma is None:
             return None
-        return (readings.current_ma / 1000.0) * NOMINAL_GRID_VOLTAGE_V
+        voltage = (
+            float(readings.voltage_v)
+            if readings.voltage_v is not None and readings.voltage_v > 0
+            else NOMINAL_GRID_VOLTAGE_V
+        )
+        return (readings.current_ma / 1000.0) * voltage

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Corrent"
             },
+            "voltage": {
+                "name": "Tensió"
+            },
             "energy_consumed": {
                 "name": "Energia elèctrica consumida"
             },

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Proud"
             },
+            "voltage": {
+                "name": "Napětí"
+            },
             "energy_consumed": {
                 "name": "Spotřebovaná elektrická energie"
             },

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Strom"
             },
+            "voltage": {
+                "name": "Spannung"
+            },
             "energy_consumed": {
                 "name": "Verbrauchte elektrische Energie"
             },

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -347,6 +347,9 @@
             "current": {
                 "name": "Current"
             },
+            "voltage": {
+                "name": "Voltage"
+            },
             "energy_consumed": {
                 "name": "Electric energy consumed"
             },

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -347,6 +347,9 @@
             "current": {
                 "name": "Corriente"
             },
+            "voltage": {
+                "name": "Voltaje"
+            },
             "energy_consumed": {
                 "name": "Energía eléctrica consumida"
             },

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Courant"
             },
+            "voltage": {
+                "name": "Tension"
+            },
             "energy_consumed": {
                 "name": "Énergie électrique consommée"
             },

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Corrente"
             },
+            "voltage": {
+                "name": "Tensione"
+            },
             "energy_consumed": {
                 "name": "Energia elettrica consumata"
             },

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Stroom"
             },
+            "voltage": {
+                "name": "Spanning"
+            },
             "energy_consumed": {
                 "name": "Verbruikte elektrische energie"
             },

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Prąd"
             },
+            "voltage": {
+                "name": "Napięcie"
+            },
             "energy_consumed": {
                 "name": "Zużyta energia elektryczna"
             },

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Corrente"
             },
+            "voltage": {
+                "name": "Tensão"
+            },
             "energy_consumed": {
                 "name": "Energia elétrica consumida"
             },

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Corrente"
             },
+            "voltage": {
+                "name": "Tensão"
+            },
             "energy_consumed": {
                 "name": "Energia elétrica consumida"
             },

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Curent"
             },
+            "voltage": {
+                "name": "Tensiune"
+            },
             "energy_consumed": {
                 "name": "Energie electrică consumată"
             },

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Akım"
             },
+            "voltage": {
+                "name": "Voltaj"
+            },
             "energy_consumed": {
                 "name": "Tüketilen elektrik enerjisi"
             },

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -331,6 +331,9 @@
             "current": {
                 "name": "Струм"
             },
+            "voltage": {
+                "name": "Напруга"
+            },
             "energy_consumed": {
                 "name": "Спожита електроенергія"
             },

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -395,6 +395,41 @@ class TestParseDeviceReadings:
         r = parse_device_readings("relay_fibra_base", {})
         assert r == DeviceReadings(current_ma=None, power_consumed_wh=None)
 
+    def test_partial_update_without_keys_preserves_existing(self) -> None:
+        """STATUS_UPDATE deltas often omit 0x42/0x43; cached readings must survive (#123)."""
+        prior = DeviceReadings(current_ma=40, power_consumed_wh=2409)
+        # kv carries an unrelated sub-key (the relay state byte) — neither
+        # electrical sub-key is present.
+        r = parse_device_readings("wall_switch", {0x05: b"\x01"}, existing=prior)
+        assert r == prior
+
+    def test_partial_update_with_only_current_keeps_energy(self) -> None:
+        prior = DeviceReadings(current_ma=10, power_consumed_wh=2409)
+        r = parse_device_readings(
+            "wall_switch",
+            {DEVICE_KEY_CURRENT_MA: b"\x00\x00\x00\x28"},
+            existing=prior,
+        )
+        assert r == DeviceReadings(current_ma=40, power_consumed_wh=2409)
+
+    def test_partial_update_with_only_energy_keeps_current(self) -> None:
+        prior = DeviceReadings(current_ma=40, power_consumed_wh=1000)
+        r = parse_device_readings(
+            "socket",
+            {DEVICE_KEY_POWER_CONSUMED_WH: b"\x00\x00\x09\x69"},
+            existing=prior,
+        )
+        assert r == DeviceReadings(current_ma=40, power_consumed_wh=2409)
+
+    def test_no_existing_passed_falls_back_to_overwrite(self) -> None:
+        # Boot-time snapshot path: no prior cache, fresh DeviceReadings built
+        # straight from the kv block.
+        r = parse_device_readings(
+            "wall_switch",
+            {DEVICE_KEY_CURRENT_MA: b"\x28"},
+        )
+        assert r == DeviceReadings(current_ma=40, power_consumed_wh=None)
+
     def test_known_electrical_types(self) -> None:
         # Sanity-check: every type the switch platform treats as a
         # power-controllable relay that *should* emit readings is in

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -326,6 +326,7 @@ class TestHelpers:
 from custom_components.aegis_ajax.api.hts.hub_state import (  # noqa: E402
     DEVICE_KEY_CURRENT_MA,
     DEVICE_KEY_POWER_CONSUMED_WH,
+    DEVICE_KEY_VOLTAGE_V,
     ELECTRICAL_DEVICE_TYPES,
     DeviceReadings,
     _int_be_val,
@@ -377,9 +378,28 @@ class TestParseDeviceReadings:
             {
                 DEVICE_KEY_CURRENT_MA: b"\x00\x00\x00\x28",  # 40 mA
                 DEVICE_KEY_POWER_CONSUMED_WH: b"\x00\x00\x09\x69",  # 2409 Wh
+                DEVICE_KEY_VOLTAGE_V: b"\x00\xe6",  # 230 V
             },
         )
-        assert r == DeviceReadings(current_ma=40, power_consumed_wh=2409)
+        assert r == DeviceReadings(current_ma=40, power_consumed_wh=2409, voltage_v=230)
+
+    def test_voltage_parsed_when_other_keys_absent(self) -> None:
+        # Voltage updates can land on their own — current and energy
+        # must stay absent rather than zeroed.
+        r = parse_device_readings(
+            "wall_switch",
+            {DEVICE_KEY_VOLTAGE_V: b"\x00\xe7"},  # 231 V
+        )
+        assert r == DeviceReadings(current_ma=None, power_consumed_wh=None, voltage_v=231)
+
+    def test_partial_update_with_only_voltage_keeps_current_and_energy(self) -> None:
+        prior = DeviceReadings(current_ma=40, power_consumed_wh=2409, voltage_v=228)
+        r = parse_device_readings(
+            "wall_switch",
+            {DEVICE_KEY_VOLTAGE_V: b"\x00\xe7"},  # 231 V
+            existing=prior,
+        )
+        assert r == DeviceReadings(current_ma=40, power_consumed_wh=2409, voltage_v=231)
 
     def test_socket_partial_only_current(self) -> None:
         # Power-consumed sub-key may be absent on a freshly-installed device.

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1380,6 +1380,43 @@ class TestOnHtsDeviceKv:
         # Same values — no entity refresh needed.
         coordinator.async_set_updated_data.assert_not_called()
 
+    def test_partial_update_does_not_clear_cached_readings(self) -> None:
+        """Relay-state push without electrical keys must NOT blank out the readings (#123)."""
+        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+
+        coordinator = _make_coordinator()
+        coordinator.devices["311B058D"] = self._make_electrical_device()
+        coordinator.device_readings["311B058D"] = DeviceReadings(
+            current_ma=40, power_consumed_wh=2409
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        # Push containing only the on/off state byte — no 0x42 / 0x43.
+        coordinator._on_hts_device_kv("002B1A51", "311B058D", {0x05: b"\x01"})
+
+        assert coordinator.device_readings["311B058D"] == DeviceReadings(
+            current_ma=40, power_consumed_wh=2409
+        )
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_partial_update_with_only_current_keeps_cached_energy(self) -> None:
+        """Energy-consumed updates arrive on a different cadence than current (#123)."""
+        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+
+        coordinator = _make_coordinator()
+        coordinator.devices["311B058D"] = self._make_electrical_device()
+        coordinator.device_readings["311B058D"] = DeviceReadings(
+            current_ma=10, power_consumed_wh=2409
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("002B1A51", "311B058D", {0x42: b"\x00\x00\x00\x28"})
+
+        assert coordinator.device_readings["311B058D"] == DeviceReadings(
+            current_ma=40, power_consumed_wh=2409
+        )
+        coordinator.async_set_updated_data.assert_called_once()
+
     def test_hts_disconnect_clears_device_readings(self) -> None:
         from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
 

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -548,6 +548,7 @@ class TestAjaxDeviceElectricalSensors:
         online: bool = True,
         current_ma: int | None = 40,
         power_consumed_wh: int | None = 2409,
+        voltage_v: int | None = None,
     ) -> MagicMock:
         from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
         from custom_components.aegis_ajax.api.models import Device
@@ -568,11 +569,12 @@ class TestAjaxDeviceElectricalSensors:
             battery=None,
         )
         coordinator.devices = {"311B058D": device}
-        if current_ma is not None or power_consumed_wh is not None:
+        if current_ma is not None or power_consumed_wh is not None or voltage_v is not None:
             coordinator.device_readings = {
                 "311B058D": DeviceReadings(
                     current_ma=current_ma,
                     power_consumed_wh=power_consumed_wh,
+                    voltage_v=voltage_v,
                 )
             }
         else:
@@ -626,12 +628,53 @@ class TestAjaxDeviceElectricalSensors:
         assert sensor.state_class is SensorStateClass.TOTAL_INCREASING
 
     def test_derived_power_uses_nominal_voltage(self) -> None:
-        # PRO renders 9W from 0.04A × 230V; we mirror that exactly.
+        # No voltage reported by the device (older firmware) → falls back to
+        # the labelled 230 V baseline, same as the Ajax app does.
         from custom_components.aegis_ajax.sensor import AjaxDeviceDerivedPowerSensor
 
-        coordinator = self._make_coordinator(current_ma=40)
+        coordinator = self._make_coordinator(current_ma=40, voltage_v=None)
         sensor = AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")
         assert sensor.native_value == pytest.approx(9.2)
+
+    def test_derived_power_uses_real_voltage_when_present(self) -> None:
+        # 0.04 A × 231 V = 9.24 W; PRO renders the line the same way.
+        from custom_components.aegis_ajax.sensor import AjaxDeviceDerivedPowerSensor
+
+        coordinator = self._make_coordinator(current_ma=40, voltage_v=231)
+        sensor = AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")
+        assert sensor.native_value == pytest.approx(9.24)
+
+    def test_derived_power_falls_back_when_voltage_is_zero(self) -> None:
+        # Sentinel-zero is the firmware's "unset" marker, not a real
+        # 0 V reading. Treat it as missing and use the nominal baseline.
+        from custom_components.aegis_ajax.sensor import AjaxDeviceDerivedPowerSensor
+
+        coordinator = self._make_coordinator(current_ma=40, voltage_v=0)
+        sensor = AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")
+        assert sensor.native_value == pytest.approx(9.2)
+
+    def test_voltage_sensor_returns_value(self) -> None:
+        from custom_components.aegis_ajax.sensor import AjaxDeviceVoltageSensor
+
+        coordinator = self._make_coordinator(voltage_v=230)
+        sensor = AjaxDeviceVoltageSensor(coordinator, "311B058D")
+        assert sensor.native_value == 230.0
+
+    def test_voltage_sensor_none_when_not_reported(self) -> None:
+        from custom_components.aegis_ajax.sensor import AjaxDeviceVoltageSensor
+
+        coordinator = self._make_coordinator(current_ma=40, voltage_v=None)
+        sensor = AjaxDeviceVoltageSensor(coordinator, "311B058D")
+        assert sensor.native_value is None
+
+    def test_voltage_sensor_device_class_voltage(self) -> None:
+        from homeassistant.components.sensor import SensorDeviceClass
+
+        from custom_components.aegis_ajax.sensor import AjaxDeviceVoltageSensor
+
+        coordinator = self._make_coordinator(voltage_v=230)
+        sensor = AjaxDeviceVoltageSensor(coordinator, "311B058D")
+        assert sensor.device_class is SensorDeviceClass.VOLTAGE
 
     def test_derived_power_disabled_by_default(self) -> None:
         # The current+energy pair are the load-bearing entities; the
@@ -643,17 +686,19 @@ class TestAjaxDeviceElectricalSensors:
         sensor = AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")
         assert sensor.entity_registry_enabled_default is False
 
-    def test_unique_ids_distinct_across_three_entities(self) -> None:
+    def test_unique_ids_distinct_across_four_entities(self) -> None:
         from custom_components.aegis_ajax.sensor import (
             AjaxDeviceCurrentSensor,
             AjaxDeviceDerivedPowerSensor,
             AjaxDeviceEnergyConsumedSensor,
+            AjaxDeviceVoltageSensor,
         )
 
-        coordinator = self._make_coordinator()
+        coordinator = self._make_coordinator(voltage_v=230)
         uids = {
             AjaxDeviceCurrentSensor(coordinator, "311B058D")._attr_unique_id,
+            AjaxDeviceVoltageSensor(coordinator, "311B058D")._attr_unique_id,
             AjaxDeviceEnergyConsumedSensor(coordinator, "311B058D")._attr_unique_id,
             AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")._attr_unique_id,
         }
-        assert len(uids) == 3
+        assert len(uids) == 4


### PR DESCRIPTION
Two changes against #123, both shipped together for the next beta:

## 1. Partial-update regression (fix)

WallSwitch / Socket electrical sensors went `unknown` after every relay toggle and only reappeared on the next periodic full snapshot (~60 s). The parser rebuilt the readings snapshot from scratch on every per-device delta push, so a push that didn't carry the current / energy fields produced an all-empty snapshot and overwrote the cached values.

Fix: add an `existing` parameter (symmetric with `parse_hub_params`); when provided, only fields actually present in the new message get updated — the rest survive from the prior snapshot. The coordinator now passes the cached snapshot, so deltas merge instead of replace.

## 2. Real WallSwitch voltage + corrected derived power (feature)

The previous beta hardcoded 230 V for `power_derived` based on the (wrong) assumption that the WallSwitch firmware doesn't report voltage. It does — newer firmwares emit a measured line-voltage reading, and the official Ajax app shows it on the device card. The 228-231 V values @brunovdw68 sees in the app come from this reading directly.

- The parser learns the voltage field, with the same per-key merge semantics as current / energy.
- `DeviceReadings` gains `voltage_v: int | None`.
- New `AjaxDeviceVoltageSensor` (V, `device_class=voltage`, `state_class=measurement`) — enabled by default; renders `unknown` on firmwares that don't report it.
- `AjaxDeviceDerivedPowerSensor` now multiplies by the device-reported voltage when present; falls back to `NOMINAL_GRID_VOLTAGE_V` only when the field is missing or zero. Matches the Power line the official app renders on the same card.
- Translations in all 14 locales for the new `voltage` sensor name.

## Test plan

- [x] `make check` green inside Docker (rebuilt image without volume mount): 1215 tests pass, 85.46% coverage.
- [x] Parser tests: voltage parsed when other fields absent; partial update with only voltage keeps cached current / energy; partial update without any electrical fields preserves the full prior snapshot.
- [x] Sensor tests: voltage entity reads / renders; `power_derived` uses real voltage when reported, falls back to nominal when missing or zero; four entities per WallSwitch (current / voltage / energy / power-derived) have distinct unique_ids.
- [ ] CI matrix (Python 3.12 + 3.13, hassfest, HACS validate, CodeQL) on the pushed branch.
- [ ] Real-HA confirmation in the next beta against @brunovdw68's install: toggle the WallSwitch a few times → three load-bearing sensors keep their last value through the toggle; voltage sensor shows the same 228-231 V the official app shows.

Refs #123.