### PR TITLE
feat(notification): route SmartLock doorbell ring through Pass 4 (refs #158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0-beta.2] - 2026-05-19
+
+Beta bump adding the SmartLock leg of the "doorbell ring" event surface. Closes the last of the three doorbell SKUs in the Ajax catalog: Wireless DoorBell (hub-level) and MotionCam Video Doorbell already routed in `1.4.5` stable; this beta adds the SmartLock / LockBridge (Yale) variant. Routed through a new `SmartLockEventQualifier` parser pass that mirrors the existing video qualifier walker, so the user-facing surface (an `event` entity firing with `event_type: doorbell_pressed` and `raw_tag: doorbell_pressed`) is identical across all three SKUs and the same automation works regardless of which hardware the user owns.
+
+### Added
+- **`doorbell_pressed` event for Ajax SmartLock / LockBridge (Yale) variants with integrated ring button** (#158, reported by @Sven2410). `SmartLockEventQualifier` from `event/smartlock/qualifier.proto` now walked as Pass 4 in `_extract_event_with_compiled_protos`; the `doorbell_pressed` oneof maps to the same HA event_type the Wireless DoorBell (hub) and MotionCam Video Doorbell (video) already fire. No new device-type registration needed — SmartLock / LockBridge devices already surface as `lock` entities since `1.2.4`. Other SmartLock tags (`locked_by_keypad`, `locked_automatically`, …) intentionally remain unmapped — those transitions already surface via the `lock` entity's state. Translations land in all 14 locales (no-op — `doorbell_pressed` was already translated for the hub/video path).
+
+### Internal
+- Test suite at **1282** unit tests (was 1281 in `1.5.0-beta.1`); coverage unchanged at the same band. One new test in `tests/unit/test_notification.py` (`test_smartlock_doorbell_pressed_resolves_to_doorbell_pressed`) uses a real `SmartLockEventQualifier` proto instance to cover Pass 4.
+
 ## [1.5.0-beta.1] - 2026-05-18
 
 First MINOR-line beta. Bundles the regression fix for the CRA-company diagnostic sensor (rooted in `1.2.3` and only fully diagnosed today), the UX cleanup that drops the `"multiple"` sentinel in favour of the actual company names, and two foundation pieces for the modern Ajax client-version envelope: a `getMonitoringCompany`-based name resolver and a new `set_photo_on_demand_mode` service. SemVer MINOR because of the new service and the new public `MonitoringCompany.hex_id` field.

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -296,9 +296,23 @@ VIDEO_EVENT_TAG_MAP: dict[str, str] = {
     "human_detected": "motion",
 }
 
+# Map SmartLockEventTag oneof field names to simplified HA event types. Ajax
+# SmartLock / LockBridge (Yale) variants with an integrated ring button fire
+# the press through `SmartLockEventQualifier` — disjoint from
+# `HubEventQualifier` and `VideoEventQualifier`. Pass 4 of
+# `_extract_event_with_compiled_protos` walks this. The rest of the SmartLock
+# tag vocabulary (locked_by_keypad, locked_automatically, …) is intentionally
+# unmapped here: those transitions already surface via the `lock` entity's
+# state, mirroring how `VIDEO_EVENT_TAG_MAP` only mirrors the events with a
+# distinct automation hook.
+SMARTLOCK_EVENT_TAG_MAP: dict[str, str] = {
+    "doorbell_pressed": "doorbell_pressed",
+}
+
 
 ALL_EVENT_TYPES: list[str] = sorted(
     set(HUB_EVENT_TAG_MAP.values())
     | set(SPACE_EVENT_TAG_MAP.values())
     | set(VIDEO_EVENT_TAG_MAP.values())
+    | set(SMARTLOCK_EVENT_TAG_MAP.values())
 )

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -16,6 +16,7 @@ from custom_components.aegis_ajax.const import (
     DOMAIN,
     HUB_EVENT_TAG_MAP,
     RAW_TAG_TO_SECURITY_STATE,
+    SMARTLOCK_EVENT_TAG_MAP,
     SPACE_EVENT_TAG_MAP,
     VIDEO_EVENT_TAG_MAP,
 )
@@ -506,6 +507,9 @@ class AjaxNotificationListener:
         from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (  # noqa: PLC0415, E501
             qualifier_pb2 as hub_qualifier_pb2,
         )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.smartlock import (  # noqa: PLC0415, E501
+            qualifier_pb2 as smartlock_qualifier_pb2,
+        )
         from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.space import (  # noqa: PLC0415, E501
             qualifier_pb2 as space_qualifier_pb2,
         )
@@ -570,6 +574,30 @@ class AjaxNotificationListener:
                 data = {"raw_tag": tag_field}
                 if video_q.HasField("transition"):
                     trans_field = video_q.transition.WhichOneof("transition")
+                    if trans_field:
+                        data["transition"] = trans_field
+                return event_type, data
+
+        # Pass 4 — SmartLockEventQualifier (#158: SmartLock / LockBridge Yale
+        # variants with an integrated ring button fire `doorbell_pressed`
+        # inside this qualifier — disjoint oneof from HubEventTag and
+        # VideoEventTag). The remaining SmartLock tags (locked_by_keypad, …)
+        # already surface via the `lock` entity's state so they stay
+        # unmapped here on purpose.
+        for candidate in candidates:
+            try:
+                smartlock_q = smartlock_qualifier_pb2.SmartLockEventQualifier()
+                smartlock_q.ParseFromString(candidate)
+            except Exception:
+                continue
+            if not smartlock_q.HasField("tag"):
+                continue
+            tag_field = smartlock_q.tag.WhichOneof("event_tag_case")
+            if tag_field and tag_field in SMARTLOCK_EVENT_TAG_MAP:
+                event_type = SMARTLOCK_EVENT_TAG_MAP[tag_field]
+                data = {"raw_tag": tag_field}
+                if smartlock_q.HasField("transition"):
+                    trans_field = smartlock_q.transition.WhichOneof("transition")
                     if trans_field:
                         data["transition"] = trans_field
                 return event_type, data

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -700,6 +700,39 @@ class TestExtractEventCompiledProtos:
         assert event_type == "doorbell_pressed"
         assert data["raw_tag"] == "ring_button_pressed"
 
+    def test_smartlock_doorbell_pressed_resolves_to_doorbell_pressed(self) -> None:
+        # Ajax SmartLock / LockBridge (Yale) with integrated ring button
+        # fires its press inside `SmartLockEventQualifier` — disjoint oneof
+        # from HubEventTag and VideoEventTag, so the parser needs its own
+        # pass (Pass 4 in `_extract_event_with_compiled_protos`) for #158.
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
+            transition_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.smartlock import (  # noqa: E501
+            qualifier_pb2 as smartlock_qualifier_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.smartlock import (  # noqa: E501
+            tag_pb2 as smartlock_tag_pb2,
+        )
+
+        qualifier = smartlock_qualifier_pb2.SmartLockEventQualifier(
+            tag=smartlock_tag_pb2.SmartLockEventTag(
+                doorbell_pressed=smartlock_tag_pb2.DoorbellPressed()
+            ),
+            transition=transition_pb2.EventTransition(
+                impulse=transition_pb2.EventTransition.Impulse()
+            ),
+        )
+        wrapped = self._wrap(qualifier.SerializeToString())
+
+        listener = self._make_listener()
+        result = listener._extract_event_with_compiled_protos(wrapped)
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "doorbell_pressed"
+        assert data["raw_tag"] == "doorbell_pressed"
+
     def test_video_qualifier_motion_detected_does_not_false_positive(self) -> None:
         # The Video Doorbell also emits non-doorbell events (motion_detected,
         # human_detected, etc.). Those are not currently mapped so the parser


### PR DESCRIPTION
## Summary
- Adds `SmartLockEventQualifier` as Pass 4 in `_extract_event_with_compiled_protos` so Ajax SmartLock / LockBridge (Yale) variants with an integrated ring button fire the same `event_type: doorbell_pressed` HA event the Wireless DoorBell (Pass 2, hub) and MotionCam Video Doorbell (Pass 3, video) already emit.
- Closes the third and final "doorbell" SKU in the Ajax catalog — the user-facing surface is now uniform across all three: an `event` entity firing with `event_type: doorbell_pressed` + `raw_tag: doorbell_pressed`. Same automation works regardless of which hardware the reporter owns.
- No new device-type registration — SmartLock / LockBridge already surface as `lock` entities since `1.2.4`.
- Other SmartLock tags (`locked_by_keypad`, `locked_automatically`, …) intentionally stay unmapped — those transitions already surface via the `lock` entity state.

## Context (refs #158)
@Sven2410 asked for a "Doorbell pressed event" in #158 without specifying SKU. Ajax sells three things called "doorbell": Wireless DoorBell (standalone Jeweller button paired to hub), MotionCam Video Doorbell (camera + ring button), and SmartLock with integrated ring button (LockBridge / Yale variants). The first two are shipped (#119 + the hub map entry). This PR adds the third. Per-SKU routing reference: see `project_doorbell_paths.md` in repo notes.

## Implementation
- `SMARTLOCK_EVENT_TAG_MAP` in `const.py` — only `doorbell_pressed` is mapped here on purpose.
- Pass 4 in `notification.py::_extract_event_with_compiled_protos` mirrors the Video pass, importing `smartlock.qualifier_pb2`. Walks the `SmartLockEventQualifier` candidates and emits `{raw_tag, transition}` data exactly like the existing passes.
- `ALL_EVENT_TYPES` unions the new map (no-op since `doorbell_pressed` is already in the set).
- Translations: zero new strings — `doorbell_pressed` was already translated in all 14 locales when the Wireless DoorBell + Video Doorbell paths landed.

## Verification status
**End-to-end NOT YET CONFIRMED.** None of the three doorbell paths has been verified with a real device push in HA (the existing two were shipped on proto evidence too — see `project_doorbell_paths.md`). I do not have SmartLock-with-doorbell hardware on any test account. This PR is the wire-shape work; the next beta cycle should ask the #158 reporter to confirm the press → event round-trip on real hardware.

## Test plan
- [x] Unit test added: `test_smartlock_doorbell_pressed_resolves_to_doorbell_pressed` uses a real `SmartLockEventQualifier(tag=SmartLockEventTag(doorbell_pressed=DoorbellPressed()), transition=Impulse)` proto instance and asserts the parser returns `("doorbell_pressed", {"raw_tag": "doorbell_pressed", "transition": "impulse"})`.
- [x] Full CI in Docker without volume mount passes: 1282 tests (was 1281), 86.09% coverage, ruff lint + format + mypy + vulture all green.
- [ ] Awaiting @Sven2410 end-to-end confirmation on real hardware (first time any doorbell path will be confirmed live).