### PR TITLE
fix(update): render hub firmware entity as 'up to date' instead of 'unknown'

### DIFF
--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -42,6 +42,18 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Sentinel value used for both `installed_version` and `latest_version`
+# when the Ajax cloud reports no pending update. HA's `UpdateEntity`
+# treats matching non-None versions as "up to date" and renders the
+# entity state as `STATE_OFF`; with both versions left at `None` the
+# entity would render as `unknown`, which is misleading because the
+# absence of a pending update IS the "up to date" signal from Ajax.
+# The placeholder is also surfaced on `installed_version` while an
+# update IS pending so the state computation lands on `STATE_ON` —
+# Ajax's `streamHubObject` does not carry the currently-installed
+# firmware version, so this is the most truthful answer we can give.
+_INSTALLED_VERSION_PLACEHOLDER = "current"
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -84,17 +96,20 @@ class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateE
 
     @property
     def installed_version(self) -> str | None:
-        # The streamHubObject payload does not carry the currently-installed
-        # firmware version. HA renders the entity with just `latest_version`
-        # in that case, which is the intended behaviour.
-        return None
+        # See `_INSTALLED_VERSION_PLACEHOLDER` for why this is always a
+        # constant rather than `None`: HA's state computation needs a
+        # non-`None` installed version to differentiate "up to date"
+        # from "unknown".
+        return _INSTALLED_VERSION_PLACEHOLDER
 
     @property
     def latest_version(self) -> str | None:
         info = self._info
-        if info is None:
-            return None
-        return info.target_version or None
+        if info is None or not info.target_version:
+            # No pending update from Ajax — mirror installed_version so
+            # HA computes `STATE_OFF` and renders "Up to date".
+            return _INSTALLED_VERSION_PLACEHOLDER
+        return info.target_version
 
     @property
     def in_progress(self) -> bool:

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -49,12 +49,14 @@ class TestAjaxHubFirmwareUpdate:
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
         assert entity._attr_unique_id == "aegis_ajax_002B1A51_firmware"
 
-    def test_installed_version_always_none(self) -> None:
-        """Ajax stream doesn't expose installed version — HA renders just `latest`."""
+    def test_installed_version_is_constant_placeholder(self) -> None:
+        """Ajax doesn't expose installed version; entity always reports the placeholder."""
+        from custom_components.aegis_ajax.update import _INSTALLED_VERSION_PLACEHOLDER
+
         info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
         coordinator = self._make_coordinator(info)
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
-        assert entity.installed_version is None
+        assert entity.installed_version == _INSTALLED_VERSION_PLACEHOLDER
 
     def test_latest_version_reflects_pending_update(self) -> None:
         info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
@@ -62,12 +64,19 @@ class TestAjaxHubFirmwareUpdate:
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
         assert entity.latest_version == "2.17.0"
 
-    def test_latest_version_none_when_no_pending_update(self) -> None:
-        """Absence of `hub_firmware_updates` entry == hub is up to date."""
+    def test_latest_version_matches_installed_when_no_pending_update(self) -> None:
+        """Up-to-date case: latest == installed so HA renders STATE_OFF, not unknown."""
         coordinator = self._make_coordinator(None)
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
-        assert entity.latest_version is None
+        assert entity.latest_version == entity.installed_version
         assert entity.in_progress is False
+
+    def test_latest_version_falls_back_to_placeholder_on_empty_target(self) -> None:
+        """Defensive: an empty target_version string is treated as 'no pending update'."""
+        info = HubFirmwareUpdateInfo(target_version="", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.latest_version == entity.installed_version
 
     def test_in_progress_true_when_downloading(self) -> None:
         info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_DOWNLOADING)
@@ -99,12 +108,22 @@ class TestAjaxHubFirmwareUpdate:
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
         assert entity.device_class is UpdateDeviceClass.FIRMWARE
 
-    def test_empty_target_version_renders_as_none(self) -> None:
-        """Defensive: an empty version string is reported as no latest available."""
-        info = HubFirmwareUpdateInfo(target_version="", state=HUB_FW_STATE_NOT_STARTED)
+    def test_state_resolves_to_off_when_no_pending_update(self) -> None:
+        """Smoke-check the full HA state computation lands on 'off' (up to date)."""
+        from homeassistant.const import STATE_OFF
+
+        coordinator = self._make_coordinator(None)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        # HA's UpdateEntity.state returns STATE_OFF when installed == latest.
+        assert entity.state == STATE_OFF
+
+    def test_state_resolves_to_on_when_pending_update(self) -> None:
+        from homeassistant.const import STATE_ON
+
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
         coordinator = self._make_coordinator(info)
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
-        assert entity.latest_version is None
+        assert entity.state == STATE_ON
 
 
 class TestAsyncSetupEntry:


### PR DESCRIPTION
## Summary

After `1.4.0-beta.5` shipped, the new `update.hub_firmware` entity rendered as **"Firmware desconocido"** on healthy installs instead of "Up to date".

Root cause: HA's `UpdateEntity.state` returns `None` (rendered as `unknown`) whenever **either** `installed_version` or `latest_version` is `None`. The previous code left both at `None` whenever no pending update was reported by Ajax, so the up-to-date case fell into the unknown branch.

## Fix

- `installed_version` now returns a constant placeholder (`"current"`) — Ajax's `streamHubObject` doesn't expose the actual installed version, and the placeholder is more truthful than a fabricated number.
- `latest_version` mirrors `installed_version` when no pending update is reported, so HA computes `STATE_OFF` and the entity renders as "Up to date".
- When a pending update IS reported, `latest_version` returns the target version and the state flips to `STATE_ON` ("Update available"). `installed_version` stays at `"current"` so HA shows a real version diff on the entity card.

## Test plan

- [x] `make check` green inside Docker (rebuilt without volume mount): 1243 tests pass, 85.72% coverage, `update.py` at 98%.
- [x] New `test_state_resolves_to_off_when_no_pending_update` + `test_state_resolves_to_on_when_pending_update` exercise HA's full state computation end-to-end.
- [x] Existing tests rewritten for the new placeholder semantics.
- [ ] CI matrix.
- [ ] Real-HA confirmation on bvis-home — entity should switch from "Firmware desconocido" to "Up to date" after upgrading.