### PR TITLE
fix(config_flow): unambiguous FCM credential deletion via explicit toggle

### DIFF
--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -437,22 +437,34 @@ class AjaxCobrandedOptionsFlow(OptionsFlow):
                 ).hexdigest()
             else:
                 user_input.pop("pin_code", None)
-            # Move FCM credentials into config_entry.data (encrypted storage).
-            # Empty strings mean "clear this credential", so drop those keys
-            # from entry.data instead of persisting "" (issue #138).
+            # FCM credentials live in `entry.data` (encrypted storage).
+            # Two routes can update them:
+            #   1. The dedicated "Delete FCM credentials" toggle wipes all
+            #      four keys unconditionally — the unambiguous deletion
+            #      path, immune to selector-default round-trips.
+            #   2. Otherwise, any non-empty value in a FCM field updates
+            #      that key. An empty string also clears the key, but
+            #      only if the field was actually submitted as empty —
+            #      the password selector tends to round-trip its prior
+            #      value, so the toggle above is the recommended way to
+            #      clear credentials (issue #138).
+            clear_fcm = user_input.pop("clear_fcm_credentials", False)
             fcm_input = {k: user_input.pop(k) for k in _FCM_KEYS if k in user_input}
-            if fcm_input:
-                new_data = {**self._entry.data}
+            new_data = {**self._entry.data}
+            if clear_fcm:
+                for k in _FCM_KEYS:
+                    new_data.pop(k, None)
+            else:
                 for k, v in fcm_input.items():
                     if v:
                         new_data[k] = v
                     else:
                         new_data.pop(k, None)
-                if new_data != self._entry.data:
-                    self.hass.config_entries.async_update_entry(
-                        self._entry,
-                        data=new_data,
-                    )
+            if new_data != self._entry.data:
+                self.hass.config_entries.async_update_entry(
+                    self._entry,
+                    data=new_data,
+                )
             return self.async_create_entry(title="", data=user_input)
         return self.async_show_form(
             step_id="init",
@@ -475,20 +487,21 @@ class AjaxCobrandedOptionsFlow(OptionsFlow):
                     ),
                     vol.Optional(
                         "fcm_project_id",
-                        default=self._get_fcm("fcm_project_id"),
+                        description={"suggested_value": self._get_fcm("fcm_project_id")},
                     ): str,
                     vol.Optional(
                         "fcm_app_id",
-                        default=self._get_fcm("fcm_app_id"),
+                        description={"suggested_value": self._get_fcm("fcm_app_id")},
                     ): str,
                     vol.Optional(
                         "fcm_api_key",
-                        default=self._get_fcm("fcm_api_key"),
+                        description={"suggested_value": self._get_fcm("fcm_api_key")},
                     ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
                     vol.Optional(
                         "fcm_sender_id",
-                        default=self._get_fcm("fcm_sender_id"),
+                        description={"suggested_value": self._get_fcm("fcm_sender_id")},
                     ): str,
+                    vol.Optional("clear_fcm_credentials", default=False): bool,
                     vol.Optional(
                         CONF_PHOTO_RETENTION_DAYS,
                         default=self._entry.options.get(

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID d'app FCM",
                     "fcm_api_key": "Clau d'API FCM",
                     "fcm_sender_id": "ID de remitent FCM",
+                    "clear_fcm_credentials": "Eliminar credencials FCM (esborra els quatre camps)",
                     "photo_retention_days": "Retenció de fotos (dies)",
                     "photo_max_per_device": "Màxim de fotos per dispositiu (0 = il·limitat)",
                     "auto_create_labels": "Crear i assignar automàticament etiquetes Aegis a les entitats"

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID aplikace FCM",
                     "fcm_api_key": "API klíč FCM",
                     "fcm_sender_id": "ID odesílatele FCM",
+                    "clear_fcm_credentials": "Smazat FCM přihlašovací údaje (vymaže všechna čtyři pole)",
                     "photo_retention_days": "Uchovávání fotografií (dny)",
                     "photo_max_per_device": "Max fotografií na zařízení (0 = neomezeno)",
                     "auto_create_labels": "Automaticky vytvářet a přiřazovat štítky Aegis entitám"

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "FCM-App-ID",
                     "fcm_api_key": "FCM-API-Schlüssel",
                     "fcm_sender_id": "FCM-Absender-ID",
+                    "clear_fcm_credentials": "FCM-Anmeldedaten löschen (alle vier Felder leeren)",
                     "photo_retention_days": "Foto-Aufbewahrung (Tage)",
                     "photo_max_per_device": "Max. Fotos pro Gerät (0 = unbegrenzt)",
                     "auto_create_labels": "Aegis-Labels automatisch erstellen und Entitäten zuweisen"

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "FCM App ID",
                     "fcm_api_key": "FCM API Key",
                     "fcm_sender_id": "FCM Sender ID",
+                    "clear_fcm_credentials": "Delete FCM credentials (clears all four fields)",
                     "photo_retention_days": "Photo retention (days)",
                     "photo_max_per_device": "Max photos per device (0 = unlimited)",
                     "auto_create_labels": "Auto-create and assign Aegis labels to entities"

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID de app FCM",
                     "fcm_api_key": "Clave de API FCM",
                     "fcm_sender_id": "ID de remitente FCM",
+                    "clear_fcm_credentials": "Eliminar credenciales FCM (borra los cuatro campos)",
                     "photo_retention_days": "Retención de fotos (días)",
                     "photo_max_per_device": "Máximo de fotos por dispositivo (0 = ilimitado)",
                     "auto_create_labels": "Crear y asignar automáticamente etiquetas Aegis a las entidades"

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID d'application FCM",
                     "fcm_api_key": "Clé API FCM",
                     "fcm_sender_id": "ID d'expéditeur FCM",
+                    "clear_fcm_credentials": "Supprimer les identifiants FCM (efface les quatre champs)",
                     "photo_retention_days": "Rétention des photos (jours)",
                     "photo_max_per_device": "Max photos par appareil (0 = illimité)",
                     "auto_create_labels": "Créer et attribuer automatiquement des étiquettes Aegis aux entités"

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID app FCM",
                     "fcm_api_key": "Chiave API FCM",
                     "fcm_sender_id": "ID mittente FCM",
+                    "clear_fcm_credentials": "Elimina credenziali FCM (cancella tutti e quattro i campi)",
                     "photo_retention_days": "Conservazione foto (giorni)",
                     "photo_max_per_device": "Max foto per dispositivo (0 = illimitato)",
                     "auto_create_labels": "Crea e assegna automaticamente etichette Aegis alle entità"

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "FCM-app-ID",
                     "fcm_api_key": "FCM-API-sleutel",
                     "fcm_sender_id": "FCM-afzender-ID",
+                    "clear_fcm_credentials": "FCM-inloggegevens verwijderen (wist alle vier velden)",
                     "photo_retention_days": "Foto bewaarperiode (dagen)",
                     "photo_max_per_device": "Max foto's per apparaat (0 = onbeperkt)",
                     "auto_create_labels": "Aegis-labels automatisch aanmaken en aan entiteiten toewijzen"

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID aplikacji FCM",
                     "fcm_api_key": "Klucz API FCM",
                     "fcm_sender_id": "ID nadawcy FCM",
+                    "clear_fcm_credentials": "Usuń poświadczenia FCM (czyści wszystkie cztery pola)",
                     "photo_retention_days": "Przechowywanie zdjęć (dni)",
                     "photo_max_per_device": "Maks. zdjęć na urządzenie (0 = bez limitu)",
                     "auto_create_labels": "Automatycznie twórz i przypisuj etykiety Aegis do encji"

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID do aplicativo FCM",
                     "fcm_api_key": "Chave de API FCM",
                     "fcm_sender_id": "ID do remetente FCM",
+                    "clear_fcm_credentials": "Excluir credenciais FCM (limpa todos os quatro campos)",
                     "photo_retention_days": "Retenção de fotos (dias)",
                     "photo_max_per_device": "Máx. fotos por dispositivo (0 = ilimitado)",
                     "auto_create_labels": "Criar e atribuir automaticamente etiquetas Aegis às entidades"

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID da aplicação FCM",
                     "fcm_api_key": "Chave de API FCM",
                     "fcm_sender_id": "ID do remetente FCM",
+                    "clear_fcm_credentials": "Eliminar credenciais FCM (limpa todos os quatro campos)",
                     "photo_retention_days": "Retenção de fotos (dias)",
                     "photo_max_per_device": "Máx. fotos por dispositivo (0 = ilimitado)",
                     "auto_create_labels": "Criar e atribuir automaticamente etiquetas Aegis às entidades"

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID aplicație FCM",
                     "fcm_api_key": "Cheie API FCM",
                     "fcm_sender_id": "ID expeditor FCM",
+                    "clear_fcm_credentials": "Șterge acreditările FCM (golește toate cele patru câmpuri)",
                     "photo_retention_days": "Reținere fotografii (zile)",
                     "photo_max_per_device": "Max fotografii per dispozitiv (0 = nelimitat)",
                     "auto_create_labels": "Creează și atribuie automat etichete Aegis entităților"

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "FCM Uygulama Kimliği",
                     "fcm_api_key": "FCM API Anahtarı",
                     "fcm_sender_id": "FCM Gönderici Kimliği",
+                    "clear_fcm_credentials": "FCM kimlik bilgilerini sil (dört alanı da temizler)",
                     "photo_retention_days": "Fotoğraf saklama süresi (gün)",
                     "photo_max_per_device": "Cihaz başına maks. fotoğraf (0 = sınırsız)",
                     "auto_create_labels": "Aegis etiketlerini otomatik olarak oluştur ve varlıklara ata"

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -82,6 +82,7 @@
                     "fcm_app_id": "ID додатку FCM",
                     "fcm_api_key": "Ключ API FCM",
                     "fcm_sender_id": "ID відправника FCM",
+                    "clear_fcm_credentials": "Видалити облікові дані FCM (очищає всі чотири поля)",
                     "photo_retention_days": "Зберігання фото (днів)",
                     "photo_max_per_device": "Макс. фото на пристрій (0 = необмежено)",
                     "auto_create_labels": "Автоматично створювати та призначати мітки Aegis сутностям"

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -642,6 +642,62 @@ class TestOptionsFlow:
         assert new_data["fcm_sender_id"] == "new_sender"
 
     @pytest.mark.asyncio
+    async def test_options_flow_clear_fcm_toggle_removes_all_keys(self) -> None:
+        """'Delete FCM credentials' toggle wipes all four keys regardless of field values (#138)."""
+        flow, entry = self._make_flow(
+            data={
+                "email": "x@y",
+                "fcm_project_id": "old_proj",
+                "fcm_app_id": "old_app",
+                "fcm_api_key": "old_key",
+                "fcm_sender_id": "old_sender",
+            }
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        # The toggle wins even when the form re-submits the prior FCM values
+        # (selector-default round-trip case — what HA's password field does).
+        await flow.async_step_init(
+            {
+                "poll_interval": 60,
+                "use_pin_code": False,
+                "fcm_project_id": "old_proj",
+                "fcm_app_id": "old_app",
+                "fcm_api_key": "old_key",
+                "fcm_sender_id": "old_sender",
+                "clear_fcm_credentials": True,
+            }
+        )
+
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+        for k in ("fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id"):
+            assert k not in new_data
+        assert new_data["email"] == "x@y"
+        # The toggle itself must not leak into entry.options
+        stored_options = flow.async_create_entry.call_args[1]["data"]
+        assert "clear_fcm_credentials" not in stored_options
+
+    @pytest.mark.asyncio
+    async def test_options_flow_clear_fcm_toggle_off_keeps_normal_update_path(self) -> None:
+        flow, entry = self._make_flow(data={"fcm_project_id": "old"})
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init(
+            {
+                "poll_interval": 60,
+                "use_pin_code": False,
+                "fcm_project_id": "new_proj",
+                "clear_fcm_credentials": False,
+            }
+        )
+
+        new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+        assert new_data["fcm_project_id"] == "new_proj"
+
+    @pytest.mark.asyncio
     async def test_options_flow_clearing_fcm_also_strips_legacy_options(self) -> None:
         """Legacy installs kept FCM in entry.options; clearing must also drop them there."""
         flow, entry = self._make_flow(


### PR DESCRIPTION
## Summary

The beta.2 fix (#139) was incomplete: @Hansontech190 reports on #138 that on `1.4.0-beta.3` the credentials still re-appear, with the extra clue that the API Key field "shows the original key in grey" when cleared — i.e. the password selector won't let the user clear it by typing.

Two HA frontend behaviours conspired to bring the bug back:

1. `vol.Optional(key, default=val)` re-fills the key with the default when the frontend doesn't submit it. The password selector with a pre-filled default sometimes omits the key on submit, so voluptuous restored the prior value on the way in.
2. The password selector with `default=` can't be reliably cleared via backspace in the HA frontend — the placeholder rendering keeps the prior value visible and round-trips it back.

## Changes

- Switch the four FCM fields from `default=` to `description={"suggested_value": ...}`. The frontend still pre-fills the prior value as a suggestion, but voluptuous no longer re-fills missing keys, so an empty submission stays empty end-to-end.
- Add a dedicated `clear_fcm_credentials` boolean below the FCM fields. When toggled, all four FCM keys are dropped from `entry.data` unconditionally, regardless of what the form submits — the unambiguous deletion path that works even when the password selector won't accept an empty value. Translations in all 14 locales.

Refs #138.

## Test plan

- [x] `make check` green inside Docker (rebuilt image without volume mount): 1217 tests pass, 85.47% coverage.
- [x] New `TestOptionsFlow` cases: the toggle wipes all four keys even when the form re-submits the prior FCM values (selector-default round-trip case); with the toggle off, the existing per-field update / delete logic is preserved.
- [ ] CI matrix (Python 3.12 + 3.13, hassfest, HACS validate, CodeQL) on the pushed branch.
- [ ] Real-HA confirmation in the next beta against Hansontech190's install: enable the toggle, save → fields render empty on reopen and the `fcm_not_configured` Repair card is raised again on next start.