### PR TITLE
feat(diag): explain duplicate-protobuf-descriptor failure on load

### DIFF
--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -8,21 +8,53 @@ from typing import TYPE_CHECKING
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 
-from custom_components.aegis_ajax.api.client import AjaxGrpcClient
-from custom_components.aegis_ajax.const import (
+_LOGGER = logging.getLogger(__name__)
+
+
+def _log_proto_descriptor_collision(exc: TypeError) -> None:
+    """Spell out a remediation when protobuf's descriptor pool collides (#151).
+
+    `_descriptor_pool.AddSerializedFile` raises
+    `TypeError("Couldn't build proto file into descriptor pool: duplicate
+    file name ...")` when two `_pb2.py` modules try to register the same
+    proto path in protobuf's global default pool — almost always a stale
+    copy of this integration in `custom_components/` (backup folder,
+    partial HACS update). HA's UI surfaces the bare TypeError as the
+    cryptic "Invalid handler specified", so we log the fix path before
+    re-raising. No-op for unrelated TypeErrors.
+    """
+    if "duplicate file name" not in str(exc):
+        return
+    _LOGGER.error(
+        "Aegis for Ajax failed to load: duplicate protobuf descriptors "
+        "detected (%s). This usually means there's a stale or backup copy "
+        "of the integration alongside the live one in custom_components/ "
+        "(any folder starting with 'aegis_ajax' other than the active "
+        "install will trip this). List custom_components/, move or rename "
+        "the extra folder so it no longer starts with 'aegis_ajax', and "
+        "restart Home Assistant. A clean uninstall + reinstall via HACS "
+        "also clears it.",
+        exc,
+    )
+
+
+try:
+    from custom_components.aegis_ajax.api.client import AjaxGrpcClient
+except TypeError as exc:
+    _log_proto_descriptor_collision(exc)
+    raise
+from custom_components.aegis_ajax.const import (  # noqa: E402
     CONF_AUTO_CREATE_LABELS,
     DEFAULT_AUTO_CREATE_LABELS,
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
     LABELS,
 )
-from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
-from custom_components.aegis_ajax.repairs import async_check_grpcio_version
+from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator  # noqa: E402
+from custom_components.aegis_ajax.repairs import async_check_grpcio_version  # noqa: E402
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
-
-_LOGGER = logging.getLogger(__name__)
 
 _FCM_KEYS = {"fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id"}
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -175,6 +175,40 @@ class TestAsyncSetupEntry:
         mock_client.session.set_session.assert_not_called()
 
 
+class TestProtoDescriptorCollisionGuard:
+    """#151 — surface a remediation hint when protobuf descriptor pool collides."""
+
+    def test_logs_remediation_for_duplicate_file_name(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging as _logging
+
+        from custom_components.aegis_ajax import _log_proto_descriptor_collision
+
+        exc = TypeError(
+            "Couldn't build proto file into descriptor pool: "
+            "duplicate file name systems/ajax/api/ecosystem/v2/hubsvc/"
+            "commonmodels/object_type.proto"
+        )
+        with caplog.at_level(_logging.ERROR, logger="custom_components.aegis_ajax"):
+            _log_proto_descriptor_collision(exc)
+
+        assert any("backup copy" in r.message for r in caplog.records), (
+            "remediation hint should mention the backup-folder scenario"
+        )
+        assert any("custom_components" in r.message for r in caplog.records)
+
+    def test_no_log_for_unrelated_typeerror(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging as _logging
+
+        from custom_components.aegis_ajax import _log_proto_descriptor_collision
+
+        with caplog.at_level(_logging.ERROR, logger="custom_components.aegis_ajax"):
+            _log_proto_descriptor_collision(TypeError("something else broke"))
+
+        assert not caplog.records, "guard should only fire for descriptor-pool collisions"
+
+
 class TestOptionsUpdateListener:
     @pytest.mark.asyncio
     async def test_options_change_triggers_reload(self) -> None:


### PR DESCRIPTION
## Summary

Reported by @mschev in #151: a fresh install of `1.4.3` raised "Invalid handler specified" in HA's UI, with the underlying log showing only a bare `TypeError: Couldn't build proto file into descriptor pool: duplicate file name systems/ajax/api/ecosystem/v2/hubsvc/commonmodels/object_type.proto`. Root cause is two `_pb2.py` modules trying to register the same proto path in protobuf's global default pool — almost always a stale or backup copy of this integration sitting next to the live one in `custom_components/`. The current UX leaves the user staring at a cryptic UI message with no hint at the fix.

Refs #151.

## Change

Wrap the first proto-triggering import in `__init__.py` with a narrow `try/except TypeError`; if the exception text contains "duplicate file name", log an `ERROR` that names the most likely cause and the remediation, then re-raise the original exception so HA's existing broken-integration handling is unchanged.

```python
try:
    from custom_components.aegis_ajax.api.client import AjaxGrpcClient
except TypeError as exc:
    _log_proto_descriptor_collision(exc)
    raise
```

The classification + log message live in a tiny helper `_log_proto_descriptor_collision`, which is what the tests exercise.

## Safety

- Narrow exception class (`TypeError`) — no behavioural change for `ImportError`, attribute errors, syntax errors, anything else.
- Inner string match (`"duplicate file name"`) — no spurious logs when an unrelated `TypeError` bubbles up from the import.
- Bare `raise` preserves the original traceback and HA's "integration broken" state.

## Test plan

- [x] `test_logs_remediation_for_duplicate_file_name` — asserts the ERROR log fires with the right hint when the descriptor-pool TypeError lands.
- [x] `test_no_log_for_unrelated_typeerror` — asserts the guard is a no-op for unrelated TypeErrors.
- [x] Full suite: 1263 passed, 85.84% coverage.
- [x] `ruff check`, `ruff format --check`, `mypy`, `vulture` clean in a freshly rebuilt Docker image (no volume mount).
- [ ] Live verification by @mschev after `1.4.5` lands on HACS, OR by simulating a duplicate folder locally.

## Release target

`1.4.5` patch — diagnostic improvement, SemVer PATCH.