### PR TITLE
feat(update): read-only hub firmware update entity

### DIFF
--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -36,6 +36,7 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.LIGHT,
     Platform.LOCK,
+    Platform.UPDATE,
     Platform.VALVE,
 ]
 

--- a/custom_components/aegis_ajax/api/hub_object.py
+++ b/custom_components/aegis_ajax/api/hub_object.py
@@ -29,6 +29,32 @@ class SimCardInfo:
         return self.status == 2
 
 
+# Phase of an Ajax-side firmware update. `system_firmware_update` only
+# appears in `streamHubObject` when an update is queued or already in
+# flight, so absence of the field means "hub is up to date".
+HUB_FW_STATE_NONE = "none"  # no pending update
+HUB_FW_STATE_NOT_STARTED = "not_started"  # queued, hub hasn't begun
+HUB_FW_STATE_DOWNLOADING = "downloading"  # server pushing bytes to hub
+
+
+@dataclass(frozen=True)
+class HubFirmwareUpdateInfo:
+    """Pending hub firmware update, as reported by `streamHubObject`.
+
+    `target_version` is the version string the hub will move to once
+    the update completes; `state` is one of the `HUB_FW_STATE_*`
+    constants. Currently-installed version is not exposed by Ajax in
+    this stream, so the HA Update entity surfaces only `latest_version`.
+
+    The Ajax cloud schedules and triggers firmware updates on its own —
+    this integration never calls the install RPC, so the entity is
+    informational only.
+    """
+
+    target_version: str
+    state: str
+
+
 class HubObjectApi:
     """API for hub-level data via streamHubObject."""
 
@@ -63,6 +89,84 @@ class HubObjectApi:
             _LOGGER.debug("Failed to get hub object data for %s", hub_id)
 
         return None
+
+    async def get_firmware_info(self, hub_id: str) -> HubFirmwareUpdateInfo | None:
+        """Get pending hub firmware update from streamHubObject (field 201).
+
+        Returns `None` when the hub reports no pending update, when the
+        stream errors, or when the payload doesn't include the field.
+        The Ajax cloud only populates `system_firmware_update` when an
+        update is queued or in flight, so a `None` return means "hub
+        is up to date" from the cloud's perspective.
+        """
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+
+        tag = (1 << 3) | 2
+        encoded = hub_id.encode("utf-8")
+        request_bytes = bytes([tag, len(encoded)]) + encoded
+
+        method = channel.unary_stream(
+            "/systems.ajax.api.mobile.v2.hubobject.HubObjectService/streamHubObject",
+            request_serializer=lambda x: x,
+            response_deserializer=lambda x: x,
+        )
+
+        try:
+            stream = method(request_bytes, metadata=metadata, timeout=15)
+            async for raw_msg in stream:
+                return self._parse_firmware_from_hub_object(raw_msg)
+        except Exception:
+            _LOGGER.debug("Failed to get hub firmware info for %s", hub_id)
+
+        return None
+
+    @staticmethod
+    def _parse_firmware_from_hub_object(
+        raw_msg: bytes,
+    ) -> HubFirmwareUpdateInfo | None:
+        """Parse the system firmware update sub-message from a StreamHubObject frame.
+
+        Uses the generated proto class — cleaner than the manual byte
+        walking the SIM path does, since this message hangs off field
+        201 which is a multi-byte tag and `FromString` handles it
+        without us re-implementing varint parsing.
+        """
+        from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+            StreamHubObject,
+        )
+
+        try:
+            response = StreamHubObject.FromString(raw_msg)
+        except Exception:
+            return None
+
+        # `StreamHubObject` is a oneof — snapshot, create, update,
+        # delete. Firmware metadata only ships in the snapshot
+        # (first message of the stream); deltas carry just changed
+        # fields and won't include a fresh firmware_version.
+        if response.WhichOneof("item") != "snapshot":
+            return None
+        hub_object = response.snapshot
+
+        if not hub_object.HasField("system_firmware_update"):
+            return None
+
+        sfu = hub_object.system_firmware_update
+        status_name = sfu.status.WhichOneof("status")
+        if status_name == "downloading":
+            state = HUB_FW_STATE_DOWNLOADING
+        elif status_name == "not_started":
+            state = HUB_FW_STATE_NOT_STARTED
+        else:
+            # Future status values fall back to a known label rather than
+            # raising — the entity stays informational either way.
+            state = status_name or HUB_FW_STATE_NONE
+
+        return HubFirmwareUpdateInfo(
+            target_version=sfu.firmware_version or "",
+            state=state,
+        )
 
     @staticmethod
     def _parse_sim_from_hub_object(raw_msg: bytes) -> SimCardInfo | None:

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -15,7 +15,11 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.aegis_ajax.api.devices import DevicesApi
 from custom_components.aegis_ajax.api.hts.client import HtsClient
-from custom_components.aegis_ajax.api.hub_object import HubObjectApi, SimCardInfo
+from custom_components.aegis_ajax.api.hub_object import (
+    HubFirmwareUpdateInfo,
+    HubObjectApi,
+    SimCardInfo,
+)
 from custom_components.aegis_ajax.api.media import MediaApi
 from custom_components.aegis_ajax.api.models import Device as DeviceModel
 from custom_components.aegis_ajax.api.security import SecurityApi
@@ -111,6 +115,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.devices: dict[str, Device] = {}
         self.rooms: dict[str, Room] = {}
         self.sim_info: dict[str, SimCardInfo] = {}
+        # Pending hub firmware update keyed by hub_id (#updates). Absent
+        # entry = the hub reports no pending update OR the streamHubObject
+        # call hasn't completed yet. Refreshed on the same hourly cycle
+        # as `sim_info`. Read-only; the integration never calls the
+        # install RPC even though the proto exposes one.
+        self.hub_firmware_updates: dict[str, HubFirmwareUpdateInfo] = {}
         self._notification_listener: AjaxNotificationListener | None = None
         self._stream_tasks: list[asyncio.Task[None]] = []
         self._streams_started: bool = False
@@ -301,14 +311,26 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.spaces = new_spaces
             self._update_hub_offline_repairs(now)
 
-            # Fetch SIM info for each hub (cached, refresh once per hour)
+            # Fetch SIM info and pending firmware update for each hub.
+            # Both come from the same `streamHubObject` snapshot, so we
+            # piggyback firmware on the SIM refresh cadence (once per
+            # hour). The firmware fetch always re-runs because a pending
+            # update can be cleared between cycles, unlike SIM info
+            # which we cache once.
             sim_refresh_interval = 3600.0
             if now - self._sim_info_last_fetch > sim_refresh_interval:
                 for space in self.spaces.values():
-                    if space.hub_id and space.hub_id not in self.sim_info:
+                    if not space.hub_id:
+                        continue
+                    if space.hub_id not in self.sim_info:
                         sim = await self._hub_object_api.get_sim_info(space.hub_id)
                         if sim:
                             self.sim_info[space.hub_id] = sim
+                    fw = await self._hub_object_api.get_firmware_info(space.hub_id)
+                    if fw is None:
+                        self.hub_firmware_updates.pop(space.hub_id, None)
+                    else:
+                        self.hub_firmware_updates[space.hub_id] = fw
                 self._sim_info_last_fetch = now
 
             # Fetch rooms for each space (cached, refresh once per hour). Used

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Canal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Microprogramari"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Kanál 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Kanal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -365,6 +365,11 @@
             "channel_2": {
                 "name": "Channel 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -365,6 +365,11 @@
             "channel_2": {
                 "name": "Canal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Canal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Micrologiciel"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Canale 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Kanaal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Kanał 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Oprogramowanie"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Canal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Canal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Canal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Firmware"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Kanal 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Donanım yazılımı"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -349,6 +349,11 @@
             "channel_2": {
                 "name": "Канал 2"
             }
+        },
+        "update": {
+            "hub_firmware": {
+                "name": "Прошивка"
+            }
         }
     }
 }

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -1,0 +1,102 @@
+"""Update entities for Ajax hubs (read-only — #123 follow-up).
+
+Surfaces the pending firmware update the Ajax cloud has queued for the
+hub. The entity is informational only:
+
+- No `install` feature is declared, so HA renders no install button.
+- `async_install` is not implemented.
+- Ajax controls update scheduling server-side; the cloud pushes updates
+  to the hub on its own cadence. This integration deliberately never
+  calls the install RPC even though the proto exposes one — firmware
+  updates are higher-stakes than the rest of the surface and the user
+  should manage them via the official app if they want to force one.
+
+The Ajax stream doesn't carry the currently-installed firmware version,
+so `installed_version` stays `None`; HA still renders the entity as
+"<latest> available" with a progress bar when downloading.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.aegis_ajax.api.hub_object import (
+    HUB_FW_STATE_DOWNLOADING,
+    HubFirmwareUpdateInfo,
+)
+from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.entity import build_device_info
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: AjaxCobrandedCoordinator = entry.runtime_data
+    entities: list[AjaxHubFirmwareUpdate] = []
+    seen: set[str] = set()
+    for space in coordinator.spaces.values():
+        hub_id = space.hub_id
+        if not hub_id or hub_id in seen:
+            continue
+        # Only attach when a hub device exists in the snapshot — otherwise
+        # there's nothing to bind `device_info` to.
+        if coordinator.devices.get(hub_id):
+            entities.append(AjaxHubFirmwareUpdate(coordinator, hub_id))
+            seen.add(hub_id)
+    async_add_entities(entities)
+
+
+class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateEntity):
+    """Read-only firmware update entity for an Ajax hub."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "hub_firmware"
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    # No `INSTALL` feature — the entity is informational only.
+    _attr_supported_features = UpdateEntityFeature(0)
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
+        super().__init__(coordinator)
+        self._hub_id = hub_id
+        self._attr_unique_id = f"aegis_ajax_{hub_id}_firmware"
+        hub_device = coordinator.devices.get(hub_id)
+        if hub_device:
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
+
+    @property
+    def _info(self) -> HubFirmwareUpdateInfo | None:
+        return self.coordinator.hub_firmware_updates.get(self._hub_id)
+
+    @property
+    def installed_version(self) -> str | None:
+        # The streamHubObject payload does not carry the currently-installed
+        # firmware version. HA renders the entity with just `latest_version`
+        # in that case, which is the intended behaviour.
+        return None
+
+    @property
+    def latest_version(self) -> str | None:
+        info = self._info
+        if info is None:
+            return None
+        return info.target_version or None
+
+    @property
+    def in_progress(self) -> bool:
+        info = self._info
+        return info is not None and info.state == HUB_FW_STATE_DOWNLOADING

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1354,6 +1354,7 @@ class TestHubFirmwareRefresh:
         coordinator = _make_coordinator()
         coordinator._client.session.is_authenticated = True
         coordinator._streams_started = True
+        coordinator._sim_info_last_fetch = -10_000.0
         # Pre-seed a stale entry
         coordinator.hub_firmware_updates["hub-1"] = HubFirmwareUpdateInfo(
             target_version="2.16.0", state=HUB_FW_STATE_NOT_STARTED

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1318,6 +1318,11 @@ class TestHubFirmwareRefresh:
         coordinator = _make_coordinator()
         coordinator._client.session.is_authenticated = True
         coordinator._streams_started = True
+        # Force the SIM/firmware refresh branch to fire — `monotonic()`
+        # returns a small value on freshly-booted CI runners, so the
+        # default `_sim_info_last_fetch = 0` doesn't always exceed the
+        # 3600 s gate.
+        coordinator._sim_info_last_fetch = -10_000.0
         coordinator._spaces_api = MagicMock()
         coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
         coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1224,6 +1224,7 @@ class TestCachedSnapshotStart:
         )
         coordinator._hub_object_api = MagicMock()
         coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_firmware_info = AsyncMock(return_value=None)
         coordinator._start_device_streams = AsyncMock()
         coordinator._start_hts = AsyncMock()
         return coordinator
@@ -1302,6 +1303,68 @@ class TestCachedSnapshotStart:
 # ---------------------------------------------------------------------------
 # Per-device readings via HTS (#123)
 # ---------------------------------------------------------------------------
+
+
+class TestHubFirmwareRefresh:
+    """Coordinator piggybacks firmware fetch on the SIM refresh cadence."""
+
+    @pytest.mark.asyncio
+    async def test_firmware_info_stored_when_returned(self) -> None:
+        from custom_components.aegis_ajax.api.hub_object import (
+            HUB_FW_STATE_DOWNLOADING,
+            HubFirmwareUpdateInfo,
+        )
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+        coordinator._hub_object_api = MagicMock()
+        coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_firmware_info = AsyncMock(
+            return_value=HubFirmwareUpdateInfo(
+                target_version="2.17.0", state=HUB_FW_STATE_DOWNLOADING
+            )
+        )
+
+        await coordinator._async_update_data()
+
+        # _make_space defaults hub_id to "hub-1"
+        assert "hub-1" in coordinator.hub_firmware_updates
+        assert coordinator.hub_firmware_updates["hub-1"].target_version == "2.17.0"
+        assert coordinator.hub_firmware_updates["hub-1"].state == HUB_FW_STATE_DOWNLOADING
+
+    @pytest.mark.asyncio
+    async def test_firmware_entry_cleared_when_api_returns_none(self) -> None:
+        """Hub reports no pending update → previous cached entry must be dropped."""
+        from custom_components.aegis_ajax.api.hub_object import (
+            HUB_FW_STATE_NOT_STARTED,
+            HubFirmwareUpdateInfo,
+        )
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        # Pre-seed a stale entry
+        coordinator.hub_firmware_updates["hub-1"] = HubFirmwareUpdateInfo(
+            target_version="2.16.0", state=HUB_FW_STATE_NOT_STARTED
+        )
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+        coordinator._hub_object_api = MagicMock()
+        coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_firmware_info = AsyncMock(return_value=None)
+
+        await coordinator._async_update_data()
+
+        assert "hub-1" not in coordinator.hub_firmware_updates
 
 
 class TestOnHtsDeviceKv:

--- a/tests/unit/test_hub_object.py
+++ b/tests/unit/test_hub_object.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.aegis_ajax.api.hub_object import HubObjectApi, SimCardInfo
+from custom_components.aegis_ajax.api.hub_object import (
+    HUB_FW_STATE_DOWNLOADING,
+    HUB_FW_STATE_NOT_STARTED,
+    HubFirmwareUpdateInfo,
+    HubObjectApi,
+    SimCardInfo,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -213,4 +219,170 @@ class TestGetSimInfo:
         api._client._session.get_call_metadata.return_value = []
 
         result = await api.get_sim_info("hub-abc")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Firmware update parser (read-only platform — never installs)
+# ---------------------------------------------------------------------------
+
+
+def _build_firmware_snapshot(version: str = "2.17.0", state: str = "not_started") -> bytes:
+    """Build a StreamHubObject snapshot frame carrying a SystemFirmwareUpdate."""
+    from google.protobuf.empty_pb2 import Empty  # noqa: PLC0415
+    from systems.ajax.api.mobile.v2.hubobject.model.firmware.system_firmware_update_pb2 import (  # noqa: PLC0415
+        SystemFirmwareUpdate,
+    )
+    from systems.ajax.api.mobile.v2.hubobject.model.hub_object_pb2 import (  # noqa: PLC0415
+        HubObject,
+    )
+    from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+        StreamHubObject,
+    )
+
+    status_kwargs: dict[str, Empty] = {state: Empty()}
+    sfu = SystemFirmwareUpdate(
+        firmware_version=version,
+        status=SystemFirmwareUpdate.Status(**status_kwargs),
+    )
+    hub_obj = HubObject(hex_id="ABCD1234", system_firmware_update=sfu)
+    return StreamHubObject(snapshot=hub_obj).SerializeToString()
+
+
+class TestHubFirmwareUpdateInfo:
+    def test_state_constants(self) -> None:
+        assert HUB_FW_STATE_NOT_STARTED == "not_started"
+        assert HUB_FW_STATE_DOWNLOADING == "downloading"
+
+    def test_dataclass_is_frozen(self) -> None:
+        import dataclasses  # noqa: PLC0415
+
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state="not_started")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            info.target_version = "X"  # type: ignore[misc]
+
+
+class TestParseFirmwareFromHubObject:
+    def test_not_started_snapshot(self) -> None:
+        raw = _build_firmware_snapshot(version="2.17.0", state="not_started")
+        info = HubObjectApi._parse_firmware_from_hub_object(raw)
+        assert info == HubFirmwareUpdateInfo(
+            target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED
+        )
+
+    def test_downloading_snapshot(self) -> None:
+        raw = _build_firmware_snapshot(version="2.17.0", state="downloading")
+        info = HubObjectApi._parse_firmware_from_hub_object(raw)
+        assert info == HubFirmwareUpdateInfo(
+            target_version="2.17.0", state=HUB_FW_STATE_DOWNLOADING
+        )
+
+    def test_snapshot_without_firmware_field_returns_none(self) -> None:
+        from systems.ajax.api.mobile.v2.hubobject.model.hub_object_pb2 import (  # noqa: PLC0415
+            HubObject,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+            StreamHubObject,
+        )
+
+        raw = StreamHubObject(snapshot=HubObject(hex_id="ABCD")).SerializeToString()
+        assert HubObjectApi._parse_firmware_from_hub_object(raw) is None
+
+    def test_delta_frame_returns_none(self) -> None:
+        """Firmware metadata only ships in snapshot — deltas are ignored."""
+        from google.protobuf.empty_pb2 import Empty  # noqa: PLC0415
+        from systems.ajax.api.mobile.v2.hubobject.model.firmware.system_firmware_update_pb2 import (  # noqa: PLC0415
+            SystemFirmwareUpdate,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.model.hub_object_pb2 import (  # noqa: PLC0415
+            HubObject,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+            StreamHubObject,
+        )
+
+        sfu = SystemFirmwareUpdate(
+            firmware_version="2.17.0",
+            status=SystemFirmwareUpdate.Status(downloading=Empty()),
+        )
+        hub_obj = HubObject(hex_id="ABCD", system_firmware_update=sfu)
+        raw = StreamHubObject(update=hub_obj).SerializeToString()
+        assert HubObjectApi._parse_firmware_from_hub_object(raw) is None
+
+    def test_garbage_bytes_returns_none(self) -> None:
+        assert HubObjectApi._parse_firmware_from_hub_object(b"\xff\xff\xff") is None
+
+    def test_empty_target_version_string(self) -> None:
+        # Defensive: if Ajax sends an empty version string, the parser
+        # still returns an info object with state but caller can choose
+        # to suppress display via `target_version or None`.
+        from google.protobuf.empty_pb2 import Empty  # noqa: PLC0415
+        from systems.ajax.api.mobile.v2.hubobject.model.firmware.system_firmware_update_pb2 import (  # noqa: PLC0415
+            SystemFirmwareUpdate,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.model.hub_object_pb2 import (  # noqa: PLC0415
+            HubObject,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+            StreamHubObject,
+        )
+
+        sfu = SystemFirmwareUpdate(status=SystemFirmwareUpdate.Status(not_started=Empty()))
+        hub_obj = HubObject(hex_id="ABCD", system_firmware_update=sfu)
+        raw = StreamHubObject(snapshot=hub_obj).SerializeToString()
+        info = HubObjectApi._parse_firmware_from_hub_object(raw)
+        assert info is not None
+        assert info.target_version == ""
+
+
+class TestGetFirmwareInfo:
+    def _make_api(self) -> HubObjectApi:
+        client = MagicMock()
+        return HubObjectApi(client)
+
+    @pytest.mark.asyncio
+    async def test_returns_firmware_info_from_snapshot(self) -> None:
+        api = self._make_api()
+        raw = _build_firmware_snapshot(version="2.17.0", state="downloading")
+
+        async def _fake_stream() -> AsyncGenerator[bytes, None]:
+            yield raw
+
+        mock_method = MagicMock(return_value=_fake_stream())
+        api._client._get_channel().unary_stream.return_value = mock_method
+        api._client._session.get_call_metadata.return_value = []
+
+        result = await api.get_firmware_info("ABCD1234")
+        assert result == HubFirmwareUpdateInfo(
+            target_version="2.17.0", state=HUB_FW_STATE_DOWNLOADING
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_stream_exception(self) -> None:
+        api = self._make_api()
+
+        async def _raising_stream() -> AsyncGenerator[bytes, None]:
+            raise RuntimeError("stream error")
+            yield
+
+        mock_method = MagicMock(return_value=_raising_stream())
+        api._client._get_channel().unary_stream.return_value = mock_method
+        api._client._session.get_call_metadata.return_value = []
+
+        result = await api.get_firmware_info("ABCD")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_stream_empty(self) -> None:
+        api = self._make_api()
+
+        async def _empty_stream() -> AsyncGenerator[bytes, None]:
+            return
+            yield
+
+        mock_method = MagicMock(return_value=_empty_stream())
+        api._client._get_channel().unary_stream.return_value = mock_method
+        api._client._session.get_call_metadata.return_value = []
+
+        result = await api.get_firmware_info("ABCD")
         assert result is None

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,0 +1,185 @@
+"""Tests for the read-only update.py platform (hub firmware)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.aegis_ajax.api.hub_object import (
+    HUB_FW_STATE_DOWNLOADING,
+    HUB_FW_STATE_NOT_STARTED,
+    HubFirmwareUpdateInfo,
+)
+from custom_components.aegis_ajax.update import AjaxHubFirmwareUpdate
+
+
+class TestAjaxHubFirmwareUpdate:
+    @staticmethod
+    def _make_coordinator(
+        info: HubFirmwareUpdateInfo | None,
+        hub_id: str = "002B1A51",
+    ) -> MagicMock:
+        from custom_components.aegis_ajax.api.models import Device
+        from custom_components.aegis_ajax.const import DeviceState
+
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        coordinator.devices = {
+            hub_id: Device(
+                id=hub_id,
+                hub_id=hub_id,
+                name="Hub",
+                device_type="hub",
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            )
+        }
+        coordinator.hub_firmware_updates = {hub_id: info} if info else {}
+        return coordinator
+
+    def test_unique_id_namespaced_by_hub(self) -> None:
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity._attr_unique_id == "aegis_ajax_002B1A51_firmware"
+
+    def test_installed_version_always_none(self) -> None:
+        """Ajax stream doesn't expose installed version — HA renders just `latest`."""
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.installed_version is None
+
+    def test_latest_version_reflects_pending_update(self) -> None:
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.latest_version == "2.17.0"
+
+    def test_latest_version_none_when_no_pending_update(self) -> None:
+        """Absence of `hub_firmware_updates` entry == hub is up to date."""
+        coordinator = self._make_coordinator(None)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.latest_version is None
+        assert entity.in_progress is False
+
+    def test_in_progress_true_when_downloading(self) -> None:
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_DOWNLOADING)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.in_progress is True
+
+    def test_in_progress_false_when_not_started(self) -> None:
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.in_progress is False
+
+    def test_supported_features_excludes_install(self) -> None:
+        """The entity is read-only by design — no INSTALL feature exposed."""
+        from homeassistant.components.update import UpdateEntityFeature
+
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert not (entity.supported_features & UpdateEntityFeature.INSTALL)
+        assert entity.supported_features == UpdateEntityFeature(0)
+
+    def test_device_class_firmware(self) -> None:
+        from homeassistant.components.update import UpdateDeviceClass
+
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.device_class is UpdateDeviceClass.FIRMWARE
+
+    def test_empty_target_version_renders_as_none(self) -> None:
+        """Defensive: an empty version string is reported as no latest available."""
+        info = HubFirmwareUpdateInfo(target_version="", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.latest_version is None
+
+
+class TestAsyncSetupEntry:
+    @pytest.mark.asyncio
+    async def test_setup_creates_one_entity_per_hub(self) -> None:
+        from custom_components.aegis_ajax.api.models import Device, Space
+        from custom_components.aegis_ajax.const import (
+            ConnectionStatus,
+            DeviceState,
+            SecurityState,
+        )
+        from custom_components.aegis_ajax.update import async_setup_entry
+
+        hub_id = "002B1A51"
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        coordinator.spaces = {
+            "s1": Space(
+                id="s1",
+                hub_id=hub_id,
+                name="Home",
+                security_state=SecurityState.DISARMED,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+            )
+        }
+        coordinator.devices = {
+            hub_id: Device(
+                id=hub_id,
+                hub_id=hub_id,
+                name="Hub",
+                device_type="hub",
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            )
+        }
+        coordinator.hub_firmware_updates = {}
+        entry = MagicMock(runtime_data=coordinator)
+        async_add_entities = MagicMock()
+
+        await async_setup_entry(MagicMock(), entry, async_add_entities)
+        async_add_entities.assert_called_once()
+        entities = async_add_entities.call_args[0][0]
+        assert len(entities) == 1
+        assert isinstance(entities[0], AjaxHubFirmwareUpdate)
+
+    @pytest.mark.asyncio
+    async def test_setup_skips_spaces_without_hub_device(self) -> None:
+        from custom_components.aegis_ajax.api.models import Space
+        from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
+        from custom_components.aegis_ajax.update import async_setup_entry
+
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        coordinator.spaces = {
+            "s1": Space(
+                id="s1",
+                hub_id="HUB1",
+                name="Home",
+                security_state=SecurityState.DISARMED,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+            )
+        }
+        # No hub device yet — the hub-id-keyed lookup misses.
+        coordinator.devices = {}
+        coordinator.hub_firmware_updates = {}
+        entry = MagicMock(runtime_data=coordinator)
+        async_add_entities = MagicMock()
+
+        await async_setup_entry(MagicMock(), entry, async_add_entities)
+        entities = async_add_entities.call_args[0][0]
+        assert entities == []


### PR DESCRIPTION
## Summary

Surfaces the pending hub firmware update the Ajax cloud reports as a native HA `update.<hub>_firmware` entity. **Read-only by design** — the entity is informational only.

The user's stated concern (#123 follow-up discussion): "actualizar el FW desde HA y brickear algo". Two protections against that:

- **No `INSTALL` feature** declared, no `async_install` implementation — HA renders no install button at all.
- The integration **never calls** the `Start*FirmwareUpdate` RPC even though the proto exposes one. Firmware updates are higher-stakes than the rest of the surface and Ajax controls scheduling server-side anyway.

## What gets rendered

`installed_version` stays `None` (the `streamHubObject` payload doesn't carry the currently-installed version), so HA renders the entity as "<latest_version> available" with a progress indicator while the cloud is pushing bytes. When the hub reports no pending update at all, the cache entry is dropped and the entity renders with `latest_version = None` (HA treats that as "up to date" — no notification).

## Wire-up

- `HubObjectApi.get_firmware_info(hub_id)` parses the system firmware update from the HubObject snapshot via `StreamHubObject.FromString` (cleaner than the SIM path's manual byte walking, since the firmware sub-message hangs off a multi-byte tag).
- Coordinator piggybacks the fetch on the existing hourly SIM refresh — same `streamHubObject` snapshot, one extra dict update.
- Translations in all 14 locales for the new `hub_firmware` entity name.
- `Platform.UPDATE` added to `PLATFORMS`.

## Test plan

- [x] `make check` green inside Docker (rebuilt image without volume mount): 1241 tests pass (was 1217), coverage 85.72% (was 85.46%); `update.py` at 98% line coverage.
- [x] New parser tests cover the four shapes the stream can deliver (`not_started` snapshot, `downloading` snapshot, snapshot without the field, delta frame, garbage bytes).
- [x] New entity tests cover unique_id namespacing, `installed_version == None`, `latest_version` for both states, `in_progress` only true while downloading, `supported_features` excludes `INSTALL`, defensive handling of empty target version, and skip when no hub device in the snapshot.
- [x] New coordinator test confirms a freshly returned `HubFirmwareUpdateInfo` lands in `coordinator.hub_firmware_updates`, and a `None` return drops the previously cached entry.
- [ ] CI matrix (Python 3.12 + 3.13, hassfest, HACS validate, CodeQL) on the pushed branch.
- [ ] Real-HA confirmation in the next beta: entity appears under each hub's device card; renders "up to date" today (no pending update on the maintainer's `bvis-home`) and would show "X.Y.Z available" / progress bar when Ajax queues an update.