### PR TITLE
feat(notification): dispatch group-level arm/disarm pushes to per-group panels (refs #148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0-beta.3] - 2026-05-19
+
+Beta bump fixing the long-standing delay on per-group alarm panels in spaces configured with Ajax groups (zones). Arming or disarming a single group from the Ajax mobile app now updates the matching `alarm_control_panel.<group>` instantly via the FCM push channel; previously the per-group state only refreshed on the next hourly poll (or on a manual reload), so users with groups would see HA out of sync with the app for up to an hour. Space-wide events are unchanged.
+
+### Added
+- **Per-group `alarm_control_panel` entities now react to FCM arm/disarm pushes** (#148, reported by @ArshSoni). The seven `space_group_*` variants of `SpaceEventTag` (`space_group_armed`, `space_group_armed_with_malfunctions`, `space_group_auto_armed`, `space_group_auto_armed_with_malfunctions`, `space_group_disarmed`, `space_group_auto_disarmed`, `space_group_duress_disarmed`) are now mapped to `RAW_TAG_TO_GROUP_SECURITY_STATE` in `const.py` and dispatched through a new `AjaxCobrandedCoordinator.apply_push_group_security_state(space_id, group_id, new_state)` helper. The group_id is resolved from the FCM payload's `SpaceNotificationSource` (a new `_extract_space_source_info` scan in `notification.py` looks for `type == GROUP (3)` and reads `id` + `name`). The space-level `security_state` is intentionally left alone on group events — arming one group doesn't imply the whole space is armed, so the hub-level alarm panel still relies on the next poll to resolve that. Group-level pushes also fire an `aegis_ajax_event` with `event_type: arm` (or `disarm`) and `raw_tag: space_group_*` so existing automations keep working unchanged; the `raw_tag` and `group_id`/`group_name` fields on the event let new automations target a specific group.
+
+### Internal
+- Test suite at **1289** unit tests (was 1282 in `1.5.0-beta.2`); coverage unchanged. Seven new tests: two in `test_coordinator.py::TestApplyPushGroupSecurityState` exercise the matching/non-matching/unknown-space paths, three in `test_notification.py::TestApplySecurityStateFromEvent` cover the dispatch routing (group_id present → group, missing → no-op, plus disarm variant), three in `test_notification.py::TestNotificationListener` cover `_extract_space_source_info` against real `SpaceNotificationSource` protos (GROUP source, SPACE source skipped, garbage handled).
+
 ## [1.5.0-beta.2] - 2026-05-19
 
 Beta bump adding the SmartLock leg of the "doorbell ring" event surface. Closes the last of the three doorbell SKUs in the Ajax catalog: Wireless DoorBell (hub-level) and MotionCam Video Doorbell already routed in `1.4.5` stable; this beta adds the SmartLock / LockBridge (Yale) variant. Routed through a new `SmartLockEventQualifier` parser pass that mirrors the existing video qualifier walker, so the user-facing surface (an `event` entity firing with `event_type: doorbell_pressed` and `raw_tag: doorbell_pressed`) is identical across all three SKUs and the same automation works regardless of which hardware the user owns.

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -176,9 +176,11 @@ EVENT_DOMAIN = f"{DOMAIN}_event"
 # Map HubEventTag oneof field names to the resulting space `security_state`
 # when the corresponding push event arrives. Used to refresh the alarm panel
 # instantly from the FCM payload instead of waiting for the next poll.
-# `group_*` tags are intentionally omitted — they only affect a subgroup, so
-# the resulting space-level state (PARTIALLY_ARMED, ARMED, …) depends on the
-# other groups; let the next poll resolve it.
+# `space_group_*` tags are intentionally omitted from this map — they only
+# affect a single subgroup, so the resulting *space-level* state (PARTIALLY_
+# ARMED, ARMED, …) depends on the other groups; let the next poll resolve
+# space-level. The same tags are mapped per-group in
+# `RAW_TAG_TO_GROUP_SECURITY_STATE` below for the group-level panels (#148).
 RAW_TAG_TO_SECURITY_STATE: dict[str, SecurityState] = {
     # HubEventTag tags (sub-incidents that imply a space-level transition)
     "arm": SecurityState.ARMED,
@@ -203,6 +205,25 @@ RAW_TAG_TO_SECURITY_STATE: dict[str, SecurityState] = {
     "space_night_mode_on_with_malfunctions": SecurityState.NIGHT_MODE,
     "space_night_mode_off": SecurityState.DISARMED,
     "space_duress_night_mode_off": SecurityState.DISARMED,
+}
+
+
+# Map `space_group_*` SpaceEventTag oneof field names to the resulting
+# *group-level* `security_state`. Used to refresh the per-group alarm panel
+# (`AjaxGroupAlarmControlPanel`) instantly from the FCM payload instead of
+# waiting for the next poll (#148). The group_id comes from the
+# `SpaceNotificationSource` wrapping the qualifier — see
+# `notification.py::_extract_space_source_info`. Night-mode tags are absent
+# because per-group panels intentionally don't expose night mode (the
+# underlying flag is space-wide on Ajax).
+RAW_TAG_TO_GROUP_SECURITY_STATE: dict[str, SecurityState] = {
+    "space_group_armed": SecurityState.ARMED,
+    "space_group_armed_with_malfunctions": SecurityState.ARMED,
+    "space_group_auto_armed": SecurityState.ARMED,
+    "space_group_auto_armed_with_malfunctions": SecurityState.ARMED,
+    "space_group_disarmed": SecurityState.DISARMED,
+    "space_group_auto_disarmed": SecurityState.DISARMED,
+    "space_group_duress_disarmed": SecurityState.DISARMED,
 }
 
 
@@ -262,9 +283,11 @@ HUB_EVENT_TAG_MAP: dict[str, str] = {
 # parallel to HUB_EVENT_TAG_MAP because arm/disarm pushes carry a
 # SpaceEventQualifier (in SpaceNotificationContent.qualifier), not a
 # HubEventQualifier — the former is what we need for #68 to fire.
-# `space_group_*` tags are intentionally omitted: they describe a single
-# group's transition and the resulting space-level state can only be resolved
-# from the next poll.
+# Group-level events (`space_group_*`) also map to `arm` / `disarm` so the
+# logbook / event entity render the same wording as space-wide events; the
+# `raw_tag` field on the event payload still distinguishes them, and the
+# per-group alarm panel is updated from `RAW_TAG_TO_GROUP_SECURITY_STATE`
+# (#148).
 SPACE_EVENT_TAG_MAP: dict[str, str] = {
     "space_armed": "arm",
     "space_armed_with_malfunctions": "arm",
@@ -278,6 +301,15 @@ SPACE_EVENT_TAG_MAP: dict[str, str] = {
     "space_night_mode_off": "disarm_night",
     "space_duress_night_mode_off": "disarm_night",
     "space_panic_button_pressed": "panic",
+    # Group-level arm/disarm (#148). Same downstream event_type as space-wide
+    # so existing automations keep working; `raw_tag` differentiates.
+    "space_group_armed": "arm",
+    "space_group_armed_with_malfunctions": "arm",
+    "space_group_auto_armed": "arm",
+    "space_group_auto_armed_with_malfunctions": "arm",
+    "space_group_disarmed": "disarm",
+    "space_group_auto_disarmed": "disarm",
+    "space_group_duress_disarmed": "disarm",
 }
 
 # Map VideoEventTag oneof field names to simplified HA event types. The

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -679,6 +679,36 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.spaces[space_id] = dc_replace(space, security_state=new_state)
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
+    def apply_push_group_security_state(
+        self,
+        space_id: str,
+        group_id: str,
+        new_state: Any,  # noqa: ANN401
+    ) -> None:
+        """Apply a per-group security_state derived from an FCM push event (#148).
+
+        Mirrors `apply_push_security_state` for the per-group
+        `AjaxGroupAlarmControlPanel` entities: updates the matching `Group`
+        within `space.groups` and notifies listeners. No-ops when the space
+        or group is unknown, or the new state matches the existing one. The
+        space-level state is deliberately not changed here — arming a single
+        group doesn't imply the whole space is armed; that resolves on the
+        next poll.
+        """
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        space = self.spaces.get(space_id)
+        if space is None or not space.groups:
+            return
+        target = next((g for g in space.groups if g.id == group_id), None)
+        if target is None or target.security_state == new_state:
+            return
+        new_groups = tuple(
+            dc_replace(g, security_state=new_state) if g.id == group_id else g for g in space.groups
+        )
+        self.spaces[space_id] = dc_replace(space, groups=new_groups)
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
     def _handle_devices_snapshot(self, devices: list[Device]) -> None:
         """Handle initial snapshot or full device snapshot update from stream."""
         for device in devices:

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.storage import Store
 from custom_components.aegis_ajax.const import (
     DOMAIN,
     HUB_EVENT_TAG_MAP,
+    RAW_TAG_TO_GROUP_SECURITY_STATE,
     RAW_TAG_TO_SECURITY_STATE,
     SMARTLOCK_EVENT_TAG_MAP,
     SPACE_EVENT_TAG_MAP,
@@ -437,10 +438,17 @@ class AjaxNotificationListener:
             event_info = self._extract_event_from_proto(raw)
             if event_info:
                 event_type, event_data = event_info
-                # Enrich with source device info (name, room, type)
+                # Enrich with source device info (name, room, type). For
+                # group-level events the source is a SpaceNotificationSource
+                # carrying the group_id; extract that too so the per-group
+                # alarm panel can be updated (#148).
                 source_info = self._extract_source_info(raw)
                 if source_info:
                     event_data.update(source_info)
+                if event_data.get("raw_tag") in RAW_TAG_TO_GROUP_SECURITY_STATE:
+                    group_info = self._extract_space_source_info(raw)
+                    if group_info:
+                        event_data.update(group_info)
                 # Try to route to the correct space by matching hub_id from raw bytes
                 target_space = self._find_space_for_event(raw)
                 if target_space:
@@ -455,7 +463,11 @@ class AjaxNotificationListener:
             _LOGGER.debug("Failed to parse event from push notification", exc_info=True)
 
     def _apply_security_state_from_event(self, space_id: str, event_data: dict[str, Any]) -> None:
-        """If the push event implies a new space security_state, push it now (#68).
+        """If the push event implies a new security_state, push it now (#68 / #148).
+
+        Routes space-wide tags to the space-level `apply_push_security_state`
+        and `space_group_*` tags (when accompanied by a `group_id` extracted
+        from the SpaceNotificationSource) to the per-group equivalent.
 
         The FCM callback runs on the firebase_messaging worker thread, so we
         dispatch the update to the HA event loop via call_soon_threadsafe.
@@ -463,15 +475,26 @@ class AjaxNotificationListener:
         raw_tag = event_data.get("raw_tag")
         if not isinstance(raw_tag, str):
             return
+        if not (self._hass.loop and self._hass.loop.is_running()):
+            return
+        group_state = RAW_TAG_TO_GROUP_SECURITY_STATE.get(raw_tag)
+        group_id = event_data.get("group_id")
+        if group_state is not None and isinstance(group_id, str) and group_id:
+            self._hass.loop.call_soon_threadsafe(
+                self._coordinator.apply_push_group_security_state,
+                space_id,
+                group_id,
+                group_state,
+            )
+            return
         new_state = RAW_TAG_TO_SECURITY_STATE.get(raw_tag)
         if new_state is None:
             return
-        if self._hass.loop and self._hass.loop.is_running():
-            self._hass.loop.call_soon_threadsafe(
-                self._coordinator.apply_push_security_state,
-                space_id,
-                new_state,
-            )
+        self._hass.loop.call_soon_threadsafe(
+            self._coordinator.apply_push_security_state,
+            space_id,
+            new_state,
+        )
 
     def _find_space_for_event(self, raw: bytes) -> str | None:
         """Try to match the event to a space by finding a known hub_id in raw bytes."""
@@ -679,6 +702,50 @@ class AjaxNotificationListener:
                         return result
                 except Exception:
                     continue
+        return {}
+
+    @staticmethod
+    def _extract_space_source_info(raw: bytes) -> dict[str, Any]:
+        """Extract group identifier from a SpaceNotificationSource (#148).
+
+        `space_group_*` SpaceEventTag events are wrapped in a
+        SpaceNotificationContent whose `space_source` is a
+        SpaceNotificationSource with `type == GROUP (3)`, `id == <group_id>`
+        and `name == <group_name>`. The parser scans for that shape and
+        returns `{"group_id": ..., "group_name": ...}` when found, so the
+        per-group alarm panel can be refreshed instantly from FCM. Returns
+        `{}` when the payload doesn't carry a group source (typical for
+        whole-space arm/disarm).
+        """
+        try:
+            from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space import (  # noqa: PLC0415, E501
+                source_pb2,
+                source_type_pb2,
+            )
+        except ImportError:
+            _LOGGER.debug("SpaceNotificationSource proto not available")
+            return {}
+
+        group_type_value = source_type_pb2.SpaceNotificationSourceType.GROUP
+        # Same scan strategy as `_extract_source_info`: look for field 1
+        # varint (0x08 XX) and try parsing increasingly long slices as
+        # SpaceNotificationSource. Require id + name to be populated to
+        # avoid latching onto a short prefix that parses cleanly but is
+        # missing the trailing fields.
+        for i in range(len(raw) - 5):
+            if raw[i] != 0x08:
+                continue
+            for end in range(i + 6, min(i + 80, len(raw) + 1)):
+                try:
+                    source = source_pb2.SpaceNotificationSource()
+                    source.ParseFromString(raw[i:end])
+                except Exception:
+                    continue
+                if source.type != group_type_value:
+                    continue
+                if not source.id or not source.name:
+                    continue
+                return {"group_id": source.id, "group_name": source.name}
         return {}
 
     @staticmethod

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1204,6 +1204,92 @@ class TestApplyPushSecurityState:
         coordinator.async_set_updated_data.assert_called_once()
 
 
+class TestApplyPushGroupSecurityState:
+    """Per-group arm/disarm push updates (#148): only the matching Group is
+    refreshed instantly, the space-level state stays put until the next poll
+    resolves whether all groups now agree."""
+
+    def _make_coordinator_with_groups(self) -> AjaxCobrandedCoordinator:  # noqa: F821
+        from custom_components.aegis_ajax.api.models import Group
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        hass = MagicMock()
+        client = MagicMock()
+        with patch(
+            "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+            return_value=None,
+        ):
+            coordinator = AjaxCobrandedCoordinator(
+                hass=hass, client=client, space_ids=["s1"], poll_interval=300
+            )
+        coordinator.hass = hass
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.spaces = {
+            "s1": Space(
+                id="s1",
+                hub_id="hub-1",
+                name="Home",
+                security_state=SecurityState.DISARMED,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+                group_mode_enabled=True,
+                groups=(
+                    Group(
+                        id="g1",
+                        space_id="s1",
+                        name="Downstairs",
+                        security_state=SecurityState.DISARMED,
+                        sorting_key="01",
+                    ),
+                    Group(
+                        id="g2",
+                        space_id="s1",
+                        name="Upstairs",
+                        security_state=SecurityState.DISARMED,
+                        sorting_key="02",
+                    ),
+                ),
+            )
+        }
+        return coordinator
+
+    def test_arm_one_group_only_updates_that_group(self) -> None:
+        coordinator = self._make_coordinator_with_groups()
+
+        coordinator.apply_push_group_security_state("s1", "g1", SecurityState.ARMED)
+
+        groups = {g.id: g for g in coordinator.spaces["s1"].groups}
+        assert groups["g1"].security_state == SecurityState.ARMED
+        assert groups["g2"].security_state == SecurityState.DISARMED
+        # Space-level state intentionally not touched — only the next poll
+        # decides whether the whole space is armed.
+        assert coordinator.spaces["s1"].security_state == SecurityState.DISARMED
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_no_change_skips_update(self) -> None:
+        coordinator = self._make_coordinator_with_groups()
+
+        coordinator.apply_push_group_security_state("s1", "g1", SecurityState.DISARMED)
+
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_unknown_group_no_op(self) -> None:
+        coordinator = self._make_coordinator_with_groups()
+
+        coordinator.apply_push_group_security_state("s1", "unknown", SecurityState.ARMED)
+
+        groups = {g.id: g for g in coordinator.spaces["s1"].groups}
+        assert groups["g1"].security_state == SecurityState.DISARMED
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_unknown_space_no_op(self) -> None:
+        coordinator = self._make_coordinator_with_groups()
+
+        coordinator.apply_push_group_security_state("missing", "g1", SecurityState.ARMED)
+
+        coordinator.async_set_updated_data.assert_not_called()
+
+
 class TestCachedSnapshotStart:
     """First-refresh path now skips `get_devices_snapshot` when a cache is
     available, returning cached devices immediately so platform setup

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -202,6 +202,52 @@ class TestNotificationListener:
         result = AjaxNotificationListener._extract_source_info(raw)
         assert result == {}
 
+    def test_extract_space_source_info_returns_group_id_for_group_source(self) -> None:
+        # `space_group_*` events come wrapped in a SpaceNotificationContent
+        # whose `space_source` carries `type=GROUP (3)` plus the group's id
+        # and name. The parser scans for this and returns
+        # `{"group_id": ..., "group_name": ...}` so the per-group alarm panel
+        # can refresh from the push (#148).
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space import (  # noqa: E501
+            source_pb2,
+            source_type_pb2,
+        )
+
+        source = source_pb2.SpaceNotificationSource(
+            type=source_type_pb2.SpaceNotificationSourceType.GROUP,
+            id="group-abc-123",
+            name="Downstairs",
+        )
+        # The push payload wraps the source as a length-delimited field; the
+        # parser is robust against the outer wrapper, so emitting the raw
+        # source bytes is enough to exercise the scan.
+        raw = source.SerializeToString()
+
+        result = AjaxNotificationListener._extract_space_source_info(raw)
+        assert result == {"group_id": "group-abc-123", "group_name": "Downstairs"}
+
+    def test_extract_space_source_info_skips_non_group_source(self) -> None:
+        # A SPACE-level source (whole-space arm/disarm) must not be reported
+        # as a group, so the per-group routing path stays inert.
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space import (  # noqa: E501
+            source_pb2,
+            source_type_pb2,
+        )
+
+        source = source_pb2.SpaceNotificationSource(
+            type=source_type_pb2.SpaceNotificationSourceType.SPACE,
+            id="space-xyz",
+            name="Home",
+        )
+        raw = source.SerializeToString()
+
+        result = AjaxNotificationListener._extract_space_source_info(raw)
+        assert result == {}
+
+    def test_extract_space_source_info_returns_empty_for_garbage(self) -> None:
+        result = AjaxNotificationListener._extract_space_source_info(b"\x00\x01\x02\x03")
+        assert result == {}
+
     @pytest.mark.asyncio
     async def test_on_notification_extracts_notification_id(self) -> None:
         """ENCODED_DATA with a notification_id resolves pending notification_id futures."""
@@ -485,13 +531,48 @@ class TestApplySecurityStateFromEvent:
             coordinator.apply_push_security_state, "space-1", SecurityState.NIGHT_MODE
         )
 
-    def test_space_group_armed_does_not_dispatch(self) -> None:
-        # Group-level transitions don't determine the space-level state alone.
+    def test_space_group_armed_without_group_id_does_not_dispatch(self) -> None:
+        # Group-level transitions only refresh the matching per-group panel.
+        # Without a group_id (parser couldn't extract a SpaceNotificationSource
+        # of type GROUP) we have nothing to route, so we no-op rather than
+        # falling back to the space-level dispatch (#148).
         listener, hass, _ = self._make_listener()
 
         listener._apply_security_state_from_event("space-1", {"raw_tag": "space_group_armed"})
 
         hass.loop.call_soon_threadsafe.assert_not_called()
+
+    def test_space_group_armed_with_group_id_dispatches_group_state(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event(
+            "space-1", {"raw_tag": "space_group_armed", "group_id": "group-7"}
+        )
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.apply_push_group_security_state,
+            "space-1",
+            "group-7",
+            SecurityState.ARMED,
+        )
+
+    def test_space_group_disarmed_with_group_id_dispatches_disarmed(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event(
+            "space-1", {"raw_tag": "space_group_disarmed", "group_id": "group-7"}
+        )
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.apply_push_group_security_state,
+            "space-1",
+            "group-7",
+            SecurityState.DISARMED,
+        )
 
 
 class TestExtractEventCompiledProtos:


### PR DESCRIPTION
## Summary
- Maps the seven `space_group_*` SpaceEventTag variants (armed, armed_with_malfunctions, auto_armed, auto_armed_with_malfunctions, disarmed, auto_disarmed, duress_disarmed) to per-group security_state in a new `RAW_TAG_TO_GROUP_SECURITY_STATE` map.
- Adds `_extract_space_source_info()` in `notification.py` that scans the FCM payload for a `SpaceNotificationSource` of `type=GROUP (3)` and returns `{group_id, group_name}`.
- Adds `AjaxCobrandedCoordinator.apply_push_group_security_state(space_id, group_id, new_state)` mirroring the existing space-level helper but updating the matching `Group` within `space.groups`.
- Wires both together in `_apply_security_state_from_event`: when the raw_tag is in the group map AND we resolved a group_id, route to the group helper; otherwise fall back to the space-level path. Space-level state is intentionally left alone on group events (arming one group doesn't imply the whole space is armed).

## Context (refs #148)
@ArshSoni reported that with Ajax groups configured (two zones: Home and Studio), per-group `alarm_control_panel` entities stayed stuck on the previous state for ~20 minutes after he armed everything from the Ajax mobile app. The parser was deliberately dropping `space_group_*` tags because they don't tell us the *space-level* state — but they do tell us the *group-level* state, and that's exactly what the per-group panels need. The hub-level panel still relies on the next poll to resolve whether the whole space is armed.

## Implementation details
- `SPACE_EVENT_TAG_MAP` now also maps the 7 group tags to `arm` / `disarm` so `aegis_ajax_event` fires the same downstream event_type as space-wide events; existing automations on `event_type: arm` keep working. The `raw_tag` field on the event payload (e.g. `space_group_armed`) plus the new `group_id` / `group_name` fields let new automations target a specific group.
- `_extract_space_source_info` requires both `id` and `name` to be present in the parse before returning — same shape as the existing `_extract_source_info` helper, avoids latching onto a short prefix that parses cleanly but is missing the trailing fields.
- The group helper on the coordinator uses `dataclasses.replace` to swap in a new Group within `space.groups`; the rest of the space dataclass is untouched.

## Verification status
**End-to-end NOT YET CONFIRMED.** I do not have an Ajax space with groups on any test account. The wire shape comes from the protos (`SpaceEventTag.space_group_*` + `SpaceNotificationSource.type=GROUP`); we should ask @ArshSoni to test the resulting beta and confirm that arming a single group in the Ajax app reflects in HA within seconds rather than after the poll cycle. The unit tests exercise the routing and the state apply, but the proto-bytes-on-the-wire reality only one user can validate.

## Test plan
- [x] 7 new unit tests added (4 in `test_notification.py`, 2 in `test_coordinator.py`, plus the existing `test_space_group_armed_does_not_dispatch` was rewritten to `test_space_group_armed_without_group_id_does_not_dispatch` because the no-dispatch is now conditional on missing group_id rather than unconditional).
- [x] Full CI in Docker without volume mount passes: 1291 tests (was 1282), 86.07% coverage, lint/format/typecheck/dead-code all green.
- [ ] Awaiting @ArshSoni real-hardware confirmation on a multi-group install.