### PR TITLE
feat(api): resolve CRA company names via SpaceMonitoringCompanyService.getMonitoringCompany

### DIFF
--- a/custom_components/aegis_ajax/api/models.py
+++ b/custom_components/aegis_ajax/api/models.py
@@ -24,10 +24,19 @@ class MonitoringCompanyStatus(IntEnum):
 
 @dataclass(frozen=True)
 class MonitoringCompany:
-    """Represents a monitoring company attached to a space."""
+    """Represents a monitoring company attached to a space.
+
+    `hex_id` is the stable per-company opaque identifier the Ajax cloud uses
+    to address this company on every endpoint that returns or accepts a
+    `SpaceMonitoringCompany`. Kept alongside `name` so the integration can
+    resolve a missing name through `SpaceMonitoringCompanyService.getMonitoringCompany`
+    when the space-stream snapshot only ships `(hex_id, status)` without a
+    name attached.
+    """
 
     name: str
     status: MonitoringCompanyStatus
+    hex_id: str = ""
 
 
 @dataclass(frozen=True)

--- a/custom_components/aegis_ajax/api/spaces.py
+++ b/custom_components/aegis_ajax/api/spaces.py
@@ -101,17 +101,69 @@ class SpacesApi:
     @staticmethod
     def parse_monitoring_company(proto_company: Any) -> MonitoringCompany:  # noqa: ANN401
         name = ""
-        if hasattr(proto_company, "company_info") and hasattr(proto_company.company_info, "name"):
-            raw_name = proto_company.company_info.name
-            if isinstance(raw_name, str):
-                name = raw_name
-            elif hasattr(raw_name, "value") and isinstance(raw_name.value, str):
-                name = raw_name.value
+        hex_id = ""
+        if hasattr(proto_company, "company_info"):
+            company_info = proto_company.company_info
+            if hasattr(company_info, "name"):
+                raw_name = company_info.name
+                if isinstance(raw_name, str):
+                    name = raw_name
+                elif hasattr(raw_name, "value") and isinstance(raw_name.value, str):
+                    name = raw_name.value
+            if hasattr(company_info, "hex_id") and isinstance(company_info.hex_id, str):
+                hex_id = company_info.hex_id
         try:
             status = MonitoringCompanyStatus(proto_company.status)
         except ValueError:
             status = MonitoringCompanyStatus.UNSPECIFIED
-        return MonitoringCompany(name=name, status=status)
+        return MonitoringCompany(name=name, status=status, hex_id=hex_id)
+
+    async def get_monitoring_company(
+        self, space_id: str, company_hex_id: str
+    ) -> MonitoringCompany | None:
+        """Resolve a CRA company's full record by `(space_id, company_hex_id)`.
+
+        Wraps `SpaceMonitoringCompanyService.getMonitoringCompany`. Returns
+        a `MonitoringCompany` on success, `None` on a `failure` response or
+        any RPC error — callers should be ready to treat the lookup as
+        best-effort. Used as a fallback by `get_space_snapshot` when the
+        stream-level snapshot only carries `hex_id` without a populated
+        `name` (the modern client-version response shape).
+        """
+        from systems.ajax.api.mobile.v2.space.company.monitoring import (  # noqa: PLC0415
+            get_monitoring_company_request_pb2,
+            space_monitoring_company_endpoints_pb2_grpc,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = space_monitoring_company_endpoints_pb2_grpc.SpaceMonitoringCompanyServiceStub(
+            channel
+        )
+        request = get_monitoring_company_request_pb2.GetMonitoringCompanyRequest(
+            company_hex_id=company_hex_id,
+            space_id=space_id,
+        )
+        try:
+            response = await stub.getMonitoringCompany(request, metadata=metadata, timeout=15)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "getMonitoringCompany RPC failed for space %s hex_id %s",
+                space_id,
+                company_hex_id,
+                exc_info=True,
+            )
+            return None
+        which = response.WhichOneof("response") if hasattr(response, "WhichOneof") else None
+        if which != "success":
+            _LOGGER.debug(
+                "getMonitoringCompany returned non-success (%s) for space %s hex_id %s",
+                which,
+                space_id,
+                company_hex_id,
+            )
+            return None
+        return self.parse_monitoring_company(response.success.company)
 
     async def list_spaces(self) -> list[Space]:
         from v3.mobilegwsvc.service.find_user_spaces_with_pagination import (  # noqa: PLC0415
@@ -182,6 +234,16 @@ class SpacesApi:
             if callable(cancel):
                 cancel()
 
+        # Best-effort name resolution for companies that arrived with an
+        # empty name field but a usable hex_id — happens on modern client
+        # versions where the legacy `monitoring_companies` slot ships the
+        # tuple `(hex_id, status)` without an attached name. Falls back to
+        # the original record on any RPC failure so the snapshot still
+        # surfaces the company by its known status.
+        monitoring_companies = [
+            await self._resolve_company_name(space_id, company) for company in monitoring_companies
+        ]
+
         return SpaceSnapshot(
             rooms=tuple(rooms),
             monitoring_companies=tuple(monitoring_companies),
@@ -189,6 +251,28 @@ class SpacesApi:
             groups=groups,
             group_mode_enabled=group_mode_enabled,
         )
+
+    async def _resolve_company_name(
+        self, space_id: str, company: MonitoringCompany
+    ) -> MonitoringCompany:
+        """Fill in `company.name` via `getMonitoringCompany` when missing.
+
+        No-op when `name` is already populated or `hex_id` is empty. Returns
+        the original `company` if the resolver returns `None` (RPC failure
+        or backend `failure` response) so callers always have a usable
+        record.
+        """
+        if company.name or not company.hex_id:
+            return company
+        resolved = await self.get_monitoring_company(space_id, company.hex_id)
+        if resolved is None or not resolved.name:
+            return company
+        # Trust the resolver's name; keep the snapshot's status (the stream
+        # is the authoritative state source, the lookup may return cached
+        # data on the company-tenancy side).
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        return dc_replace(company, name=resolved.name)
 
     async def list_rooms(self, space_id: str) -> list[Room]:
         """Return the rooms defined in the given space."""

--- a/tests/unit/test_spaces.py
+++ b/tests/unit/test_spaces.py
@@ -572,3 +572,312 @@ class TestPressPanicButton:
             pytest.raises(RuntimeError, match="permissions_denied"),
         ):
             await api.press_panic_button("space-1")
+
+
+_GET_MONITORING_REQ = (
+    "systems.ajax.api.mobile.v2.space.company.monitoring.get_monitoring_company_request_pb2"
+)
+_GET_MONITORING_GRPC = (
+    "systems.ajax.api.mobile.v2.space.company.monitoring"
+    ".space_monitoring_company_endpoints_pb2_grpc"
+)
+
+
+class TestParseMonitoringCompanyHexId:
+    def test_extracts_hex_id_when_present(self) -> None:
+        proto_company = MagicMock()
+        proto_company.company_info.name = "Central One"
+        proto_company.company_info.hex_id = "AABBDC47"
+        proto_company.status = 2
+
+        result = SpacesApi.parse_monitoring_company(proto_company)
+
+        assert result.hex_id == "AABBDC47"
+        assert result.name == "Central One"
+
+    def test_hex_id_defaults_to_empty_when_field_absent(self) -> None:
+        proto_company = MagicMock(spec=["company_info", "status"])
+        proto_company.company_info = MagicMock(spec=["name"])
+        proto_company.company_info.name = "Central"
+        proto_company.status = 2
+
+        result = SpacesApi.parse_monitoring_company(proto_company)
+
+        assert result.hex_id == ""
+
+
+class TestGetMonitoringCompany:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_company_on_success(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        proto_company = MagicMock()
+        proto_company.company_info.name = "EXPANSIVA"
+        proto_company.company_info.hex_id = "0000016A"
+        proto_company.status = 2
+
+        success_response = MagicMock()
+        success_response.WhichOneof.return_value = "success"
+        success_response.success.company = proto_company
+
+        stub_instance = MagicMock()
+        stub_instance.getMonitoringCompany = AsyncMock(return_value=success_response)
+
+        request_pb2 = MagicMock()
+        grpc_module = MagicMock(
+            SpaceMonitoringCompanyServiceStub=MagicMock(return_value=stub_instance)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _GET_MONITORING_REQ: request_pb2,
+                _GET_MONITORING_GRPC: grpc_module,
+            },
+        ):
+            result = await api.get_monitoring_company("space-1", "0000016A")
+
+        assert result is not None
+        assert result.name == "EXPANSIVA"
+        assert result.hex_id == "0000016A"
+        assert result.status == MonitoringCompanyStatus.APPROVED
+
+        # Verify the request that was sent (request was built from the patched module)
+        stub_instance.getMonitoringCompany.assert_awaited_once()
+        assert request_pb2.GetMonitoringCompanyRequest.call_args.kwargs == {
+            "company_hex_id": "0000016A",
+            "space_id": "space-1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_failure_response(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        failure_response = MagicMock()
+        failure_response.WhichOneof.return_value = "failure"
+
+        stub_instance = MagicMock()
+        stub_instance.getMonitoringCompany = AsyncMock(return_value=failure_response)
+
+        request_pb2 = MagicMock()
+        grpc_module = MagicMock(
+            SpaceMonitoringCompanyServiceStub=MagicMock(return_value=stub_instance)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _GET_MONITORING_REQ: request_pb2,
+                _GET_MONITORING_GRPC: grpc_module,
+            },
+        ):
+            result = await api.get_monitoring_company("space-1", "00000000")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_rpc_exception(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        stub_instance = MagicMock()
+        stub_instance.getMonitoringCompany = AsyncMock(side_effect=RuntimeError("boom"))
+
+        request_pb2 = MagicMock()
+        grpc_module = MagicMock(
+            SpaceMonitoringCompanyServiceStub=MagicMock(return_value=stub_instance)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _GET_MONITORING_REQ: request_pb2,
+                _GET_MONITORING_GRPC: grpc_module,
+            },
+        ):
+            result = await api.get_monitoring_company("space-1", "any")
+
+        assert result is None
+
+
+class TestGetSpaceSnapshotResolvesMissingNames:
+    """get_space_snapshot fills empty names via getMonitoringCompany."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_missing_name_when_hex_id_present(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        # Company arrived with empty name but a hex_id — the modern shape.
+        unresolved = MagicMock()
+        unresolved.company_info.name = ""
+        unresolved.company_info.hex_id = "0000016A"
+        unresolved.status = 2
+
+        snapshot_msg = MagicMock()
+        snapshot_msg.HasField.side_effect = lambda f: f == "success"
+        snapshot_msg.success.WhichOneof.return_value = "snapshot"
+        snapshot_msg.success.snapshot.rooms = []
+        snapshot_msg.success.snapshot.monitoring_companies = [unresolved]
+
+        stream = _async_iter([snapshot_msg])
+        space_stub = MagicMock()
+        space_stub.stream = MagicMock(return_value=stream)
+
+        # The resolver's response — fully populated company.
+        resolved_proto = MagicMock()
+        resolved_proto.company_info.name = "EXPANSIVA"
+        resolved_proto.company_info.hex_id = "0000016A"
+        resolved_proto.status = 2
+
+        resolve_response = MagicMock()
+        resolve_response.WhichOneof.return_value = "success"
+        resolve_response.success.company = resolved_proto
+
+        monitoring_stub = MagicMock()
+        monitoring_stub.getMonitoringCompany = AsyncMock(return_value=resolve_response)
+
+        stream_request_pb2 = MagicMock()
+        space_grpc = MagicMock(SpaceServiceStub=MagicMock(return_value=space_stub))
+        locator_pb2 = MagicMock()
+
+        get_monitoring_req_pb2 = MagicMock()
+        get_monitoring_grpc = MagicMock(
+            SpaceMonitoringCompanyServiceStub=MagicMock(return_value=monitoring_stub)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _STREAM_SPACE_REQUEST: stream_request_pb2,
+                _SPACE_GRPC: space_grpc,
+                _SPACE_LOCATOR: locator_pb2,
+                _GET_MONITORING_REQ: get_monitoring_req_pb2,
+                _GET_MONITORING_GRPC: get_monitoring_grpc,
+            },
+        ):
+            snapshot = await api.get_space_snapshot("space-1")
+
+        # The resolver fired exactly once and the resulting snapshot has the name.
+        monitoring_stub.getMonitoringCompany.assert_awaited_once()
+        assert snapshot.monitoring_companies[0].name == "EXPANSIVA"
+        assert snapshot.monitoring_companies[0].hex_id == "0000016A"
+        # Status from the snapshot stream wins (authoritative state source).
+        assert snapshot.monitoring_companies[0].status == MonitoringCompanyStatus.APPROVED
+
+    @pytest.mark.asyncio
+    async def test_skips_resolver_when_name_already_present(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        populated = MagicMock()
+        populated.company_info.name = "Already Named"
+        populated.company_info.hex_id = "AABBCCDD"
+        populated.status = 2
+
+        snapshot_msg = MagicMock()
+        snapshot_msg.HasField.side_effect = lambda f: f == "success"
+        snapshot_msg.success.WhichOneof.return_value = "snapshot"
+        snapshot_msg.success.snapshot.rooms = []
+        snapshot_msg.success.snapshot.monitoring_companies = [populated]
+
+        stream = _async_iter([snapshot_msg])
+        space_stub = MagicMock()
+        space_stub.stream = MagicMock(return_value=stream)
+
+        monitoring_stub = MagicMock()
+        monitoring_stub.getMonitoringCompany = AsyncMock()
+
+        stream_request_pb2 = MagicMock()
+        space_grpc = MagicMock(SpaceServiceStub=MagicMock(return_value=space_stub))
+        locator_pb2 = MagicMock()
+        get_monitoring_req_pb2 = MagicMock()
+        get_monitoring_grpc = MagicMock(
+            SpaceMonitoringCompanyServiceStub=MagicMock(return_value=monitoring_stub)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _STREAM_SPACE_REQUEST: stream_request_pb2,
+                _SPACE_GRPC: space_grpc,
+                _SPACE_LOCATOR: locator_pb2,
+                _GET_MONITORING_REQ: get_monitoring_req_pb2,
+                _GET_MONITORING_GRPC: get_monitoring_grpc,
+            },
+        ):
+            snapshot = await api.get_space_snapshot("space-1")
+
+        monitoring_stub.getMonitoringCompany.assert_not_called()
+        assert snapshot.monitoring_companies[0].name == "Already Named"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_original_record_when_resolver_returns_none(self) -> None:
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+
+        api = SpacesApi(mock_client)
+
+        unresolved = MagicMock()
+        unresolved.company_info.name = ""
+        unresolved.company_info.hex_id = "DEADBEEF"
+        unresolved.status = 1
+
+        snapshot_msg = MagicMock()
+        snapshot_msg.HasField.side_effect = lambda f: f == "success"
+        snapshot_msg.success.WhichOneof.return_value = "snapshot"
+        snapshot_msg.success.snapshot.rooms = []
+        snapshot_msg.success.snapshot.monitoring_companies = [unresolved]
+
+        stream = _async_iter([snapshot_msg])
+        space_stub = MagicMock()
+        space_stub.stream = MagicMock(return_value=stream)
+
+        failure_response = MagicMock()
+        failure_response.WhichOneof.return_value = "failure"
+
+        monitoring_stub = MagicMock()
+        monitoring_stub.getMonitoringCompany = AsyncMock(return_value=failure_response)
+
+        stream_request_pb2 = MagicMock()
+        space_grpc = MagicMock(SpaceServiceStub=MagicMock(return_value=space_stub))
+        locator_pb2 = MagicMock()
+        get_monitoring_req_pb2 = MagicMock()
+        get_monitoring_grpc = MagicMock(
+            SpaceMonitoringCompanyServiceStub=MagicMock(return_value=monitoring_stub)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _STREAM_SPACE_REQUEST: stream_request_pb2,
+                _SPACE_GRPC: space_grpc,
+                _SPACE_LOCATOR: locator_pb2,
+                _GET_MONITORING_REQ: get_monitoring_req_pb2,
+                _GET_MONITORING_GRPC: get_monitoring_grpc,
+            },
+        ):
+            snapshot = await api.get_space_snapshot("space-1")
+
+        # Name stays empty (resolver failed), hex_id + status preserved.
+        assert snapshot.monitoring_companies[0].name == ""
+        assert snapshot.monitoring_companies[0].hex_id == "DEADBEEF"
+        assert snapshot.monitoring_companies[0].status == MonitoringCompanyStatus.PENDING_APPROVAL


### PR DESCRIPTION
## Summary

Adds a fallback name-resolution path so the `sensor.<hub>_compania_cra` diagnostic keeps surfacing real company names even if the Ajax backend ever ships the modern slim shape — `(hex_id, status)` without an attached name — for our client. Today's behaviour stays unchanged because under the pinned client version the snapshot already carries names; the resolver is a no-op in that path.

Pieces:

- `MonitoringCompany.hex_id` field so callers can address a company on subsequent lookups.
- `SpacesApi.get_monitoring_company(space_id, company_hex_id)` wraps `SpaceMonitoringCompanyService.getMonitoringCompany` and returns a parsed `MonitoringCompany` on success, `None` on RPC error or proto failure.
- `get_space_snapshot` walks each company and resolves missing names via the new method; on resolver failure the original record is preserved so the snapshot still surfaces the company by its known status.

Verified empirically that the lookup endpoint responds under both the currently pinned and the modern client-version headers, so this commit is forward-compatible regardless of which client identity the integration ends up reporting next.

## Test plan

- [x] 8 new unit tests covering parse-hex-id, `getMonitoringCompany` success/failure/RPC-error, and snapshot integration (resolves-missing-name, skip-when-populated, fallback-on-resolver-failure).
- [x] `make check` inside a clean Docker image (no volume mount).