### PR TITLE
fix(coordinator): preserve HTS-cached state on transient reconnects; mains_power keeps alert semantics

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -566,6 +566,16 @@ class AjaxHubPowerSensor(_HubNetworkBinarySensor):
         self._attr_unique_id = f"aegis_ajax_{hub_id}_mains_power"
 
     @property
+    def available(self) -> bool:
+        # Operational alert (#146): refusing to fall back to a cached
+        # snapshot here is deliberate. If HTS drops and the hub actually
+        # lost mains during the outage, we don't want this sensor still
+        # reporting `on` from the last delta — that would silence "se fue
+        # la luz" automations. Diagnostic hub_network sensors (IP, SSID,
+        # signal level) DO keep their cached value through the outage.
+        return super().available and self.coordinator.is_hts_alive
+
+    @property
     def is_on(self) -> bool:
         state = self.coordinator.hub_network.get(self._hub_id)
         return state.externally_powered if state else False

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -560,21 +560,37 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             task.result()
         self._handle_hts_disconnect()
 
+    @property
+    def is_hts_alive(self) -> bool:
+        """True while the HTS stream client is in place (#146).
+
+        Sensors whose semantics demand a live stream (operational alerts
+        like `mains_power`) should AND their `available` with this so
+        they go `unavailable` during transient HTS dropouts even though
+        the cached value is still present. Diagnostic sensors (IP, SSID,
+        signal level, electrical readings) ignore this and rely on the
+        cached value until the next delta refreshes it.
+        """
+        return self._hts_client is not None
+
     def _handle_hts_disconnect(self, *, reconnect: bool = True) -> None:
-        """Drop stale HTS state so hub network entities become unavailable."""
+        """Drop the live HTS client; preserve cached snapshots (#146).
+
+        The hub keeps every value we cache here (network state, per-device
+        electrical readings) across our socket outage, so wiping them on
+        every transient reconnect blanked sensors for 5+ minutes even
+        though the cached value was still the truth. We now keep them in
+        place — the next STATUS_UPDATE / STATUS_BODY after reconnect
+        refreshes them as deltas arrive. The only deliberate exception
+        is `mains_power` (the operational alert), which opts into
+        `unavailable` via `is_hts_alive` on its `available` property.
+        """
         self._hts_task = None
         self._hts_client = None
-        # Hub-network state IS stale once HTS drops — we can't know the
-        # hub's current connection state without the stream, and showing
-        # a 5-minute-old `wifi_ssid` would mislead the user.
-        # Per-device electrical readings (#146) are device-state the hub
-        # itself remembers across our socket outage; keep them visible so
-        # a transient reconnect doesn't blow away the value the user was
-        # just looking at. The next STATUS_UPDATE delta refreshes them
-        # in place when HTS reconnects.
-        if self.hub_network:
-            self.hub_network.clear()
-            self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+        # Broadcast so coordinator entities re-evaluate `available` —
+        # `mains_power` flips to unavailable here; everything else keeps
+        # its cached state and renders the same value as before.
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         # Track the first failure of an otherwise-healthy run so we can
         # raise a Repair after a sustained outage. Successful reconnect
         # clears it via `_clear_hts_chronic_failure`. Uses time.monotonic

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -564,9 +564,16 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Drop stale HTS state so hub network entities become unavailable."""
         self._hts_task = None
         self._hts_client = None
-        if self.hub_network or self.device_readings:
+        # Hub-network state IS stale once HTS drops — we can't know the
+        # hub's current connection state without the stream, and showing
+        # a 5-minute-old `wifi_ssid` would mislead the user.
+        # Per-device electrical readings (#146) are device-state the hub
+        # itself remembers across our socket outage; keep them visible so
+        # a transient reconnect doesn't blow away the value the user was
+        # just looking at. The next STATUS_UPDATE delta refreshes them
+        # in place when HTS reconnects.
+        if self.hub_network:
             self.hub_network.clear()
-            self.device_readings.clear()
             self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         # Track the first failure of an otherwise-healthy run so we can
         # raise a Repair after a sustained outage. Successful reconnect

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -20,6 +20,7 @@ from custom_components.aegis_ajax.binary_sensor import (
     AjaxBinarySensor,
     AjaxConnectivitySensor,
     AjaxCraConnectionSensor,
+    AjaxHubPowerSensor,
     AjaxHubWifiSensor,
     AjaxProblemSensor,
 )
@@ -955,3 +956,65 @@ class TestAjaxHubWifiSensor:
     def test_translation_key(self) -> None:
         sensor = AjaxHubWifiSensor(self._make_coordinator(True), "hub-1")
         assert sensor._attr_translation_key == "wifi"
+
+    def test_diagnostic_sensor_stays_available_when_hts_dead(self) -> None:
+        """#146 — diagnostic hub-network sensors render cached value during dropouts."""
+        coordinator = self._make_coordinator(wifi_connected=True)
+        coordinator.is_hts_alive = False
+        sensor = AjaxHubWifiSensor(coordinator, "hub-1")
+        assert sensor.available is True
+        assert sensor.is_on is True
+
+
+class TestAjaxHubPowerSensor:
+    """`mains_power` is the operational alert exception (#146).
+
+    Unlike other hub-network sensors it MUST go `unavailable` while
+    HTS is down — otherwise a real hub power loss during the outage
+    would be silenced by the cached `externally_powered=True` snapshot.
+    """
+
+    def _make_coordinator(
+        self, externally_powered: bool = True, hts_alive: bool = True
+    ) -> MagicMock:
+        hub_device = Device(
+            id="hub-1",
+            hub_id="hub-1",
+            name="Hub Two Plus",
+            device_type="hub_two_plus",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": hub_device}
+        coordinator.hub_network = {"hub-1": HubNetworkState(externally_powered=externally_powered)}
+        coordinator.is_hts_alive = hts_alive
+        return coordinator
+
+    def test_is_on_when_externally_powered(self) -> None:
+        sensor = AjaxHubPowerSensor(self._make_coordinator(externally_powered=True), "hub-1")
+        assert sensor.is_on is True
+
+    def test_is_off_when_running_on_battery(self) -> None:
+        sensor = AjaxHubPowerSensor(self._make_coordinator(externally_powered=False), "hub-1")
+        assert sensor.is_on is False
+
+    def test_available_when_hts_alive(self) -> None:
+        sensor = AjaxHubPowerSensor(self._make_coordinator(hts_alive=True), "hub-1")
+        assert sensor.available is True
+
+    def test_unavailable_when_hts_dead(self) -> None:
+        """HTS down → mains_power refuses to fall back to the cached snapshot."""
+        sensor = AjaxHubPowerSensor(self._make_coordinator(hts_alive=False), "hub-1")
+        assert sensor.available is False
+
+    def test_unavailable_when_no_hub_network_yet(self) -> None:
+        coordinator = self._make_coordinator()
+        coordinator.hub_network = {}
+        sensor = AjaxHubPowerSensor(coordinator, "hub-1")
+        assert sensor.available is False

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -432,6 +432,7 @@ class TestAsyncUpdateData:
 
         coordinator = _make_coordinator()
         coordinator._hts_first_failure_at = _time.monotonic() - 31 * 60
+        coordinator.async_set_updated_data = MagicMock()
 
         with patch(
             "custom_components.aegis_ajax.coordinator.async_register_hts_chronic_failure"
@@ -445,6 +446,7 @@ class TestAsyncUpdateData:
     def test_hts_first_disconnect_seeds_timestamp_without_repair(self) -> None:
         """The first HTS disconnect after a healthy run records the time but stays quiet."""
         coordinator = _make_coordinator()
+        coordinator.async_set_updated_data = MagicMock()
         assert coordinator._hts_first_failure_at is None
 
         with patch(
@@ -571,10 +573,11 @@ class TestAsyncUpdateData:
 
     @pytest.mark.asyncio
     async def test_update_restarts_hts_when_previous_task_finished(self) -> None:
+        net_state = HubNetworkState(ethernet_connected=True)
         coordinator = _make_coordinator()
         coordinator._client.session.is_authenticated = True
         coordinator._streams_started = True
-        coordinator.hub_network = {"hub-1": HubNetworkState(ethernet_connected=True)}
+        coordinator.hub_network = {"hub-1": net_state}
         coordinator._hts_task = MagicMock()
         coordinator._hts_task.done.return_value = True
         coordinator._start_hts = AsyncMock()
@@ -589,7 +592,9 @@ class TestAsyncUpdateData:
 
         await coordinator._async_update_data()
 
-        assert coordinator.hub_network == {}
+        # Cached state survives the disconnect cycle (#146); restart is
+        # triggered to refresh it with new deltas.
+        assert coordinator.hub_network == {"hub-1": net_state}
         coordinator._start_hts.assert_awaited_once()
         coordinator.async_set_updated_data.assert_called_once()
 
@@ -917,13 +922,22 @@ class TestStreamHandlers:
         coordinator._handle_status_update("nonexistent", "door_opened", {"op": 1})
         coordinator.async_set_updated_data.assert_not_called()
 
-    def test_handle_hts_disconnect_clears_stale_network_state(self) -> None:
+    def test_handle_hts_disconnect_preserves_hub_network(self) -> None:
+        """#146 — hub_network entries survive transient HTS dropouts.
+
+        Only the live HTS client is torn down; `is_hts_alive` becomes
+        False so the `mains_power` alert flips to unavailable, but all
+        diagnostic hub-network sensors keep rendering their cached
+        value until the next STATUS_BODY refreshes them on reconnect.
+        """
+        state = HubNetworkState(ethernet_connected=True)
         coordinator = self._make_coordinator_with_stream()
-        coordinator.hub_network["hub-1"] = HubNetworkState(ethernet_connected=True)
+        coordinator.hub_network["hub-1"] = state
 
         coordinator._handle_hts_disconnect()
 
-        assert coordinator.hub_network == {}
+        assert coordinator.hub_network == {"hub-1": state}
+        assert coordinator.is_hts_alive is False
         coordinator.async_set_updated_data.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1011,16 +1025,24 @@ class TestStreamHandlers:
         assert "ConnectionRefusedError" in caplog.text
         assert coordinator._hts_client is None
 
-    def test_handle_hts_task_done_clears_state(self) -> None:
+    def test_handle_hts_task_done_drops_client_and_broadcasts(self) -> None:
+        """Task-done routes through `_handle_hts_disconnect` (#146).
+
+        Cached hub_network entries stay intact — only the live client
+        is torn down and a broadcast fires so `is_hts_alive`-aware
+        sensors (e.g. `mains_power`) re-evaluate their availability.
+        """
+        state = HubNetworkState(ethernet_connected=True)
         coordinator = self._make_coordinator_with_stream()
-        coordinator.hub_network["hub-1"] = HubNetworkState(ethernet_connected=True)
+        coordinator.hub_network["hub-1"] = state
         task = MagicMock(spec=asyncio.Task)
         task.cancelled.return_value = False
         task.result.return_value = None
 
         coordinator._handle_hts_task_done(task)
 
-        assert coordinator.hub_network == {}
+        assert coordinator.hub_network == {"hub-1": state}
+        assert coordinator.is_hts_alive is False
         coordinator.async_set_updated_data.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1486,13 +1508,13 @@ class TestOnHtsDeviceKv:
         )
         coordinator.async_set_updated_data.assert_called_once()
 
-    def test_hts_disconnect_preserves_device_readings(self) -> None:
-        """#146 — keep last-known readings visible across transient HTS reconnects.
+    def test_hts_disconnect_preserves_cached_state(self) -> None:
+        """#146 — both hub_network and device_readings survive transient dropouts.
 
-        Hub-network state is genuinely stale once the stream drops, but
-        per-device electrical readings reflect device-state the hub
-        itself remembers, so the cached value remains the truth until a
-        fresh STATUS_UPDATE delta lands.
+        Diagnostic values (IP, SSID, signal level, per-device electrical
+        readings) keep rendering through the dropout. The single
+        broadcast is what lets `mains_power` flip to `unavailable` via
+        its `is_hts_alive`-gated `available` property.
         """
         from custom_components.aegis_ajax.api.hts.hub_state import (
             DeviceReadings,
@@ -1500,27 +1522,24 @@ class TestOnHtsDeviceKv:
         )
 
         coordinator = _make_coordinator()
-        coordinator.hub_network["hub-1"] = HubNetworkState(ethernet_connected=True)
+        net_state = HubNetworkState(ethernet_connected=True, wifi_ssid="my-ssid")
         readings = DeviceReadings(current_ma=40, power_consumed_wh=2409)
+        coordinator.hub_network["hub-1"] = net_state
         coordinator.device_readings["311B058D"] = readings
+        coordinator._hts_client = MagicMock()
         coordinator.async_set_updated_data = MagicMock()
 
         coordinator._handle_hts_disconnect(reconnect=False)
 
-        assert coordinator.hub_network == {}
+        assert coordinator.hub_network == {"hub-1": net_state}
         assert coordinator.device_readings == {"311B058D": readings}
+        assert coordinator.is_hts_alive is False
         coordinator.async_set_updated_data.assert_called_once()
 
-    def test_hts_disconnect_with_only_readings_does_not_broadcast(self) -> None:
-        """No state change to broadcast — readings stay untouched, hub_network already empty."""
-        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
-
+    def test_is_hts_alive_reflects_client_presence(self) -> None:
         coordinator = _make_coordinator()
-        readings = DeviceReadings(current_ma=40, power_consumed_wh=2409)
-        coordinator.device_readings["311B058D"] = readings
-        coordinator.async_set_updated_data = MagicMock()
-
-        coordinator._handle_hts_disconnect(reconnect=False)
-
-        assert coordinator.device_readings == {"311B058D": readings}
-        coordinator.async_set_updated_data.assert_not_called()
+        assert coordinator.is_hts_alive is False
+        coordinator._hts_client = MagicMock()
+        assert coordinator.is_hts_alive is True
+        coordinator._hts_client = None
+        assert coordinator.is_hts_alive is False

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1486,18 +1486,41 @@ class TestOnHtsDeviceKv:
         )
         coordinator.async_set_updated_data.assert_called_once()
 
-    def test_hts_disconnect_clears_device_readings(self) -> None:
-        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+    def test_hts_disconnect_preserves_device_readings(self) -> None:
+        """#146 — keep last-known readings visible across transient HTS reconnects.
+
+        Hub-network state is genuinely stale once the stream drops, but
+        per-device electrical readings reflect device-state the hub
+        itself remembers, so the cached value remains the truth until a
+        fresh STATUS_UPDATE delta lands.
+        """
+        from custom_components.aegis_ajax.api.hts.hub_state import (
+            DeviceReadings,
+            HubNetworkState,
+        )
 
         coordinator = _make_coordinator()
-        coordinator.device_readings["311B058D"] = DeviceReadings(
-            current_ma=40, power_consumed_wh=2409
-        )
+        coordinator.hub_network["hub-1"] = HubNetworkState(ethernet_connected=True)
+        readings = DeviceReadings(current_ma=40, power_consumed_wh=2409)
+        coordinator.device_readings["311B058D"] = readings
         coordinator.async_set_updated_data = MagicMock()
 
         coordinator._handle_hts_disconnect(reconnect=False)
 
-        assert coordinator.device_readings == {}
-        # Both hub_network and device_readings clear in the same call,
-        # so async_set_updated_data fires exactly once.
+        assert coordinator.hub_network == {}
+        assert coordinator.device_readings == {"311B058D": readings}
         coordinator.async_set_updated_data.assert_called_once()
+
+    def test_hts_disconnect_with_only_readings_does_not_broadcast(self) -> None:
+        """No state change to broadcast — readings stay untouched, hub_network already empty."""
+        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+
+        coordinator = _make_coordinator()
+        readings = DeviceReadings(current_ma=40, power_consumed_wh=2409)
+        coordinator.device_readings["311B058D"] = readings
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._handle_hts_disconnect(reconnect=False)
+
+        assert coordinator.device_readings == {"311B058D": readings}
+        coordinator.async_set_updated_data.assert_not_called()

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -800,6 +800,7 @@ class TestAjaxDeviceElectricalSensors:
         coordinator.device_readings["311B058D"] = DeviceReadings(
             current_ma=40, power_consumed_wh=2409
         )
+        coordinator.async_set_updated_data = MagicMock()
 
         sensor = AjaxDeviceCurrentSensor(coordinator, "311B058D")
         assert sensor.available is True

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -756,6 +756,61 @@ class TestAjaxDeviceElectricalSensors:
         assert sensor.native_value is None
         assert sensor.available is False
 
+    def test_sensor_stays_available_across_hts_disconnect(self) -> None:
+        """#146 — transient HTS reconnect must not blank the readings sensors.
+
+        The hub remembers device state across our socket outage, so the
+        cached value remains the truth until a fresh STATUS_UPDATE delta
+        lands when HTS comes back. Without this, every reconnect cycle
+        (5+ min on busy installs) renders the sensor `unavailable` even
+        though we have a perfectly good last-known value.
+        """
+        from unittest.mock import patch as _patch
+
+        from custom_components.aegis_ajax.api.hts.hub_state import DeviceReadings
+        from custom_components.aegis_ajax.api.models import Device
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+        from custom_components.aegis_ajax.sensor import AjaxDeviceCurrentSensor
+
+        hass = MagicMock()
+        client = MagicMock()
+        with _patch(
+            "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+            return_value=None,
+        ):
+            coordinator = AjaxCobrandedCoordinator(
+                hass=hass, client=client, space_ids=["s1"], poll_interval=30
+            )
+        coordinator.hass = hass
+        coordinator.devices = {
+            "311B058D": Device(
+                id="311B058D",
+                hub_id="002B1A51",
+                name="Relay",
+                device_type="wall_switch",
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            )
+        }
+        coordinator.device_readings["311B058D"] = DeviceReadings(
+            current_ma=40, power_consumed_wh=2409
+        )
+
+        sensor = AjaxDeviceCurrentSensor(coordinator, "311B058D")
+        assert sensor.available is True
+        assert sensor.native_value == 0.04
+
+        coordinator._handle_hts_disconnect(reconnect=False)
+
+        # Readings preserved → sensor reports the cached value, not `unavailable`.
+        assert sensor.available is True
+        assert sensor.native_value == 0.04
+
     def test_unique_ids_distinct_across_four_entities(self) -> None:
         from custom_components.aegis_ajax.sensor import (
             AjaxDeviceCurrentSensor,


### PR DESCRIPTION
## Summary

`_handle_hts_disconnect` no longer wipes any HTS-cached state. The hub keeps every value we cache (network state + per-device electrical readings) across our socket outage, so blanking sensors on every transient reconnect (typical 5+ min cycle on busy installs) was misleading users with `unavailable` for data we actually had.

- `hub_network` and `device_readings` are preserved through the disconnect.
- New `coordinator.is_hts_alive` property — single source of truth for "we have a live stream right now".
- `AjaxHubPowerSensor` (`mains_power`) ANDs its `available` with `is_hts_alive`, so the operational alert still flips to `unavailable` during dropouts. If HTS drops at the same time the hub really lost external power, a cached `externally_powered=True` would silence "se fue la luz" automations — that's the one path where stale-but-cached is worse than `unavailable`.
- All other diagnostic hub-network sensors (IP, SSID, DNS, signal level, ethernet/wifi/gsm channel flags) and the four reading sensors (current, voltage, energy_consumed, power_derived) keep their cached value through the dropout and refresh in place when the next `STATUS_UPDATE` / `STATUS_BODY` delta lands.

Refs #146.

### Behaviour matrix after the fix

| Path | Before | After |
|------|--------|-------|
| HTS active, value updates as deltas arrive | unchanged | unchanged |
| HTS drops mid-session, electrical readings | `unavailable` (bug) | last value |
| HTS drops mid-session, hub_network diagnostics (IP/SSID/signal) | `unavailable` | last value |
| HTS drops mid-session, `mains_power` | `unavailable` | `unavailable` (deliberate) |
| HA restart | `RestoreSensor` (1.4.0) seeds from persisted state | unchanged |

## Test plan

- [x] `test_handle_hts_disconnect_preserves_hub_network` — entries survive, `is_hts_alive` flips to False, broadcast fires.
- [x] `test_handle_hts_task_done_drops_client_and_broadcasts` — task-done path matches.
- [x] `test_hts_disconnect_preserves_cached_state` — both dicts preserved, single broadcast.
- [x] `test_is_hts_alive_reflects_client_presence` — property tracks `_hts_client`.
- [x] `test_update_restarts_hts_when_previous_task_finished` — restart path preserves cache too.
- [x] `TestAjaxHubPowerSensor.test_unavailable_when_hts_dead` — alert sensor goes `unavailable` on disconnect.
- [x] `TestAjaxHubPowerSensor.test_available_when_hts_alive` — and recovers when stream is back.
- [x] `TestAjaxHubWifiSensor.test_diagnostic_sensor_stays_available_when_hts_dead` — diagnostic sensors stay rendered.
- [x] `test_sensor_stays_available_across_hts_disconnect` — integration with real coordinator.
- [x] Full suite: 1256 passed, 85.85% coverage (above 80% gate).
- [x] `ruff check`, `ruff format --check`, `mypy`, `vulture` clean in a freshly rebuilt Docker image (no volume mount).
- [x] Deployed manually to `bvis-home` (`coordinator.py` only). Restart + `homeassistant.reload_config_entry` exercised the disconnect path cleanly — no aegis tracebacks/warnings. (`bvis-home` lacks WallSwitch/Socket devices, so device_readings stays empty there; the diagnostic-preservation half of the fix would also need a WallSwitch install to observe end-to-end.)
- [ ] Live verification on a WallSwitch-owning install (Bruno or another #123/#146 reporter) once `1.4.1` is on HACS.

## Release target

`1.4.1` patch — bug fix, SemVer PATCH.