### PR TITLE
fix(notification): resolve group_id from DisplayGroups, not SpaceNotificationSource

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -447,18 +447,25 @@ class AjaxNotificationListener:
                 if source_info:
                     event_data.update(source_info)
                 if event_data.get("raw_tag") in RAW_TAG_TO_GROUP_SECURITY_STATE:
-                    group_info = self._extract_space_source_info(raw)
+                    # Ajax actually encodes the group context in
+                    # `additional_data.space_display_groups` as a
+                    # `DisplayGroups.Group(group_hex_id, group_name)` —
+                    # not in the `SpaceNotificationSource` we used to scan
+                    # (#148 wire capture in beta.6). Try DisplayGroups
+                    # first; fall back to the legacy SpaceNotificationSource
+                    # path in case a future Ajax build also emits it there.
+                    group_info = self._extract_space_group_info(
+                        raw
+                    ) or self._extract_space_source_info(raw)
                     if group_info:
                         event_data.update(group_info)
                     else:
-                        # The parser confirmed a `space_group_*` event but
-                        # `_extract_space_source_info` could not locate the
-                        # SpaceNotificationSource that carries the group_id —
-                        # so the per-group panel cannot be updated from the
-                        # push and falls back on the next poll. Dump the raw
-                        # payload hex so the wire shape can be inspected and
-                        # the heuristic fixed (#148). WARNING is intentional:
-                        # this is a degraded path for the user.
+                        # Diagnostic path: parser confirmed a `space_group_*`
+                        # event but neither extractor located the group_id,
+                        # so the per-group panel only updates on next poll.
+                        # The hex dump survives in case Ajax ships yet another
+                        # wire shape down the road. WARNING is intentional —
+                        # degraded user-visible behaviour.
                         _LOGGER.warning(
                             "Group push %s parsed without group_id; "
                             "per-group panel will only update on next poll. "
@@ -758,6 +765,54 @@ class AjaxNotificationListener:
                 if not source.id or not source.name:
                     continue
                 return {"group_id": source.id, "group_name": source.name}
+        return {}
+
+    @staticmethod
+    def _extract_space_group_info(raw: bytes) -> dict[str, Any]:
+        """Extract group identifier from a `DisplayGroups.Group` (#148 fix).
+
+        Reverse-engineered from a real-install hex capture in `1.5.0-beta.6`:
+        Ajax encodes the group context of `space_group_*` push events inside
+        `additional_data.space_display_groups` (a `DisplayGroups` message),
+        not in the SpaceNotificationSource our previous extractor scanned —
+        so that scan always returned `{}` for group events in production.
+        The inner `DisplayGroups.Group` carries `group_hex_id` (field 1
+        string) and `group_name` (field 2 string).
+
+        Scan strategy: every `0x0a` byte (wire tag for field 1 length-delim,
+        i.e. the start of `group_hex_id`) is a candidate. Try parsing the
+        next 4–80 bytes as `DisplayGroups.Group` and accept the first match
+        with both string fields populated and printable. Other `0x0a` hits
+        either fail to parse or end up with non-printable bytes (e.g. when
+        the position is the OUTER `DisplayGroups.groups` wire tag and the
+        Group bytes are absorbed as a single binary string), which the
+        printable check filters out.
+        """
+        try:
+            from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: PLC0415, E501
+                display_groups_pb2,
+            )
+        except ImportError:
+            _LOGGER.debug("DisplayGroups proto not available")
+            return {}
+
+        group_class = display_groups_pb2.DisplayGroups.Group
+        for i in range(len(raw) - 5):
+            if raw[i] != 0x0A:
+                continue
+            for end in range(i + 4, min(i + 80, len(raw) + 1)):
+                try:
+                    group = group_class()
+                    group.ParseFromString(raw[i:end])
+                except Exception:
+                    continue
+                if not group.group_hex_id or not group.group_name:
+                    continue
+                if not group.group_hex_id.isprintable():
+                    continue
+                if not group.group_name.isprintable():
+                    continue
+                return {"group_id": group.group_hex_id, "group_name": group.group_name}
         return {}
 
     @staticmethod

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -248,6 +248,64 @@ class TestNotificationListener:
         result = AjaxNotificationListener._extract_space_source_info(b"\x00\x01\x02\x03")
         assert result == {}
 
+    def test_extract_space_group_info_resolves_group_from_display_groups(self) -> None:
+        """Real production fix (#148): Ajax actually carries the group_id in
+        `additional_data.space_display_groups` → `DisplayGroups.Group`, not
+        in the `SpaceNotificationSource` the previous extractor scanned.
+        Confirmed against a wire capture from beta.6's WARNING dump.
+        """
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: E501
+            display_groups_pb2,
+        )
+
+        group = display_groups_pb2.DisplayGroups.Group(
+            group_hex_id="00000001", group_name="Out House"
+        )
+        # Test against the inner-Group bytes (the wire shape we land on
+        # mid-payload after scanning).
+        raw = group.SerializeToString()
+        result = AjaxNotificationListener._extract_space_group_info(raw)
+        assert result == {"group_id": "00000001", "group_name": "Out House"}
+
+    def test_extract_space_group_info_resolves_from_wrapped_display_groups(self) -> None:
+        """The extractor must also work when the Group bytes are embedded
+        inside the parent `DisplayGroups`'s repeated `groups` field — that's
+        the actual wire shape in a real push payload."""
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: E501
+            display_groups_pb2,
+        )
+
+        display = display_groups_pb2.DisplayGroups(
+            groups=[
+                display_groups_pb2.DisplayGroups.Group(
+                    group_hex_id="00000001", group_name="Out House"
+                ),
+                display_groups_pb2.DisplayGroups.Group(group_hex_id="00000002", group_name="Home"),
+            ]
+        )
+        # Pad with leading bytes so the scan also has to walk past noise.
+        raw = b"\x99\x88" + display.SerializeToString() + b"\x77"
+        result = AjaxNotificationListener._extract_space_group_info(raw)
+        # First populated group wins — that's the one Ajax pushes for the
+        # specific event (the others are context).
+        assert result == {"group_id": "00000001", "group_name": "Out House"}
+
+    def test_extract_space_group_info_returns_empty_for_no_match(self) -> None:
+        assert AjaxNotificationListener._extract_space_group_info(b"\x00\x01\x02\x03") == {}
+
+    def test_extract_space_group_info_rejects_binary_garbage_in_strings(self) -> None:
+        """If a `0x0a` lands somewhere that ParseFromString succeeds but
+        fills the strings with non-printable bytes (the OUTER
+        `DisplayGroups.groups` tag absorbs the entire Group as a binary
+        string), the printable-only check must reject it. Otherwise we'd
+        return junk as `group_id`."""
+        # 0x0a + length + Group-bytes starting with another 0x0a (binary):
+        binary_blob = b"\x0a\x12\x0a\x08aaaaaaaa\x12\x06xxxxxx"  # outer wrap
+        result = AjaxNotificationListener._extract_space_group_info(binary_blob)
+        # First 0x0a (outer): group_hex_id would contain `\x0a\x08aaaaaaaa…`
+        # which fails isprintable() — must skip and try inner 0x0a at index 2.
+        assert result == {"group_id": "aaaaaaaa", "group_name": "xxxxxx"}
+
     @pytest.mark.asyncio
     async def test_on_notification_extracts_notification_id(self) -> None:
         """ENCODED_DATA with a notification_id resolves pending notification_id futures."""
@@ -1034,17 +1092,14 @@ class TestParseAndFireEventLogging:
     def test_group_event_without_group_id_logs_warning_with_hex(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """When `space_group_*` is recognised but the source scan finds no
-        `group_id`, we WARN and dump the raw payload hex (#148 beta.6).
-
-        Without this signal the user's only clue is a panel that doesn't
-        update — and without the hex we can't reverse-engineer why the
-        SpaceNotificationSource heuristic missed.
-        """
+        """When `space_group_*` is recognised but neither extractor finds
+        a `group_id`, we WARN and dump the raw payload hex (#148 beta.6).
+        The hex dump survives even after the DisplayGroups fix — if Ajax
+        ever ships yet another wire shape, we'll still see the bytes."""
         import logging as _logging
 
         listener = self._make_listener()
-        raw_bytes = b"\x0a\x05group\x12\x04test"
+        raw_bytes = b"\xff\xfe\xfd\xfc\xfb"
         encoded = base64.b64encode(raw_bytes).decode()
         notif_logger = "custom_components.aegis_ajax.notification"
         with (
@@ -1054,6 +1109,7 @@ class TestParseAndFireEventLogging:
                 return_value=("disarm", {"raw_tag": "space_group_disarmed"}),
             ),
             patch.object(listener, "_extract_source_info", return_value={}),
+            patch.object(listener, "_extract_space_group_info", return_value={}),
             patch.object(listener, "_extract_space_source_info", return_value={}),
             patch.object(listener, "_find_space_for_event", return_value="space-1"),
             caplog.at_level(_logging.WARNING, logger=notif_logger),
@@ -1064,6 +1120,63 @@ class TestParseAndFireEventLogging:
         assert any(
             "space_group_disarmed" in r.message and raw_bytes.hex() in r.message for r in warnings
         ), f"missing expected WARNING with hex dump, got {[r.message for r in warnings]}"
+
+    def test_group_event_from_display_groups_sets_group_id_silently(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """End-to-end (#148 fix): with a real `DisplayGroups.Group` in the
+        payload, the DisplayGroups extractor resolves `group_id` and the
+        WARNING path stays silent. Counter-test to ensure the new extractor
+        is actually wired into `_parse_and_fire_event`, not just defined."""
+        import logging as _logging
+
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: E501
+            display_groups_pb2,
+        )
+
+        listener = self._make_listener()
+        # Build a payload with a real DisplayGroups embedded; padding before
+        # and after makes the scan walk past noise like a real push would.
+        display = display_groups_pb2.DisplayGroups(
+            groups=[
+                display_groups_pb2.DisplayGroups.Group(
+                    group_hex_id="00000001", group_name="Out House"
+                )
+            ]
+        )
+        raw_bytes = b"\x99\x88\x77" + display.SerializeToString() + b"\x66"
+        encoded = base64.b64encode(raw_bytes).decode()
+
+        # Capture event_data so we can assert group_id was routed through.
+        captured: dict[str, object] = {}
+
+        def _capture_fire(space_id: str, event_type: str, event_data: dict) -> None:
+            captured["space_id"] = space_id
+            captured["event_type"] = event_type
+            captured["event_data"] = dict(event_data)
+
+        listener._coordinator.fire_push_event = _capture_fire
+        notif_logger = "custom_components.aegis_ajax.notification"
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=("disarm", {"raw_tag": "space_group_disarmed"}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value={}),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+            caplog.at_level(_logging.WARNING, logger=notif_logger),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+        # No diagnostic WARNING — the fix worked.
+        assert not [r for r in caplog.records if r.levelname == "WARNING"], (
+            "DisplayGroups extractor should resolve group_id and silence the warning path"
+        )
+        # And the group_id arrived in event_data so the coordinator can
+        # route to the right per-group alarm panel.
+        assert captured["event_data"]["group_id"] == "00000001"
+        assert captured["event_data"]["group_name"] == "Out House"
 
     def test_group_event_with_group_id_does_not_log_warning(
         self, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
## Summary

Reverse-engineered from the raw push hex captured by `1.5.0-beta.6`'s diagnostic WARNING on #148. The captured payload's tail decoded as `0a 08 "00000001" 12 09 "Out House"` — fields 1 and 2 of a length-delimited message. That's `DisplayGroups.Group`, not `SpaceNotificationSource`. Ajax actually carries the group context of `space_group_*` events in `additional_data.space_display_groups`, so the previous heuristic was scanning for the wrong proto and always returned `{}` in production — explaining why per-group panels in group-mode hubs never refreshed from FCM since #161 landed.

## Fix

- New `_extract_space_group_info(raw)`: scans for `0x0a` (wire tag of `DisplayGroups.Group.group_hex_id`), tries `ParseFromString` with growing slice, accepts the first match where both string fields are populated AND printable. The printable check rejects outer-wrapper false positives where the Group bytes get absorbed as a single binary string.
- `_parse_and_fire_event` prefers DisplayGroups, falls back to the legacy `SpaceNotificationSource` path as paranoia.
- Diagnostic WARNING hex-dump from beta.6 stays — if Ajax ever ships yet another wire shape, we'll see the bytes.

## Test plan

- [x] `make check` inside a freshly-rebuilt Docker image — 1309 passed (was 1304), coverage 86.17%, lint/format/typecheck/vulture all green.
- [x] 4 new direct tests on the extractor: synthetic Group, wrapped DisplayGroups in noise, empty input, outer-wrapper-with-binary-leadbyte path.
- [x] 1 end-to-end test through `_parse_and_fire_event` confirming `group_id` reaches `event_data` and the WARNING stays silent.
- [ ] Ship as `1.5.0-beta.8`, ask ArshSoni to update and arm a single group from the Ajax app — expectation: the matching `alarm_control_panel` entity flips within ~1 s instead of waiting for the next poll.

Refs #148