### PR TITLE
feat: restore electrical readings on boot + clarify update entity semantics

### DIFF
--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -6,7 +6,12 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    RestoreSensor,
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
@@ -477,12 +482,23 @@ class AjaxHubCellularNetworkSensor(_HubNetworkSensor):
 # ---------------------------------------------------------------------------
 
 
-class _AjaxDeviceReadingsBase(CoordinatorEntity[AjaxCobrandedCoordinator], SensorEntity):
-    """Shared scaffold for the current / energy / power triplet.
+class _AjaxDeviceReadingsBase(CoordinatorEntity[AjaxCobrandedCoordinator], RestoreSensor):
+    """Shared scaffold for the current / voltage / energy / power quartet.
 
     Each subclass picks its own translation_key, device_class, state_class
-    and unit. All three pull from `coordinator.device_readings[device_id]`
-    which is populated by the HTS path (see `_on_hts_device_kv`).
+    and unit, and provides `_live_native_value` reading from
+    `coordinator.device_readings[device_id]` (populated by the HTS path
+    in `_on_hts_device_kv`).
+
+    Restoration on boot (#123): some Ajax hubs only emit electrical
+    readings via `STATUS_UPDATE` deltas on change, not in the initial
+    `STATUS_BODY` snapshot. For loads that run at a constant rate for
+    hours (e.g. a relay driving fixed-speed ventilation), no delta
+    arrives until the load actually shifts, so the sensor would render
+    `unknown` after every restart even though the last known value is
+    still the truth. `RestoreSensor` lets us seed the entity from its
+    last persisted state on HA boot; the value is refreshed in place
+    as soon as the next live delta lands.
     """
 
     _attr_has_entity_name = True
@@ -490,19 +506,48 @@ class _AjaxDeviceReadingsBase(CoordinatorEntity[AjaxCobrandedCoordinator], Senso
     def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
         super().__init__(coordinator)
         self._device_id = device_id
+        # Per-entity fallback used when the coordinator has no live reading
+        # yet but HA restored a state from the previous run. Populated by
+        # `async_added_to_hass`; stays `None` on a fresh install.
+        self._restored_native_value: float | None = None
         device = coordinator.devices.get(device_id)
         if device:
             self._attr_device_info = build_device_info(device, coordinator.rooms)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last = await self.async_get_last_sensor_data()
+        if last is None or last.native_value is None:
+            return
+        try:
+            self._restored_native_value = float(last.native_value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            # State recorded as a non-numeric string (e.g. "unknown")
+            # or a non-castable type (date/Decimal) — skip the restore.
+            self._restored_native_value = None
+
+    @property
+    def _live_native_value(self) -> float | None:
+        """Subclass-specific lookup against `coordinator.device_readings`."""
+        raise NotImplementedError
+
+    @property
+    def native_value(self) -> float | None:
+        live = self._live_native_value
+        if live is not None:
+            return live
+        return self._restored_native_value
 
     @property
     def available(self) -> bool:
         device = self.coordinator.devices.get(self._device_id)
         if device is None or not device.is_online:
             return False
-        # No reading has arrived yet — entity stays unavailable instead of
-        # rendering 0.0, otherwise the Energy dashboard would integrate a
-        # phantom zero baseline before the hub's first STATUS_BODY.
-        return self._device_id in self.coordinator.device_readings
+        # Entity is available if we have a live reading OR a restored
+        # value from the previous run. Otherwise we'd render `unknown`
+        # for hours on installs whose hub only emits readings on
+        # change (#123 follow-up).
+        return self._live_native_value is not None or self._restored_native_value is not None
 
 
 class AjaxDeviceCurrentSensor(_AjaxDeviceReadingsBase):
@@ -519,7 +564,7 @@ class AjaxDeviceCurrentSensor(_AjaxDeviceReadingsBase):
         self._attr_unique_id = f"aegis_ajax_{device_id}_current"
 
     @property
-    def native_value(self) -> float | None:
+    def _live_native_value(self) -> float | None:
         readings = self.coordinator.device_readings.get(self._device_id)
         if readings is None or readings.current_ma is None:
             return None
@@ -545,7 +590,7 @@ class AjaxDeviceVoltageSensor(_AjaxDeviceReadingsBase):
         self._attr_unique_id = f"aegis_ajax_{device_id}_voltage"
 
     @property
-    def native_value(self) -> float | None:
+    def _live_native_value(self) -> float | None:
         readings = self.coordinator.device_readings.get(self._device_id)
         if readings is None or readings.voltage_v is None:
             return None
@@ -573,7 +618,7 @@ class AjaxDeviceEnergyConsumedSensor(_AjaxDeviceReadingsBase):
         self._attr_unique_id = f"aegis_ajax_{device_id}_energy_consumed"
 
     @property
-    def native_value(self) -> float | None:
+    def _live_native_value(self) -> float | None:
         readings = self.coordinator.device_readings.get(self._device_id)
         if readings is None or readings.power_consumed_wh is None:
             return None
@@ -601,7 +646,7 @@ class AjaxDeviceDerivedPowerSensor(_AjaxDeviceReadingsBase):
         self._attr_unique_id = f"aegis_ajax_{device_id}_power_derived"
 
     @property
-    def native_value(self) -> float | None:
+    def _live_native_value(self) -> float | None:
         readings = self.coordinator.device_readings.get(self._device_id)
         if readings is None or readings.current_ma is None:
             return None

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -115,3 +115,26 @@ class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateE
     def in_progress(self) -> bool:
         info = self._info
         return info is not None and info.state == HUB_FW_STATE_DOWNLOADING
+
+    @property
+    def release_summary(self) -> str | None:
+        # The Ajax stream doesn't expose the currently-installed firmware
+        # version, so "Up-to-date" here is shorthand for "Ajax has not
+        # queued an update for this hub right now" — not a positive
+        # confirmation that the hub is running the latest firmware Ajax
+        # has ever published. The Ajax cloud schedules updates on its
+        # own; this integration only mirrors what the cloud is telling
+        # us, and the entity is informational (no install action).
+        info = self._info
+        if info is None:
+            return (
+                "Ajax has not queued a firmware update for this hub. "
+                "The actual installed firmware version is not exposed by "
+                "Ajax to the integration, so 'Up-to-date' reflects only "
+                "the absence of a queued update."
+            )
+        return (
+            f"Ajax has queued firmware {info.target_version} for this hub. "
+            "The hub will install it on its own; this entity is "
+            "informational and cannot trigger or skip the update."
+        )

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -686,6 +686,76 @@ class TestAjaxDeviceElectricalSensors:
         sensor = AjaxDeviceDerivedPowerSensor(coordinator, "311B058D")
         assert sensor.entity_registry_enabled_default is False
 
+    @pytest.mark.asyncio
+    async def test_native_value_falls_back_to_restored_when_no_live_reading(self) -> None:
+        """Bruno's case: hub never re-pushes constant readings (#123)."""
+        from unittest.mock import AsyncMock as _AsyncMock
+
+        from homeassistant.components.sensor import SensorExtraStoredData
+
+        from custom_components.aegis_ajax.sensor import AjaxDeviceCurrentSensor
+
+        coordinator = self._make_coordinator(current_ma=None, power_consumed_wh=None)
+        sensor = AjaxDeviceCurrentSensor(coordinator, "311B058D")
+        # Simulate HA RestoreSensor handing us last persisted value.
+        sensor.async_get_last_sensor_data = _AsyncMock(
+            return_value=SensorExtraStoredData(native_value=0.04, native_unit_of_measurement="A")
+        )
+        # Patch out the upstream subscribers/event loop touches on add.
+        sensor.async_internal_added_to_hass = _AsyncMock()
+        sensor.async_on_remove = MagicMock()
+        sensor.hass = MagicMock()
+        await sensor.async_added_to_hass()
+
+        # No live reading → returns the restored 0.04 A instead of None.
+        assert sensor.native_value == 0.04
+        assert sensor.available is True
+
+    @pytest.mark.asyncio
+    async def test_live_reading_wins_over_restored_value(self) -> None:
+        from unittest.mock import AsyncMock as _AsyncMock
+
+        from homeassistant.components.sensor import SensorExtraStoredData
+
+        from custom_components.aegis_ajax.sensor import AjaxDeviceVoltageSensor
+
+        coordinator = self._make_coordinator(voltage_v=231)
+        sensor = AjaxDeviceVoltageSensor(coordinator, "311B058D")
+        sensor.async_get_last_sensor_data = _AsyncMock(
+            return_value=SensorExtraStoredData(native_value=228, native_unit_of_measurement="V")
+        )
+        sensor.async_internal_added_to_hass = _AsyncMock()
+        sensor.async_on_remove = MagicMock()
+        sensor.hass = MagicMock()
+        await sensor.async_added_to_hass()
+
+        # Live reading 231 V > restored 228 V — fresh value wins.
+        assert sensor.native_value == 231.0
+
+    @pytest.mark.asyncio
+    async def test_restore_skips_non_numeric_state(self) -> None:
+        """`unknown` or `unavailable` strings can't be parsed back as floats."""
+        from unittest.mock import AsyncMock as _AsyncMock
+
+        from homeassistant.components.sensor import SensorExtraStoredData
+
+        from custom_components.aegis_ajax.sensor import AjaxDeviceCurrentSensor
+
+        coordinator = self._make_coordinator(current_ma=None, power_consumed_wh=None)
+        sensor = AjaxDeviceCurrentSensor(coordinator, "311B058D")
+        sensor.async_get_last_sensor_data = _AsyncMock(
+            return_value=SensorExtraStoredData(
+                native_value="unknown", native_unit_of_measurement="A"
+            )
+        )
+        sensor.async_internal_added_to_hass = _AsyncMock()
+        sensor.async_on_remove = MagicMock()
+        sensor.hass = MagicMock()
+        await sensor.async_added_to_hass()
+
+        assert sensor.native_value is None
+        assert sensor.available is False
+
     def test_unique_ids_distinct_across_four_entities(self) -> None:
         from custom_components.aegis_ajax.sensor import (
             AjaxDeviceCurrentSensor,

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -117,6 +117,24 @@ class TestAjaxHubFirmwareUpdate:
         # HA's UpdateEntity.state returns STATE_OFF when installed == latest.
         assert entity.state == STATE_OFF
 
+    def test_release_summary_explains_up_to_date_semantics(self) -> None:
+        """No pending update — release_summary clarifies it's not a positive confirmation."""
+        coordinator = self._make_coordinator(None)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        summary = entity.release_summary
+        assert summary is not None
+        assert "not queued" in summary.lower()
+        assert "not exposed" in summary.lower()
+
+    def test_release_summary_names_target_version_when_update_queued(self) -> None:
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        summary = entity.release_summary
+        assert summary is not None
+        assert "2.17.0" in summary
+        assert "informational" in summary.lower()
+
     def test_state_resolves_to_on_when_pending_update(self) -> None:
         from homeassistant.const import STATE_ON
 


### PR DESCRIPTION
Two transparency changes targeting user feedback from #123:

## 1. Restore electrical readings on boot (Bruno's complaint, #123)

@brunovdw68 reports that on his hub the readings sub-keys are absent from the boot snapshot — the hub only emits them via delta pushes when the load actually changes. For loads that run constant for hours (his case: relay driving fixed-speed ventilation), no delta arrives until the load shifts, so `current` / `voltage` / `energy_consumed` / `power_derived` render `unknown` after every restart for an arbitrary amount of time.

Switch `_AjaxDeviceReadingsBase` from plain `SensorEntity` to HA's `RestoreSensor`. Each subclass now provides `_live_native_value` (the coordinator lookup); the base class falls back to the persisted last-known value when no live reading is available. `available` is True when either path produces a number; non-numeric persisted states (`unknown` / `unavailable`) are filtered out so the entity doesn't restore garbage.

UX impact: after an HA restart the sensors display the value from before the restart instead of `unknown`. They refresh to the live value the moment the next delta arrives. The Energy dashboard's `total_increasing` semantics are preserved (the restored kWh value just becomes the new baseline for the next session).

## 2. `release_summary` on `update.hub_firmware`

@basilio raised on internal review that "Up-to-date" is a strong claim while we only actually know "no firmware update is currently queued for this hub". The Ajax stream doesn't carry the installed firmware version, so we can't compare against the catalog.

Adds a `release_summary` property that explains the semantics in the entity detail panel:
- No pending update → "Ajax has not queued a firmware update for this hub. The actual installed firmware version is not exposed by Ajax to the integration, so 'Up-to-date' reflects only the absence of a queued update."
- Pending update → "Ajax has queued firmware X.Y.Z for this hub. The hub will install it on its own; this entity is informational and cannot trigger or skip the update."

Visible state in the entity list stays the same; the explanation only surfaces when the user clicks into the entity.

## Test plan

- [x] `make check` green inside Docker (rebuilt without volume mount): 1248 unit tests pass, coverage 85.76%, `update.py` at 98%.
- [x] New `TestAjaxDeviceElectricalSensors` cases: native_value falls back to restored when no live reading; live reading wins over restored; non-numeric persisted state (`unknown`) is skipped.
- [x] New `TestAjaxHubFirmwareUpdate` cases assert release_summary content for both branches.
- [ ] CI matrix.
- [ ] Real-HA confirmation on bvis-home + Bruno's install: sensors keep their value through a restart; `update.hub_firmware` detail panel shows the explanation.

Refs #123.