### PR TITLE
chore(notification): warn + hex-dump when group push has no group_id

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -450,6 +450,22 @@ class AjaxNotificationListener:
                     group_info = self._extract_space_source_info(raw)
                     if group_info:
                         event_data.update(group_info)
+                    else:
+                        # The parser confirmed a `space_group_*` event but
+                        # `_extract_space_source_info` could not locate the
+                        # SpaceNotificationSource that carries the group_id —
+                        # so the per-group panel cannot be updated from the
+                        # push and falls back on the next poll. Dump the raw
+                        # payload hex so the wire shape can be inspected and
+                        # the heuristic fixed (#148). WARNING is intentional:
+                        # this is a degraded path for the user.
+                        _LOGGER.warning(
+                            "Group push %s parsed without group_id; "
+                            "per-group panel will only update on next poll. "
+                            "Raw payload (hex, capped 2048 bytes): %s",
+                            event_data.get("raw_tag"),
+                            raw[:2048].hex(),
+                        )
                 _LOGGER.debug(
                     "Push event parsed: event_type=%s raw_tag=%s group_id=%s",
                     event_type,

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1031,6 +1031,96 @@ class TestParseAndFireEventLogging:
             for r in caplog.records
         )
 
+    def test_group_event_without_group_id_logs_warning_with_hex(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When `space_group_*` is recognised but the source scan finds no
+        `group_id`, we WARN and dump the raw payload hex (#148 beta.6).
+
+        Without this signal the user's only clue is a panel that doesn't
+        update — and without the hex we can't reverse-engineer why the
+        SpaceNotificationSource heuristic missed.
+        """
+        import logging as _logging
+
+        listener = self._make_listener()
+        raw_bytes = b"\x0a\x05group\x12\x04test"
+        encoded = base64.b64encode(raw_bytes).decode()
+        notif_logger = "custom_components.aegis_ajax.notification"
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=("disarm", {"raw_tag": "space_group_disarmed"}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value={}),
+            patch.object(listener, "_extract_space_source_info", return_value={}),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+            caplog.at_level(_logging.WARNING, logger=notif_logger),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "space_group_disarmed" in r.message and raw_bytes.hex() in r.message for r in warnings
+        ), f"missing expected WARNING with hex dump, got {[r.message for r in warnings]}"
+
+    def test_group_event_with_group_id_does_not_log_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Counter-test: when the source scan resolves a `group_id`, the
+        warning path must stay silent — otherwise every healthy group
+        push would spam the logs."""
+        import logging as _logging
+
+        listener = self._make_listener()
+        encoded = base64.b64encode(b"any-payload").decode()
+        notif_logger = "custom_components.aegis_ajax.notification"
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=("arm", {"raw_tag": "space_group_armed"}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value={}),
+            patch.object(
+                listener,
+                "_extract_space_source_info",
+                return_value={"group_id": "g7", "group_name": "Studio"},
+            ),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+            caplog.at_level(_logging.WARNING, logger=notif_logger),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    def test_non_group_event_without_source_does_not_log_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Counter-test: whole-space `space_armed` carries no
+        SpaceNotificationSource by design — must not trip the group
+        diagnostic warning."""
+        import logging as _logging
+
+        listener = self._make_listener()
+        encoded = base64.b64encode(b"any-payload").decode()
+        notif_logger = "custom_components.aegis_ajax.notification"
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=("arm", {"raw_tag": "space_armed"}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value={}),
+            patch.object(listener, "_extract_space_source_info", return_value={}),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+            caplog.at_level(_logging.WARNING, logger=notif_logger),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
 
 class TestNotificationDedupe:
     """Issue #80: Ajax dispatches two FCM messages per security transition with


### PR DESCRIPTION
## Summary

- Detected via #148 beta.5 logs: parser correctly identifies `space_group_disarmed` / `space_group_auto_disarmed`, but `_extract_space_source_info` returns `group_id=None` on the user's real payloads. So per-group panels stay out of sync until the next poll.
- We have **no captured wire payload** to inspect, so we can't fix the heuristic blind. This PR ships a WARNING + raw-hex dump that fires **only** when a `space_group_*` event lands without a `group_id`, so the reporter just shares the WARNING line and we get the bytes.
- Counter-tested so healthy group pushes and whole-space `space_armed` events stay silent — the diagnostic must not become routine log noise. WARNING level is intentional: degraded user-visible behaviour (`feedback_ha_default_log_level_warning`).

## Test plan

- [x] `make check` inside a freshly-rebuilt Docker image, no volume mount — 1302 passed, 86.21% coverage, lint/format/typecheck/vulture all green.
- [x] 4 new tests covering: hex appears for group event w/o group_id; silent when group_id resolved; silent for non-group events.
- [ ] Ship as `1.5.0-beta.6`, ask ArshSoni to update + capture the next `WARNING ... Raw payload (hex...)` line, then decode it to fix the scan in beta.7.

Refs #148