### PR TITLE
fix(binary_sensor): restore monitoring.cms_active as primary CRA signal

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -478,7 +478,18 @@ class AjaxProblemSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySenso
 
 
 class AjaxCraConnectionSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensorEntity):
-    """Binary sensor reporting whether the space has approved monitoring."""
+    """Live "Central receptora de alarmas → Conectada" status for a hub.
+
+    The Ajax mobile app renders that same row from `monitoring.cms_active`
+    on the hub's status snapshot — a real-time per-hub boolean of whether
+    the CMS channel is currently up. We keep `space.has_monitoring` as a
+    fallback for installs whose hub firmware doesn't emit `monitoring`
+    in its statuses (some older / cobranded firmwares), so the entity
+    still reflects "a monitoring company is on the account" in that path.
+
+    The diagnostic `sensor.<hub>_compania_cra` exposes the actual company
+    names + statuses for accounts that need to inspect approvals.
+    """
 
     _attr_has_entity_name = True
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
@@ -495,11 +506,21 @@ class AjaxCraConnectionSensor(CoordinatorEntity[AjaxCobrandedCoordinator], Binar
 
     @property
     def available(self) -> bool:
+        hub = self.coordinator.devices.get(self._hub_id)
+        # Primary signal is on the hub — available once we have a fresh
+        # snapshot that includes its `monitoring` status oneof. Fall back
+        # to the space-level snapshot for firmwares that don't emit it,
+        # avoiding a misleading `off` before either source has loaded.
+        if hub is not None and "monitoring_active" in hub.statuses:
+            return True
         space = self.coordinator.spaces.get(self._space_id)
         return space is not None and space.monitoring_companies_loaded
 
     @property
     def is_on(self) -> bool:
+        hub = self.coordinator.devices.get(self._hub_id)
+        if hub is not None and "monitoring_active" in hub.statuses:
+            return bool(hub.statuses["monitoring_active"])
         space = self.coordinator.spaces.get(self._space_id)
         return space.has_monitoring if space is not None else False
 

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -322,6 +322,60 @@ class TestAjaxCraConnectionSensor:
 
         assert sensor.available is False
 
+    def test_is_on_when_hub_reports_cms_active(self) -> None:
+        """Primary signal — matches the Ajax app's "Conectada" row (#?).
+
+        The hub's `monitoring.cms_active` flag is the same boolean the
+        mobile app surfaces on the "Central receptora de alarmas" row.
+        It takes priority over the (empty) `monitoring_companies` list:
+        cobranded installs (Protegim, AIKO, etc.) often have an active
+        CMS channel without an APPROVED company entry in the snapshot.
+        """
+        hub = replace(self._make_hub_device(), statuses={"monitoring_active": True})
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": hub}
+        coordinator.spaces = {"space-1": self._make_space(())}
+
+        sensor = AjaxCraConnectionSensor(coordinator, "space-1", "hub-1")
+
+        assert sensor.available is True
+        assert sensor.is_on is True
+
+    def test_is_off_when_hub_reports_cms_inactive(self) -> None:
+        """Hub-reported `cms_active=False` wins even with an approved company."""
+        hub = replace(self._make_hub_device(), statuses={"monitoring_active": False})
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": hub}
+        coordinator.spaces = {
+            "space-1": self._make_space(
+                (
+                    MonitoringCompany(
+                        name="Central One",
+                        status=MonitoringCompanyStatus.APPROVED,
+                    ),
+                )
+            )
+        }
+
+        sensor = AjaxCraConnectionSensor(coordinator, "space-1", "hub-1")
+
+        assert sensor.available is True
+        assert sensor.is_on is False
+
+    def test_available_via_hub_status_when_space_snapshot_not_loaded(self) -> None:
+        """Hub status is enough — don't gate availability on the space snapshot."""
+        hub = replace(self._make_hub_device(), statuses={"monitoring_active": True})
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": hub}
+        coordinator.spaces = {
+            "space-1": replace(self._make_space(()), monitoring_companies_loaded=False)
+        }
+
+        sensor = AjaxCraConnectionSensor(coordinator, "space-1", "hub-1")
+
+        assert sensor.available is True
+        assert sensor.is_on is True
+
 
 class TestDeviceTypeSensors:
     def test_glass_protect_s_in_device_types(self) -> None:


### PR DESCRIPTION
## Summary

Regression in PR #78 (commit 5699b8f, "Derive CRA status from monitoring companies"): `binary_sensor.<hub>_conexion_cra` switched from reading `hub.statuses["monitoring_active"]` (the real-time `monitoring.cms_active` boolean the Ajax mobile app surfaces on the "Central receptora de alarmas → Conectada" row) to deriving from `space.monitoring_companies` (approved CRA companies on the account). For cobranded installs and accounts without an explicit APPROVED company entry, the snapshot list comes back empty regardless of whether the hub is actively transmitting events to the CMS — the entity rendered `off` ("Desconectada") even with a healthy CMS channel.

Caught against bvis-home (`app_label=Protegim_alarma`):
- `hub.statuses["monitoring_active"] = True`
- `space.monitoring_companies = []`
- Ajax app shows "Conectada".
- Integration was showing "Desconectada".

## Fix

`AjaxCraConnectionSensor` now reads the hub status first and falls back to `space.has_monitoring` only when the hub firmware doesn't emit a `monitoring` status entry — which preserves the path PR #78 cared about (a firmware that doesn't surface `cms_active` but does have an APPROVED company on the account).

```python
if hub is not None and "monitoring_active" in hub.statuses:
    return bool(hub.statuses["monitoring_active"])
return space.has_monitoring if space is not None else False
```

The diagnostic `sensor.<hub>_compania_cra` (disabled by default) stays as-is — it exposes approved/pending CRA company names, which is the right surface for "who is the CRA on my account?" questions.

## Compat / migration

Zero impact:
- `unique_id` unchanged (`aegis_ajax_<hub_id>_monitoring_active`) — same entity_id, no migration.
- `translation_key` unchanged.
- `device_class=connectivity` unchanged.
- Only the value-derivation logic changes.

For users like @bogar (#78) whose hub doesn't emit `monitoring`: behaviour identical to today — falls back to the `monitoring_companies` path that landed in 5699b8f.

For users like the bvis-home / Protegim install: the entity flips from a misleading `off` to the correct real-time `on`.

## Test plan

- [x] Three new tests: `test_is_on_when_hub_reports_cms_active`, `test_is_off_when_hub_reports_cms_inactive`, `test_available_via_hub_status_when_space_snapshot_not_loaded`.
- [x] The original three tests stay (their fixture has `hub.statuses = {}`, so they implicitly exercise the fallback path).
- [x] Full suite: 1261 passed, 85.88% coverage.
- [x] `ruff check`, `ruff format --check`, `mypy`, `vulture` clean in a fresh Docker image.
- [x] Probe ran live against bvis-home: `monitoring_active=True`, matches the Ajax app's "Conectada" row.

## Release target

`1.4.4` patch — bug fix, SemVer PATCH.