### PR TITLE
chore: cross-integration proto collision message + group push README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 
 ## Features
 
-- **Alarm Control Panel**: Arm away, disarm, night mode, group arming with PIN code support
+- **Alarm Control Panel**: Arm away, disarm, night mode, group arming with PIN code support. When the space is in group / zone mode, per-group panels are created and react to FCM push events instantly — arming or disarming a single group from the Ajax mobile app reflects in HA within seconds (whole-space transitions already worked this way; group-level transitions joined in `1.5.0`)
 - **Force Arm Services**: `aegis_ajax.force_arm` and `aegis_ajax.force_arm_night` to arm ignoring open sensors
 - **Binary Sensors**: Door open/close, motion detection, smoke, steam (FireProtect 2 chamber discriminator), leak, tamper, CO, heat, glass break, vibration, tilt (DoorProtect Plus accelerometer), CRA monitoring status, cellular connection, lid tamper, external contact alert (wired reed switches on DoorProtect/Hub Hybrid inputs), external contact fault, MultiTransmitter wired-input alert with alarm category, anti-masking, interference detection, ethernet link, Wi-Fi link, mains power
 - **Hub Network**: Real-time hub network data — ethernet/wifi/gsm connection status, Wi-Fi SSID and signal strength, IP addressing, cellular signal strength and network type, power supply status

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -17,23 +17,41 @@ def _log_proto_descriptor_collision(exc: TypeError) -> None:
     `_descriptor_pool.AddSerializedFile` raises
     `TypeError("Couldn't build proto file into descriptor pool: duplicate
     file name ...")` when two `_pb2.py` modules try to register the same
-    proto path in protobuf's global default pool — almost always a stale
-    copy of this integration in `custom_components/` (backup folder,
-    partial HACS update). HA's UI surfaces the bare TypeError as the
-    cryptic "Invalid handler specified", so we log the fix path before
+    proto path in protobuf's global default pool. Two scenarios in the
+    wild:
+
+    1. A stale or backup copy of this integration alongside the live one
+       in `custom_components/` (any folder whose name starts with
+       `aegis_ajax` other than the active install). Most common cause.
+    2. Another custom integration in `custom_components/` (typically a
+       different Ajax-related HACS integration) that compiles the same
+       upstream `systems/ajax/...` proto files into its own
+       `_pb2.py` modules. Python protobuf keeps a single global descriptor
+       pool, so both integrations cannot coexist in the same HA process
+       no matter which loads first.
+
+    HA's UI surfaces the bare TypeError as the cryptic "Invalid handler
+    specified", so we log the fix path for both scenarios before
     re-raising. No-op for unrelated TypeErrors.
     """
     if "duplicate file name" not in str(exc):
         return
     _LOGGER.error(
         "Aegis for Ajax failed to load: duplicate protobuf descriptors "
-        "detected (%s). This usually means there's a stale or backup copy "
-        "of the integration alongside the live one in custom_components/ "
-        "(any folder starting with 'aegis_ajax' other than the active "
-        "install will trip this). List custom_components/, move or rename "
-        "the extra folder so it no longer starts with 'aegis_ajax', and "
-        "restart Home Assistant. A clean uninstall + reinstall via HACS "
-        "also clears it.",
+        "detected (%s). Two possible causes:\n"
+        "  (a) A stale or backup copy of this integration alongside the "
+        "live one — any folder under custom_components/ whose name starts "
+        "with 'aegis_ajax' other than the active install will trip this. "
+        "Fix: move or rename the extra folder (a clean HACS uninstall + "
+        "reinstall also clears it) and restart Home Assistant.\n"
+        "  (b) A different Ajax-related custom integration in "
+        "custom_components/ that bundles overlapping 'systems/ajax/...' "
+        "proto definitions. Python protobuf has a single global descriptor "
+        "pool, so two integrations both compiling the upstream Ajax protos "
+        "cannot coexist. Fix: list custom_components/, identify the other "
+        "Ajax-related integration (folders like 'ajax', 'ajaxsystems', "
+        "etc.), and choose one — the integrations are mutually exclusive "
+        "in the same HA instance.",
         exc,
     )
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -196,6 +196,9 @@ class TestProtoDescriptorCollisionGuard:
         assert any("backup copy" in r.message for r in caplog.records), (
             "remediation hint should mention the backup-folder scenario"
         )
+        assert any("Ajax-related custom integration" in r.message for r in caplog.records), (
+            "remediation hint should mention the cross-integration scenario"
+        )
         assert any("custom_components" in r.message for r in caplog.records)
 
     def test_no_log_for_unrelated_typeerror(self, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary
Two small polish items on the 1.5.0 line, no behaviour change for healthy installs.

- **`_log_proto_descriptor_collision` in `__init__.py` (refs #151)**: the message now enumerates both scenarios that trigger a duplicate-proto TypeError — (a) the existing stale/backup `aegis_ajax*` folder case, (b) a different Ajax-related custom integration in `custom_components/` bundling the same `systems/ajax/...` proto definitions. The previous text only covered (a), which was unhelpful for @mschev's setup in #151 where the collision came from another integration sitting alongside ours. The second test in `TestProtoDescriptorCollisionGuard` now asserts both branches are mentioned.
- **README (refs #148)**: one-line addition to the `Alarm Control Panel` bullet noting that per-group panels react to FCM push events instantly in `1.5.0`, since that's the delta we just shipped in PR #161.

## Test plan
- [x] Full CI in Docker without volume mount passes (1291 tests, 86.07% coverage, lint/format/typecheck/dead-code all green).
- [x] Existing collision test still passes; updated test asserts the new cross-integration phrasing.