### PR TITLE
feat(services): aegis_ajax.set_photo_on_demand_mode service

### DIFF
--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -180,6 +180,41 @@ async def _async_handle_press_panic_button(hass: HomeAssistant, call: ServiceCal
         )
 
 
+async def _async_handle_set_photo_on_demand_mode(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Handle the set_photo_on_demand_mode service call.
+
+    Toggles the hub-wide Photo on Demand mode that gates camera-equipped
+    devices from delivering on-demand snapshots. Two independent channels:
+    `user` (whether hub users can request photos) and `scenario` (whether
+    scenarios/automations can trigger captures). At least one must be
+    provided; the other is left untouched.
+    """
+    from homeassistant.exceptions import ServiceValidationError  # noqa: PLC0415
+
+    user_enabled = call.data.get("user")
+    scenario_enabled = call.data.get("scenario")
+    if user_enabled is None and scenario_enabled is None:
+        raise ServiceValidationError(
+            "set_photo_on_demand_mode requires at least one of `user` or `scenario`."
+        )
+
+    targets = _resolve_target_space_ids(hass, call)
+    if not targets:
+        raise ServiceValidationError(
+            "set_photo_on_demand_mode: no Aegis alarm panel found for the given target."
+        )
+
+    for coordinator, space_id in targets:
+        space = coordinator.spaces.get(space_id)
+        if space is None or not space.hub_id:
+            continue
+        await coordinator.devices_api.set_photo_on_demand_mode(
+            space.hub_id,
+            user_enabled=user_enabled,
+            scenario_enabled=scenario_enabled,
+        )
+
+
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate config entry to newer version."""
     if entry.version == 1:
@@ -340,10 +375,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
     async def _press_panic_button_handler(call: ServiceCall) -> None:
         await _async_handle_press_panic_button(hass, call)
 
+    async def _set_photo_on_demand_mode_handler(call: ServiceCall) -> None:
+        await _async_handle_set_photo_on_demand_mode(hass, call)
+
     if not hass.services.has_service(DOMAIN, "force_arm"):
         hass.services.async_register(DOMAIN, "force_arm", _force_arm_handler)
         hass.services.async_register(DOMAIN, "force_arm_night", _force_arm_night_handler)
         hass.services.async_register(DOMAIN, "press_panic_button", _press_panic_button_handler)
+        hass.services.async_register(
+            DOMAIN, "set_photo_on_demand_mode", _set_photo_on_demand_mode_handler
+        )
 
     # Reload integration when options change (e.g. FCM credentials)
     entry.async_on_unload(entry.add_update_listener(_async_options_update_listener))

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -891,3 +891,75 @@ class DevicesApi:
         except Exception:
             _LOGGER.exception("Error capturing photo for %s", device_id)
             return None
+
+    async def set_photo_on_demand_mode(
+        self,
+        hub_id: str,
+        *,
+        user_enabled: bool | None = None,
+        scenario_enabled: bool | None = None,
+    ) -> None:
+        """Toggle hub-wide Photo on Demand mode (user and/or scenario channels).
+
+        The request proto's two switches live in a oneof, so a single RPC
+        only flips one of them; we issue one call per provided argument.
+        At least one of `user_enabled` / `scenario_enabled` is required.
+        Idempotent: re-sending the current value succeeds without error.
+        """
+        if user_enabled is None and scenario_enabled is None:
+            raise DeviceCommandError(
+                "set_photo_on_demand_mode requires user_enabled and/or scenario_enabled"
+            )
+
+        from v3.mobilegwsvc.service.device_command_photo_on_demand_mode import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.DeviceCommandPhotoOnDemandModeServiceStub(channel)
+        request_cls = request_pb2.DeviceCommandPhotoOnDemandModeRequest
+        user_modes = request_cls.PhotoOnDemandModeUser
+        scenario_modes = request_cls.PhotoOnDemandModeScenario
+
+        calls: list[tuple[str, request_pb2.DeviceCommandPhotoOnDemandModeRequest]] = []
+        if user_enabled is not None:
+            calls.append(
+                (
+                    "user",
+                    request_cls(
+                        hub_id=hub_id,
+                        photo_on_demand_mode_user=(
+                            user_modes.PHOTO_ON_DEMAND_MODE_USER_ENABLE
+                            if user_enabled
+                            else user_modes.PHOTO_ON_DEMAND_MODE_USER_DISABLE
+                        ),
+                    ),
+                )
+            )
+        if scenario_enabled is not None:
+            calls.append(
+                (
+                    "scenario",
+                    request_cls(
+                        hub_id=hub_id,
+                        photo_on_demand_mode_scenario=(
+                            scenario_modes.PHOTO_ON_DEMAND_MODE_SCENARIO_ENABLE
+                            if scenario_enabled
+                            else scenario_modes.PHOTO_ON_DEMAND_MODE_SCENARIO_DISABLE
+                        ),
+                    ),
+                )
+            )
+
+        for label, request in calls:
+            response = await stub.execute(request, metadata=metadata, timeout=15)
+            if response.HasField("failure"):
+                error = response.failure.WhichOneof("error") or "unknown"
+                raise DeviceCommandError(f"photo_on_demand_mode {label}: {error}")
+            _LOGGER.debug(
+                "Hub %s photo_on_demand_mode.%s set OK",
+                hub_id,
+                label,
+            )

--- a/custom_components/aegis_ajax/services.yaml
+++ b/custom_components/aegis_ajax/services.yaml
@@ -91,3 +91,44 @@ press_panic_button:
           max: 180
           step: any
           mode: box
+
+set_photo_on_demand_mode:
+  name: Set Photo on Demand mode
+  description: >-
+    Enable or disable Photo on Demand mode on a hub. Two independent
+    channels can be toggled separately — `user` (whether hub users can
+    request photos on demand from the Ajax app) and `scenario` (whether
+    scenarios / automations can trigger captures). Leave a field unset to
+    keep its current value. At least one of the two is required.
+  target:
+    entity:
+      domain: alarm_control_panel
+      integration: aegis_ajax
+  fields:
+    user:
+      name: User requests
+      description: >-
+        When set, enables or disables on-demand photo requests initiated
+        by hub users. Leave unset to keep the current value.
+      required: false
+      selector:
+        boolean:
+    scenario:
+      name: Scenarios
+      description: >-
+        When set, enables or disables Photo on Demand captures triggered
+        by Ajax scenarios / automations. Leave unset to keep the current
+        value.
+      required: false
+      selector:
+        boolean:
+    entity_id:
+      name: Entity
+      description: >-
+        Alarm panel entity for the space whose hub mode to update. If
+        omitted, applies to every configured space.
+      required: false
+      selector:
+        entity:
+          domain: alarm_control_panel
+          integration: aegis_ajax

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -143,6 +143,24 @@
                     "description": "Optional caller longitude forwarded to Ajax. Use with latitude."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -144,6 +144,24 @@
                     "description": "Longitud opcional de qui truca, reenviada a Ajax. Usa-la amb latitud."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -144,6 +144,24 @@
                     "description": "Volitelná zeměpisná délka volajícího předávaná Ajaxu. Použijte společně se šířkou."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -144,6 +144,24 @@
                     "description": "Optionaler Längengrad des Anrufers, der an Ajax weitergegeben wird. Mit Breitengrad verwenden."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -144,6 +144,24 @@
                     "description": "Optional caller longitude forwarded to Ajax. Use with latitude."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -144,6 +144,24 @@
                     "description": "Longitud opcional de quien llama, reenviada a Ajax. Úsala junto con latitud."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Configurar modo Foto bajo demanda",
+            "description": "Activa o desactiva el modo Foto bajo demanda en un hub. Dos canales independientes que se pueden alternar por separado: peticiones de usuario (si los usuarios del hub pueden pedir fotos desde la app Ajax) y escenarios (si los escenarios / automatizaciones pueden disparar capturas). Deja un campo sin valor para mantener su estado actual. Al menos uno de los dos es obligatorio.",
+            "fields": {
+                "user": {
+                    "name": "Peticiones de usuario",
+                    "description": "Si está marcado, activa o desactiva las peticiones de foto bajo demanda iniciadas por los usuarios del hub. Déjalo sin valor para mantener el estado actual."
+                },
+                "scenario": {
+                    "name": "Escenarios",
+                    "description": "Si está marcado, activa o desactiva las capturas Foto bajo demanda disparadas por escenarios / automatizaciones de Ajax. Déjalo sin valor para mantener el estado actual."
+                },
+                "entity_id": {
+                    "name": "Entidad",
+                    "description": "Entidad del panel de alarma del espacio cuyo modo de hub actualizar. Si se omite, se aplica a todos los espacios configurados."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -144,6 +144,24 @@
                     "description": "Longitude facultative de l'appelant transmise à Ajax. À utiliser avec la latitude."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -144,6 +144,24 @@
                     "description": "Longitudine opzionale del chiamante inoltrata ad Ajax. Da usare con la latitudine."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -144,6 +144,24 @@
                     "description": "Optionele lengtegraad van de melder, doorgegeven aan Ajax. Gebruik samen met breedtegraad."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -144,6 +144,24 @@
                     "description": "Opcjonalna długość geograficzna osoby dzwoniącej przekazywana do Ajax. Używaj razem z szerokością."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -144,6 +144,24 @@
                     "description": "Longitude opcional do solicitante encaminhada para a Ajax. Use junto com a latitude."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -144,6 +144,24 @@
                     "description": "Longitude opcional do utilizador encaminhada para a Ajax. Usa em conjunto com a latitude."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -144,6 +144,24 @@
                     "description": "Longitudine opțională a apelantului transmisă către Ajax. Folosiți împreună cu latitudinea."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -144,6 +144,24 @@
                     "description": "Çağrı yapanın isteğe bağlı boylamı Ajax'a iletilir. Enlemle birlikte kullanın."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -144,6 +144,24 @@
                     "description": "Необов'язкова довгота абонента, передана Ajax. Використовуйте разом із широтою."
                 }
             }
+        },
+        "set_photo_on_demand_mode": {
+            "name": "Set Photo on Demand mode",
+            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "fields": {
+                "user": {
+                    "name": "User requests",
+                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                },
+                "scenario": {
+                    "name": "Scenarios",
+                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                },
+                "entity_id": {
+                    "name": "Entity",
+                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                }
+            }
         }
     },
     "issues": {

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -2030,3 +2030,100 @@ class TestCapturePhotoV2:
         idx = request.find(b"\x18")
         assert idx != -1
         assert request[idx + 1] == 2  # device type 2 for outdoor
+
+
+class TestSetPhotoOnDemandMode:
+    """Tests for DevicesApi.set_photo_on_demand_mode (DeviceCommandPhotoOnDemandModeService)."""
+
+    def _make_api(self) -> DevicesApi:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+        return DevicesApi(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_requires_at_least_one_channel(self) -> None:
+        """Calling without either argument raises DeviceCommandError."""
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        api = self._make_api()
+        with pytest.raises(DeviceCommandError, match="user_enabled"):
+            await api.set_photo_on_demand_mode("hub-1")
+
+    @pytest.mark.asyncio
+    async def test_user_only_sends_single_call(self) -> None:
+        """Setting only user_enabled fires exactly one gRPC execute."""
+        api = self._make_api()
+        stub = MagicMock()
+        stub.execute = AsyncMock(return_value=MagicMock(HasField=MagicMock(return_value=False)))
+
+        with patch(
+            "v3.mobilegwsvc.service.device_command_photo_on_demand_mode.endpoint_pb2_grpc.DeviceCommandPhotoOnDemandModeServiceStub",
+            return_value=stub,
+        ):
+            await api.set_photo_on_demand_mode("hub-XYZ", user_enabled=True)
+
+        assert stub.execute.await_count == 1
+        sent = stub.execute.await_args_list[0].args[0]
+        assert sent.hub_id == "hub-XYZ"
+        # USER_ENABLE = 2; field name on the oneof tracks WhichOneof:
+        assert sent.WhichOneof("additional_param") == "photo_on_demand_mode_user"
+        assert sent.photo_on_demand_mode_user == 2
+
+    @pytest.mark.asyncio
+    async def test_scenario_disable_sends_correct_enum(self) -> None:
+        api = self._make_api()
+        stub = MagicMock()
+        stub.execute = AsyncMock(return_value=MagicMock(HasField=MagicMock(return_value=False)))
+
+        with patch(
+            "v3.mobilegwsvc.service.device_command_photo_on_demand_mode.endpoint_pb2_grpc.DeviceCommandPhotoOnDemandModeServiceStub",
+            return_value=stub,
+        ):
+            await api.set_photo_on_demand_mode("hub-1", scenario_enabled=False)
+
+        sent = stub.execute.await_args_list[0].args[0]
+        assert sent.WhichOneof("additional_param") == "photo_on_demand_mode_scenario"
+        # SCENARIO_DISABLE = 1
+        assert sent.photo_on_demand_mode_scenario == 1
+
+    @pytest.mark.asyncio
+    async def test_both_channels_send_two_calls(self) -> None:
+        api = self._make_api()
+        stub = MagicMock()
+        stub.execute = AsyncMock(return_value=MagicMock(HasField=MagicMock(return_value=False)))
+
+        with patch(
+            "v3.mobilegwsvc.service.device_command_photo_on_demand_mode.endpoint_pb2_grpc.DeviceCommandPhotoOnDemandModeServiceStub",
+            return_value=stub,
+        ):
+            await api.set_photo_on_demand_mode("hub-1", user_enabled=True, scenario_enabled=True)
+
+        assert stub.execute.await_count == 2
+        sent_oneofs = [
+            call.args[0].WhichOneof("additional_param") for call in stub.execute.await_args_list
+        ]
+        assert sent_oneofs == ["photo_on_demand_mode_user", "photo_on_demand_mode_scenario"]
+
+    @pytest.mark.asyncio
+    async def test_failure_response_raises(self) -> None:
+        """A gRPC response with .failure set raises DeviceCommandError with the error name."""
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        api = self._make_api()
+        failure = MagicMock()
+        failure.WhichOneof.return_value = "bad_request"
+        response = MagicMock()
+        response.HasField.return_value = True
+        response.failure = failure
+        stub = MagicMock()
+        stub.execute = AsyncMock(return_value=response)
+
+        with (
+            patch(
+                "v3.mobilegwsvc.service.device_command_photo_on_demand_mode.endpoint_pb2_grpc.DeviceCommandPhotoOnDemandModeServiceStub",
+                return_value=stub,
+            ),
+            pytest.raises(DeviceCommandError, match="user.*bad_request"),
+        ):
+            await api.set_photo_on_demand_mode("hub-1", user_enabled=True)

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -708,3 +708,74 @@ class TestAsyncRemoveEntry:
             await async_remove_entry(hass, entry)
 
         mock_client.logout.assert_not_called()
+
+
+class TestSetPhotoOnDemandModeHandler:
+    """Verify guards + dispatch of _async_handle_set_photo_on_demand_mode."""
+
+    def _make_call(self, data: dict) -> MagicMock:
+        call = MagicMock()
+        call.data = data
+        return call
+
+    @pytest.mark.asyncio
+    async def test_missing_both_channels_raises(self) -> None:
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.aegis_ajax import _async_handle_set_photo_on_demand_mode
+
+        hass = MagicMock()
+        with pytest.raises(ServiceValidationError, match="`user`.*`scenario`"):
+            await _async_handle_set_photo_on_demand_mode(hass, self._make_call({}))
+
+    @pytest.mark.asyncio
+    async def test_no_target_raises(self) -> None:
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.aegis_ajax import _async_handle_set_photo_on_demand_mode
+
+        with patch(
+            "custom_components.aegis_ajax._resolve_target_space_ids",
+            return_value=[],
+        ):
+            hass = MagicMock()
+            with pytest.raises(ServiceValidationError, match="no Aegis alarm panel"):
+                await _async_handle_set_photo_on_demand_mode(hass, self._make_call({"user": True}))
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_devices_api(self) -> None:
+        from custom_components.aegis_ajax import _async_handle_set_photo_on_demand_mode
+
+        coordinator = MagicMock()
+        coordinator.devices_api.set_photo_on_demand_mode = AsyncMock()
+        coordinator.spaces = {"space-1": MagicMock(hub_id="HUB-A")}
+
+        with patch(
+            "custom_components.aegis_ajax._resolve_target_space_ids",
+            return_value=[(coordinator, "space-1")],
+        ):
+            hass = MagicMock()
+            await _async_handle_set_photo_on_demand_mode(
+                hass, self._make_call({"user": True, "scenario": False})
+            )
+
+        coordinator.devices_api.set_photo_on_demand_mode.assert_awaited_once_with(
+            "HUB-A", user_enabled=True, scenario_enabled=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_targets_without_hub_id(self) -> None:
+        from custom_components.aegis_ajax import _async_handle_set_photo_on_demand_mode
+
+        coordinator = MagicMock()
+        coordinator.devices_api.set_photo_on_demand_mode = AsyncMock()
+        coordinator.spaces = {"space-1": MagicMock(hub_id="")}
+
+        with patch(
+            "custom_components.aegis_ajax._resolve_target_space_ids",
+            return_value=[(coordinator, "space-1")],
+        ):
+            hass = MagicMock()
+            await _async_handle_set_photo_on_demand_mode(hass, self._make_call({"user": True}))
+
+        coordinator.devices_api.set_photo_on_demand_mode.assert_not_called()


### PR DESCRIPTION
## Summary

New service `aegis_ajax.set_photo_on_demand_mode` to toggle a hub's Photo on Demand mode from automations / scripts / the developer-tools panel.

The Ajax backend exposes two independent toggles for this mode:

- `user` — whether users of the hub can request photos on demand from the Ajax mobile app.
- `scenario` — whether scenarios / automations can trigger Photo on Demand captures.

Both fields are optional; at least one must be supplied. Omitted fields leave the current value untouched. The service can target one or more `alarm_control_panel` entities, or every configured space when no target is given.

Implementation goes through the existing `DevicesApi` (new `set_photo_on_demand_mode` method) and hits `DeviceCommandPhotoOnDemandModeService.execute` on the gRPC backend; the call is idempotent.

## Test plan

- [x] Unit tests for the API method and the service handler (9 new tests; full suite at 1272).
- [x] `make check` in a clean Docker image (no volume mount).
- [ ] Live: toggle from developer-tools → services on a real install and confirm the Ajax mobile app reflects the new mode.