### PR TITLE
fix(api): pin CLIENT_VERSION to 3.30 so Ajax keeps sending monitoring_companies

### DIFF
--- a/custom_components/aegis_ajax/api/hts/auth.py
+++ b/custom_components/aegis_ajax/api/hts/auth.py
@@ -62,9 +62,9 @@ def build_connect_request(
     device_id: str,
     app_label: str,
     client_os: str = "Android",
-    client_version: str = "3.46",
+    client_version: str = "3.30",
     connection_type: int = 5,
-    device_model: str = "SM-S921B",
+    device_model: str = "SM-A536B",
 ) -> bytes:
     """Build the TLV payload for a CONNECT_CLIENT_NEW message (msgType=0x11).
 
@@ -81,9 +81,9 @@ def build_connect_request(
         device_id:        Device identifier string.
         app_label:        Application label string.
         client_os:        OS name string (default "Android").
-        client_version:   App version string (default "3.46").
+        client_version:   App version string (default "3.30"; see const.CLIENT_VERSION).
         connection_type:  Connection type integer (default 5).
-        device_model:     Device model string (default "SM-S921B").
+        device_model:     Device model string (default "SM-A536B"; see const.CLIENT_DEVICE_MODEL).
 
     Returns:
         TLV-encoded payload bytes.

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -59,7 +59,13 @@ GRPC_HOST = "mobile-gw.prod.ajax.systems"
 GRPC_PORT = 443
 
 CLIENT_OS = "Android"
-CLIENT_VERSION = "3.46"
+# Pin to "3.30" — the Ajax server gates parts of the snapshot response on
+# `client-version-major`. Reporting a newer version (e.g. "3.46") causes the
+# server to omit `monitoring_companies` from `SpaceService.stream`, leaving
+# the CRA-company diagnostic sensor empty. Pinning to "3.30" restores the
+# legacy response shape. Bump only after verifying the modern endpoint that
+# replaces this data path.
+CLIENT_VERSION = "3.30"
 APPLICATION_LABEL = "Ajax"  # default (main Ajax app labelName)
 KNOWN_APP_LABELS = [
     "Ajax",
@@ -90,7 +96,7 @@ KNOWN_APP_LABELS = [
     "Protecta",
     "ajax_pro",
 ]
-CLIENT_DEVICE_MODEL = "SM-S921B"  # Generic Android model (Samsung Galaxy S24)
+CLIENT_DEVICE_MODEL = "SM-A536B"  # Galaxy A53 — paired with CLIENT_VERSION="3.30"
 CLIENT_DEVICE_TYPE = "MOBILE"
 CLIENT_APP_TYPE = "USER"
 


### PR DESCRIPTION
## Summary

- The Ajax server gates parts of the `SpaceService.stream` snapshot response on the `client-version-major` header. With `3.46` (set in 891bc49 to track the real Play Store version) it returns `monitoring_companies = []` and `installation_companies = []`, leaving the `sensor.<hub>_compania_cra` diagnostic entity stuck on `unknown` despite the Ajax app showing an approved CRA company. Pinning back to `3.30` brings the field through populated with no other regression. Refs #154.
- Moves `build_connect_request` defaults in `api/hts/auth.py` in lockstep so the over-the-wire client identification stays consistent across gRPC and HTS.
- Adds a docstring note pointing the next maintainer at `const.CLIENT_VERSION` and an inline comment in `const.py` explaining why this value isn't a free bump.

## Empirical verification

Reproduced live on a real install on 2026-05-18, same session token, same endpoint, same proto, same parser, same account:

| `client-version-major` | `SpaceService.stream.monitoring_companies` |
| --- | --- |
| `3.30` | 2 companies (status=APPROVED, `name` and `hex_id` populated) |
| `3.46` | 0 companies |

All other consumed endpoints continue to return the expected shape with `3.30`:

- `FindUserSpacesWithPaginationService.execute` — spaces, security state.
- `SpaceService.stream` — rooms, monitoring_companies, groups.
- `StreamLightDevices.execute` — devices snapshot.
- `HubObjectService.streamHubObject` — SIM info and pending firmware update.

## Test plan

- [x] `make check` inside a clean Docker image (no volume mount): `1263 passed`, coverage 85.84%, lint + format + typecheck + dead-code all green.
- [ ] Live verification on the reporter's install (#154) once 1.4.6 is on HACS: `sensor.<hub>_compania_cra` flips from `unknown` to the CRA company name on next snapshot refresh.
- [ ] No regression on the unrelated CRA-connection binary sensor — it still reads `monitoring.cms_active` from HTS independently.

## Follow-ups

- The HTS `build_connect_request` defaults are still hardcoded literals. Importing them from `const.py` directly would prevent the same desync that happened between 891bc49 and this fix.
- Future `CLIENT_VERSION` bumps must probe every consumed endpoint against the new value before merging — the server can silently drop fields without any status-code change.