### PR TITLE
fix(config_flow): explicitly reload entry when options flow changes data

### DIFF
--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -465,6 +465,17 @@ class AjaxCobrandedOptionsFlow(OptionsFlow):
                     self._entry,
                     data=new_data,
                 )
+                # Explicitly reload — mirror the repair-flow pattern (#148).
+                # The `_async_options_update_listener` would normally pick
+                # this up after `async_finish_flow` writes `options`, but
+                # when only `data` changes (FCM creds, password) and
+                # `options` round-trip identical to the prior values, the
+                # framework's second `async_update_entry(options=...)`
+                # short-circuits without firing a listener — leaving the
+                # FCM client running with the old credentials until the
+                # user manually reloads. `async_reload` is serialised on
+                # `entry.setup_lock`, so racing with the listener is safe.
+                await self.hass.config_entries.async_reload(self._entry.entry_id)
             return self.async_create_entry(title="", data=user_input)
         return self.async_show_form(
             step_id="init",

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -488,8 +488,12 @@ class TestOptionsFlow:
         config_entry = MagicMock()
         config_entry.options = options or {}
         config_entry.data = data or {}
+        config_entry.entry_id = "test-entry-id"
         flow = AjaxCobrandedOptionsFlow(config_entry)
         flow.hass = MagicMock()
+        # `async_step_init` awaits async_reload when data changes (#148),
+        # so the default MagicMock that wraps it must be awaitable.
+        flow.hass.config_entries.async_reload = AsyncMock()
         return flow, config_entry
 
     def test_options_flow_init(self) -> None:
@@ -696,6 +700,55 @@ class TestOptionsFlow:
 
         new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
         assert new_data["fcm_project_id"] == "new_proj"
+
+    @pytest.mark.asyncio
+    async def test_options_flow_reloads_when_data_changes(self) -> None:
+        """#148 — FCM creds in entry.data must trigger an explicit reload.
+
+        The `_async_options_update_listener` would normally fire after
+        `async_finish_flow` writes options, but when only `data` changes
+        and `options` round-trip identical, the framework's second
+        `async_update_entry(options=...)` short-circuits without firing
+        a listener — leaving the FCM client running with stale
+        credentials until the user manually reloads. Mirror the
+        repair-flow pattern: await `async_reload` explicitly.
+        """
+        flow, entry = self._make_flow(data={"email": "x@y"})
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init(
+            {
+                "poll_interval": 60,
+                "use_pin_code": False,
+                "fcm_project_id": "proj",
+                "fcm_app_id": "app",
+                "fcm_api_key": "key",
+                "fcm_sender_id": "123",
+            }
+        )
+
+        flow.hass.config_entries.async_reload.assert_awaited_once_with("test-entry-id")
+
+    @pytest.mark.asyncio
+    async def test_options_flow_no_reload_when_data_unchanged(self) -> None:
+        """Non-FCM option tweaks (poll_interval, etc.) leave entry.data alone.
+
+        The existing `_async_options_update_listener` will still fire on
+        options changes — we only want to add a second reload when data
+        actually changed (the FCM-creds path). Otherwise users editing
+        the polling interval would trigger redundant reloads.
+        """
+        flow, entry = self._make_flow(data={"email": "x@y"})
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init({"poll_interval": 90, "use_pin_code": False})
+
+        # No data changes → async_update_entry should NOT be invoked,
+        # and our explicit async_reload should NOT fire.
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+        flow.hass.config_entries.async_reload.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_options_flow_clearing_fcm_also_strips_legacy_options(self) -> None:


### PR DESCRIPTION
## Summary

Reported by @ArshSoni in #148. After providing FCM credentials through Settings → Devices & Services → Aegis for Ajax → Configure, the "Push notifications" repair card cleared but real-time pushes (arm/disarm, doorbell, alarm) still didn't reach Home Assistant. Manual reload of the integration unblocked them.

Refs #148.

## Root cause

In `AjaxCobrandedOptionsFlow.async_step_init`, when only FCM credentials change (no other options touched):

1. `async_update_entry(entry, data=new_data)` → fires `_async_options_update_listener` task R1.
2. `async_create_entry(title="", data=user_input)` → framework's `async_finish_flow` calls `async_update_entry(entry, options=user_input)`. But `user_input` (after popping FCM keys) is identical to the prior `entry.options`, so this call short-circuits without firing a second listener.

R1 still runs and *should* reload, but the listener's `async_create_task` scheduling is racy with respect to the flow completing — there's a window where the FCM client hasn't been restarted with the new credentials, and apparently in practice that window doesn't close on its own.

## Fix

Mirror the repair-flow pattern (`FcmCredentialsRepairFlow.async_step_init` already does this): when `entry.data` actually changed, `await async_reload` explicitly before returning. Serialised on `entry.setup_lock` so racing with the listener-triggered reload is safe — at worst one redundant unload/setup cycle.

```python
if new_data != self._entry.data:
    self.hass.config_entries.async_update_entry(self._entry, data=new_data)
    await self.hass.config_entries.async_reload(self._entry.entry_id)  # ← new
return self.async_create_entry(title="", data=user_input)
```

The reload is gated on `data` actually changing, so non-FCM option tweaks (poll_interval, photo_retention_days, auto_create_labels…) still flow through the existing `_async_options_update_listener` path and only trigger one reload.

## Test plan

- [x] New `test_options_flow_reloads_when_data_changes` — asserts `async_reload` is awaited with the right `entry_id` after a FCM-credential update.
- [x] New `test_options_flow_no_reload_when_data_unchanged` — guards against over-reloading on poll-interval-only changes.
- [x] Existing FCM-credential tests still pass (helper updated to install AsyncMock for `async_reload`).
- [x] Full unit-test suite: 1258 passed, coverage 85.86%.
- [x] `ruff check`, `ruff format --check`, `mypy`, `vulture` clean in a freshly rebuilt Docker image (no volume mount).
- [ ] Live verification by reporter after `1.4.3` lands on HACS.

## Release target

`1.4.3` patch — pure bug fix, SemVer PATCH.