### PR TITLE
fix(notification): resolve push events by tag priority, not pass order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0-beta.5] - 2026-05-20
+
+Beta bump fixing how the integration classifies push events when a sensor activates while the system is armed. Until now, a motion detector tripping or a door opening during night mode rendered in Home Assistant as `event_type: arm_night` — the same wording the integration uses when a user actively puts the system into night mode. That made the event entity ambiguous for automations: a doorbell ring, a motion detector tripping, and the user pressing the arm button all looked like the same event downstream of the FCM payload. After this bump, those events surface with the activity-level wording you'd expect (`motion`, `door_open`, `doorbell_pressed`, `tamper`, `alarm`, …), with the state context preserved on the `raw_tag` field for anyone whose automation keys off it.
+
+### Fixed
+- **Event-entity classification now reflects what the sensor actually did, not just the surrounding space state.** When Ajax bundles a sensor-trip qualifier (`HubEventQualifier(motion_detected)`, `HubEventQualifier(door_opened)`, `HubEventQualifier(tamper_opened)`, etc.) together with a state-context qualifier (`SpaceEventQualifier(space_night_mode_on)`, `SpaceEventQualifier(space_armed_with_malfunctions)`, …) in the same FCM payload, the integration now picks the sensor-level event as the primary signal. The previous logic walked qualifier types in a fixed order and returned the first match, which let the state context shadow the activity. Real-world impact: motion / door / tamper / panic / fire automations now fire with the expected `event_type` regardless of whether the underlying push came in during armed-away, armed-night, partially-armed, or any other state. Confirmed-incident events (`intrusion_alarm`, `panic_button_pressed`) likewise take precedence over the surrounding state context.
+
+### Internal
+- Test suite at **1299** unit tests (was 1295 in `1.5.0-beta.4`); coverage 86.18%. Four new tests in `tests/unit/test_notification.py::TestExtractEventCompiledProtos` exercise the priority resolution directly (highest-tier match wins, single match still resolves, confirmed-incident beats sensor activity, ties resolve in candidate-scan order). One existing test (`test_space_qualifier_preferred_over_hub_subincident`) rewritten as `test_intrusion_alarm_beats_state_context` to assert the new — correct — semantics; the previous test was encoding the bug it was named to protect against.
+
 ## [1.5.0-beta.4] - 2026-05-20
 
 Observability beta bump — purely additive, no runtime behaviour change. Surfaces the data needed to triage in-flight reports on the `1.5.0` line (notably the per-group push debugging in #148) without having to ask reporters for ad-hoc custom logging.

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -342,6 +342,86 @@ SMARTLOCK_EVENT_TAG_MAP: dict[str, str] = {
 }
 
 
+# Semantic weight of each push tag. Used by the parser to pick the right
+# match when a single FCM payload carries multiple valid qualifiers — most
+# notably "sensor tripped while system was armed", where Ajax bundles a
+# `SpaceEventQualifier` carrying the state context (e.g. `space_night_mode_
+# on`) together with a `HubEventQualifier` carrying the sensor activity
+# (e.g. `motion_detected`). Higher number wins; tags absent from this map
+# default to weight 0, which preserves the previous "first match wins"
+# fallback for anything not yet ranked.
+#
+# Tiers:
+#   100 — confirmed incident: someone needs to act now
+#    90 — critical detector: would normally trigger an alarm
+#    80 — sensor activity worth surfacing (motion, doorbell, door open)
+#    50 — space-level state change driven by a user action
+#    40 — HubEventTag legacy arm/disarm — Ajax mostly sends these as
+#         secondary context to the SpaceEventTag equivalents
+#    30 — informational health signals (battery, connection loss)
+TAG_PRIORITY: dict[str, int] = {
+    # Tier 100 — confirmed incidents
+    "intrusion_alarm": 100,
+    "intrusion_alarm_confirmed": 100,
+    "panic_button_pressed": 100,
+    "space_panic_button_pressed": 100,
+    # Tier 90 — critical detection
+    "tamper_opened": 90,
+    "front_tamper_opened": 90,
+    "back_tamper_opened": 90,
+    "smoke_detected": 90,
+    "high_co_level_detected": 90,
+    "leak_detected": 90,
+    "glass_break_detected": 90,
+    # Tier 80 — sensor / device activity
+    "motion_detected": 80,
+    "human_detected": 80,
+    "door_opened": 80,
+    "ring_button_pressed": 80,
+    "doorbell_pressed": 80,
+    # Tier 50 — user-driven space transitions
+    "space_armed": 50,
+    "space_armed_with_malfunctions": 50,
+    "space_auto_armed": 50,
+    "space_auto_armed_with_malfunctions": 50,
+    "space_disarmed": 50,
+    "space_auto_disarmed": 50,
+    "space_duress_disarmed": 50,
+    "space_night_mode_on": 50,
+    "space_night_mode_on_with_malfunctions": 50,
+    "space_night_mode_off": 50,
+    "space_duress_night_mode_off": 50,
+    "space_group_armed": 50,
+    "space_group_armed_with_malfunctions": 50,
+    "space_group_auto_armed": 50,
+    "space_group_auto_armed_with_malfunctions": 50,
+    "space_group_disarmed": 50,
+    "space_group_auto_disarmed": 50,
+    "space_group_duress_disarmed": 50,
+    # Tier 40 — HubEventTag legacy arm/disarm (Ajax sends these as
+    # secondary context; the SpaceEventTag variants above are the
+    # canonical signal for the user action).
+    "arm": 40,
+    "arm_attempt": 40,
+    "arm_with_malfunctions": 40,
+    "group_arm": 40,
+    "group_arm_with_malfunctions": 40,
+    "disarm": 40,
+    "duress_disarm": 40,
+    "group_disarm": 40,
+    "night_mode_on": 40,
+    "night_mode_off": 40,
+    "duress_night_mode_off": 40,
+    # Tier 30 — informational
+    "battery_low": 30,
+    "device_communication_loss": 30,
+    "server_connection_loss": 30,
+    "gsm_connection_loss": 30,
+    "ethernet_connection_loss": 30,
+    "malfunction": 30,
+}
+
+
 ALL_EVENT_TYPES: list[str] = sorted(
     set(HUB_EVENT_TAG_MAP.values())
     | set(SPACE_EVENT_TAG_MAP.values())

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -19,6 +19,7 @@ from custom_components.aegis_ajax.const import (
     RAW_TAG_TO_SECURITY_STATE,
     SMARTLOCK_EVENT_TAG_MAP,
     SPACE_EVENT_TAG_MAP,
+    TAG_PRIORITY,
     VIDEO_EVENT_TAG_MAP,
 )
 from custom_components.aegis_ajax.repairs import (
@@ -524,14 +525,24 @@ class AjaxNotificationListener:
             return self._extract_event_raw(raw)
 
     def _extract_event_with_compiled_protos(self, raw: bytes) -> tuple[str, dict[str, Any]] | None:
-        """Parse event by finding a Hub or Space event qualifier in raw protobuf.
+        """Resolve a push payload to an HA `(event_type, data)` pair.
 
-        Arm/disarm pushes embed a `SpaceEventQualifier` (`SpaceNotificationContent.
-        qualifier`) — try those first (#68). The same payload often also carries
-        unrelated `HubEventQualifier` candidates describing zone-level
-        sub-incidents (`ext_contact_opened`, `roller_shutter_alarm`); they are
-        the legitimate primary tag for hub-level pushes (alarm, tamper, …) so
-        they remain the fallback.
+        Walks every embedded protobuf candidate, tries to decode it against
+        each of the four event qualifier types (Space / Hub / Video /
+        SmartLock), and collects every successful match. The highest-
+        priority match wins per `TAG_PRIORITY` — real incidents (alarm,
+        panic) outrank critical detectors (tamper, smoke), which outrank
+        sensor activity (motion, door open, doorbell), which outranks
+        user-driven state transitions (`space_armed`, `space_night_mode_
+        on`). This avoids misreading a payload like "PORTA opened during
+        night mode" — which carries both a `HubEventQualifier(door_opened)`
+        and a `SpaceEventQualifier(space_night_mode_on)` — as a state
+        transition rather than as the door-open event a user automation
+        actually wants to trigger on.
+
+        Tags absent from `TAG_PRIORITY` default to weight 0 so they still
+        participate but lose to anything ranked — preserving the previous
+        first-match-wins behaviour for the unranked long tail.
         """
         from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event.hub import (  # noqa: PLC0415, E501
             qualifier_pb2 as hub_qualifier_pb2,
@@ -546,91 +557,70 @@ class AjaxNotificationListener:
             qualifier_pb2 as video_qualifier_pb2,
         )
 
-        candidates = self._find_embedded_messages(raw)
+        # (qualifier_proto_class, tag → ha_event_type map) pairs walked for
+        # every candidate. Order doesn't affect the result thanks to
+        # priority ranking, but matches the legacy pass numbering for grep.
+        qualifier_table: list[tuple[type, dict[str, str]]] = [
+            (space_qualifier_pb2.SpaceEventQualifier, SPACE_EVENT_TAG_MAP),
+            (hub_qualifier_pb2.HubEventQualifier, HUB_EVENT_TAG_MAP),
+            (video_qualifier_pb2.VideoEventQualifier, VIDEO_EVENT_TAG_MAP),
+            (smartlock_qualifier_pb2.SmartLockEventQualifier, SMARTLOCK_EVENT_TAG_MAP),
+        ]
 
-        # Pass 1 — SpaceEventQualifier (arm/disarm/night/panic at space level).
-        for candidate in candidates:
-            try:
-                space_q = space_qualifier_pb2.SpaceEventQualifier()
-                space_q.ParseFromString(candidate)
-            except Exception:
-                continue
-            if not space_q.HasField("tag"):
-                continue
-            tag_field = space_q.tag.WhichOneof("event_tag_case")
-            if tag_field and tag_field in SPACE_EVENT_TAG_MAP:
-                event_type = SPACE_EVENT_TAG_MAP[tag_field]
-                data: dict[str, Any] = {"raw_tag": tag_field}
-                if space_q.HasField("transition"):
-                    trans_field = space_q.transition.WhichOneof("transition")
-                    if trans_field:
-                        data["transition"] = trans_field
-                return event_type, data
+        matches: list[tuple[int, str, dict[str, Any]]] = []
+        for candidate in self._find_embedded_messages(raw):
+            # Within a single candidate, take only the first qualifier
+            # type that decodes — preserving the legacy Space > Hub >
+            # Video > SmartLock precedence so the same bytes don't get
+            # double-counted under two different interpretations (the
+            # protobuf wire format is permissive enough that a payload
+            # legitimately encoding `space_armed` can also parse as
+            # `HubEventQualifier(door_opened)` by sheer field-number
+            # coincidence). Priority then decides between *different*
+            # candidates, which is the case the refactor is for.
+            for qualifier_class, tag_map in qualifier_table:
+                resolved = self._resolve_qualifier(candidate, qualifier_class, tag_map)
+                if resolved is None:
+                    continue
+                event_type, data = resolved
+                matches.append((TAG_PRIORITY.get(data["raw_tag"], 0), event_type, data))
+                break
 
-        # Pass 2 — HubEventQualifier (zone-level events: alarm, tamper, …).
-        for candidate in candidates:
-            try:
-                qualifier = hub_qualifier_pb2.HubEventQualifier()
-                qualifier.ParseFromString(candidate)
-                if qualifier.HasField("tag"):
-                    tag = qualifier.tag
-                    tag_field = tag.WhichOneof("event_tag_case")
-                    if tag_field and tag_field in HUB_EVENT_TAG_MAP:
-                        event_type = HUB_EVENT_TAG_MAP[tag_field]
-                        data = {"raw_tag": tag_field}
-                        if qualifier.HasField("transition"):
-                            trans_field = qualifier.transition.WhichOneof("transition")
-                            if trans_field:
-                                data["transition"] = trans_field
-                        return event_type, data
-            except Exception:
-                continue
+        if not matches:
+            return None
 
-        # Pass 3 — VideoEventQualifier (#119: MotionCam Video Doorbell ring,
-        # plus motion / human detected from video devices). The video tag
-        # set is disjoint from HubEventTag so its own qualifier is needed.
-        for candidate in candidates:
-            try:
-                video_q = video_qualifier_pb2.VideoEventQualifier()
-                video_q.ParseFromString(candidate)
-            except Exception:
-                continue
-            if not video_q.HasField("tag"):
-                continue
-            tag_field = video_q.tag.WhichOneof("event_tag_case")
-            if tag_field and tag_field in VIDEO_EVENT_TAG_MAP:
-                event_type = VIDEO_EVENT_TAG_MAP[tag_field]
-                data = {"raw_tag": tag_field}
-                if video_q.HasField("transition"):
-                    trans_field = video_q.transition.WhichOneof("transition")
-                    if trans_field:
-                        data["transition"] = trans_field
-                return event_type, data
+        # `max` returns the first element at the maximum priority — i.e.
+        # ties resolve in candidate-scan order, which matches the previous
+        # first-match-wins behaviour for tags that share a tier.
+        _, event_type, data = max(matches, key=lambda m: m[0])
+        return event_type, data
 
-        # Pass 4 — SmartLockEventQualifier (#158: SmartLock / LockBridge Yale
-        # variants with an integrated ring button fire `doorbell_pressed`
-        # inside this qualifier — disjoint oneof from HubEventTag and
-        # VideoEventTag). The remaining SmartLock tags (locked_by_keypad, …)
-        # already surface via the `lock` entity's state so they stay
-        # unmapped here on purpose.
-        for candidate in candidates:
-            try:
-                smartlock_q = smartlock_qualifier_pb2.SmartLockEventQualifier()
-                smartlock_q.ParseFromString(candidate)
-            except Exception:
-                continue
-            if not smartlock_q.HasField("tag"):
-                continue
-            tag_field = smartlock_q.tag.WhichOneof("event_tag_case")
-            if tag_field and tag_field in SMARTLOCK_EVENT_TAG_MAP:
-                event_type = SMARTLOCK_EVENT_TAG_MAP[tag_field]
-                data = {"raw_tag": tag_field}
-                if smartlock_q.HasField("transition"):
-                    trans_field = smartlock_q.transition.WhichOneof("transition")
-                    if trans_field:
-                        data["transition"] = trans_field
-                return event_type, data
-        return None
+    @staticmethod
+    def _resolve_qualifier(
+        candidate: bytes,
+        qualifier_class: type,
+        tag_map: dict[str, str],
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Try to decode `candidate` as `qualifier_class` and return its
+        `(event_type, data)` if its tag is in `tag_map`. Returns None on
+        parse failure, missing tag, or unmapped tag.
+        """
+        try:
+            qualifier = qualifier_class()
+            qualifier.ParseFromString(candidate)
+        except Exception:
+            return None
+        if not qualifier.HasField("tag"):
+            return None
+        tag_field = qualifier.tag.WhichOneof("event_tag_case")
+        if not tag_field or tag_field not in tag_map:
+            return None
+        data: dict[str, Any] = {"raw_tag": tag_field}
+        if qualifier.HasField("transition"):
+            trans_field = qualifier.transition.WhichOneof("transition")
+            if trans_field:
+                data["transition"] = trans_field
+        return tag_map[tag_field], data
 
     @staticmethod
     def _find_embedded_messages(raw: bytes) -> list[bytes]:

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -647,10 +647,13 @@ class TestExtractEventCompiledProtos:
         assert event_type == "disarm"
         assert data["raw_tag"] == "space_disarmed"
 
-    def test_space_qualifier_preferred_over_hub_subincident(self) -> None:
-        # When both a SpaceEventQualifier (primary) and a HubEventQualifier
-        # (sub-incident, e.g. ext_contact_opened) are present in the same
-        # payload, the space-level transition wins.
+    def test_intrusion_alarm_beats_state_context(self) -> None:
+        # When a payload bundles a state-context tag (`space_night_mode_on`)
+        # together with a real incident (`intrusion_alarm`), the incident
+        # wins regardless of qualifier order — `TAG_PRIORITY` ranks
+        # confirmed incidents above state transitions. Previously the
+        # first SpaceEventQualifier match was returned unconditionally, so
+        # genuine alarms were rendered as `event_type=arm_night`.
         from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.event import (  # noqa: E501
             transition_pb2,
         )
@@ -679,8 +682,6 @@ class TestExtractEventCompiledProtos:
                 triggered=transition_pb2.EventTransition.Triggered()
             ),
         )
-        # Place the hub qualifier BEFORE the space one so the test would fail
-        # if we were still picking the first parseable HubEventQualifier.
         wrapped = self._wrap(hub_q.SerializeToString()) + self._wrap(space_q.SerializeToString())
 
         listener = self._make_listener()
@@ -688,8 +689,117 @@ class TestExtractEventCompiledProtos:
 
         assert result is not None
         event_type, data = result
-        assert event_type == "arm_night"
-        assert data["raw_tag"] == "space_night_mode_on"
+        assert event_type == "alarm"
+        assert data["raw_tag"] == "intrusion_alarm"
+
+    def test_priority_resolution_picks_highest_ranked_match(self) -> None:
+        # Direct unit test of the priority logic: given multiple candidate
+        # decodes across different qualifier types, the highest-ranked
+        # tag wins regardless of candidate scan order. Mocks the
+        # candidate-scan + per-qualifier-resolve helpers so the test
+        # doesn't depend on whether synthetic proto bytes happen to
+        # cross-decode (they sometimes do; real Ajax wire payloads — where
+        # each qualifier comes wrapped in its own typed
+        # `*NotificationContent` — do not).
+        listener = self._make_listener()
+        # Two candidates: first decodes as a state-context tag (priority
+        # 50), second decodes as a sensor tag (priority 80). Sensor wins
+        # by priority even though it's discovered second.
+        with (
+            patch.object(
+                listener,
+                "_find_embedded_messages",
+                return_value=[b"\x01", b"\x02"],
+            ),
+            patch.object(
+                listener,
+                "_resolve_qualifier",
+                side_effect=lambda c, *_: {
+                    b"\x01": ("arm_night", {"raw_tag": "space_night_mode_on"}),
+                    b"\x02": ("motion", {"raw_tag": "motion_detected"}),
+                }.get(c),
+            ),
+        ):
+            result = listener._extract_event_with_compiled_protos(b"")
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "motion"
+        assert data["raw_tag"] == "motion_detected"
+
+    def test_priority_resolution_state_context_alone_still_wins(self) -> None:
+        # When no higher-priority match is present, the state-context tag
+        # is correctly returned — the priority ladder only changes which
+        # match wins under contention, not what gets returned for a pure
+        # arm / disarm push.
+        listener = self._make_listener()
+        with (
+            patch.object(
+                listener,
+                "_find_embedded_messages",
+                return_value=[b"\x01"],
+            ),
+            patch.object(
+                listener,
+                "_resolve_qualifier",
+                side_effect=lambda c, *_: ("arm", {"raw_tag": "space_armed"}),
+            ),
+        ):
+            result = listener._extract_event_with_compiled_protos(b"")
+
+        assert result == ("arm", {"raw_tag": "space_armed"})
+
+    def test_priority_resolution_intrusion_alarm_beats_motion(self) -> None:
+        # Confirmed-incident tier (100) beats sensor-activity tier (80) —
+        # an intrusion in progress with concurrent motion pings should
+        # surface as `alarm`, not `motion`.
+        listener = self._make_listener()
+        with (
+            patch.object(
+                listener,
+                "_find_embedded_messages",
+                return_value=[b"\x01", b"\x02"],
+            ),
+            patch.object(
+                listener,
+                "_resolve_qualifier",
+                side_effect=lambda c, *_: {
+                    b"\x01": ("motion", {"raw_tag": "motion_detected"}),
+                    b"\x02": ("alarm", {"raw_tag": "intrusion_alarm"}),
+                }.get(c),
+            ),
+        ):
+            result = listener._extract_event_with_compiled_protos(b"")
+
+        assert result is not None
+        event_type, data = result
+        assert event_type == "alarm"
+        assert data["raw_tag"] == "intrusion_alarm"
+
+    def test_priority_resolution_ties_resolve_in_scan_order(self) -> None:
+        # When two candidates produce matches at the same tier, the first
+        # candidate (scan order) wins — preserving the legacy first-match
+        # behaviour for tags that share a tier and avoiding silent
+        # behaviour changes for state-only pushes.
+        listener = self._make_listener()
+        with (
+            patch.object(
+                listener,
+                "_find_embedded_messages",
+                return_value=[b"\x01", b"\x02"],
+            ),
+            patch.object(
+                listener,
+                "_resolve_qualifier",
+                side_effect=lambda c, *_: {
+                    b"\x01": ("arm", {"raw_tag": "space_armed"}),
+                    b"\x02": ("disarm", {"raw_tag": "space_disarmed"}),
+                }.get(c),
+            ),
+        ):
+            result = listener._extract_event_with_compiled_protos(b"")
+
+        assert result == ("arm", {"raw_tag": "space_armed"})
 
     def test_hub_qualifier_used_when_no_space_qualifier(self) -> None:
         # Hub-level events (alarm, tamper, …) still resolve through the


### PR DESCRIPTION
## Summary
When Ajax sends a push for a sensor activation that happens while the system is armed (e.g. a motion detector firing during night mode, or a door opening while the panel is armed away), the payload carries both the sensor-trip information *and* the surrounding state as context. Until now the integration's parser walked event qualifier types in a fixed order and returned the first match — which meant the state context (`space_night_mode_on`, `space_armed_with_malfunctions`, …) shadowed the actual sensor activity. A motion detector tripping during night mode rendered in Home Assistant as `event_type: arm_night`, indistinguishable from the user actually pressing the night-mode button.

This change makes the parser score every successful match by tag priority and return the highest-ranked one. Confirmed incidents (alarm, panic) outrank critical detectors (tamper, smoke, fire, leak, glass break, CO), which outrank sensor activity (motion, door open, doorbell), which outranks user-driven state transitions. Pure arm / disarm pushes — where there's no competing sensor activity — keep returning the state transition unchanged, since nothing higher-ranked is present to outrank it.

## What's user-visible
- Motion detector trips during armed-night → `event_type: motion` (was `arm_night`)
- Door opens during armed-away → `event_type: door_open` (was `arm`)
- Doorbell pressed during armed state → `event_type: doorbell_pressed` (was sometimes `arm`)
- Tamper / smoke / leak / glass break / CO during armed → respective event_type (was `arm`)
- Confirmed intrusion alarm → `event_type: alarm` (was `arm`/`arm_night`)
- **Pure arm / disarm / night-mode change by user** → unchanged
- **`raw_tag` field on the event payload preserves the original Ajax tag** in all cases, so any automation keying off it continues to work

## Why
Observed against a real install today: a sensor sequence during armed-night (door opens → motion detector trips → motion detector trips → access card disarms) rendered in HA as three `arm_night` events plus one `disarm`, all firing within ~230 ms. The events were captured (FCM healthy, parser dispatched, event entity fired), but the labels made it impossible for a user automation to distinguish "sensor tripped" from "system was put into night mode". The lower-level information was already in the payload — Ajax bundles both — we just weren't surfacing the more specific one.

## Test plan
- [x] 4 new unit tests under `TestExtractEventCompiledProtos` exercise the priority resolution directly: highest-tier match wins, single match still resolves, confirmed incident beats sensor activity, ties resolve in candidate scan order. They use mocks so they don't depend on synthetic proto bytes cross-decoding (real Ajax wire payloads, where each qualifier comes wrapped in its own typed `*NotificationContent`, don't have that cross-decode problem).
- [x] Existing test `test_space_qualifier_preferred_over_hub_subincident` renamed and rewritten as `test_intrusion_alarm_beats_state_context` — its previous assertion was encoding the bug the test was named to protect against.
- [x] All other existing parser tests remain green (single-qualifier paths, doorbell paths, SmartLock doorbell path, etc.).
- [x] Full CI in Docker without volume mount passes: 1299 tests (was 1295), 86.18% coverage, lint/format/typecheck/dead-code all green.