### PR TITLE
fix(notification): tighten group_id extractor (parent DisplayGroups + hex sanity)

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -767,26 +767,34 @@ class AjaxNotificationListener:
                 return {"group_id": source.id, "group_name": source.name}
         return {}
 
+    # Ajax `group_hex_id` values observed in real installs are short hex
+    # strings (typically 8 chars like "00000001"). The cap and hex-only
+    # check filter out false matches where the scan happens to land on
+    # an unrelated (string, string) pair — most notably the 24-char
+    # `space_id` followed by some printable field, which is what beta.8's
+    # too-permissive scan picked up in #148.
+    _MAX_GROUP_HEX_ID_LEN = 16
+    _HEX_CHARS = frozenset("0123456789abcdefABCDEF")
+
     @staticmethod
     def _extract_space_group_info(raw: bytes) -> dict[str, Any]:
-        """Extract group identifier from a `DisplayGroups.Group` (#148 fix).
+        """Extract group identifier from `DisplayGroups.groups[0]` (#148).
 
-        Reverse-engineered from a real-install hex capture in `1.5.0-beta.6`:
-        Ajax encodes the group context of `space_group_*` push events inside
-        `additional_data.space_display_groups` (a `DisplayGroups` message),
-        not in the SpaceNotificationSource our previous extractor scanned —
-        so that scan always returned `{}` for group events in production.
-        The inner `DisplayGroups.Group` carries `group_hex_id` (field 1
-        string) and `group_name` (field 2 string).
+        Beta.8 extractor was too permissive: it parsed bytes as
+        `DisplayGroups.Group` directly, so any `(printable_string,
+        printable_string)` pair in the payload could be mistaken for a
+        group — and on a real install it latched onto the 24-char
+        `space_id` instead of the actual 8-char group id.
 
-        Scan strategy: every `0x0a` byte (wire tag for field 1 length-delim,
-        i.e. the start of `group_hex_id`) is a candidate. Try parsing the
-        next 4–80 bytes as `DisplayGroups.Group` and accept the first match
-        with both string fields populated and printable. Other `0x0a` hits
-        either fail to parse or end up with non-printable bytes (e.g. when
-        the position is the OUTER `DisplayGroups.groups` wire tag and the
-        Group bytes are absorbed as a single binary string), which the
-        printable check filters out.
+        Beta.9 tightens two ways:
+          * Parse as the PARENT `DisplayGroups` (not the inner `Group`).
+            That requires the bytes to look like a length-delimited list
+            of Group sub-messages, not just one matched pair.
+          * Sanity-check the resolved `group_hex_id` shape: short
+            (≤ 16 chars) and hex-only. Matches Ajax's actual id format
+            and excludes the `space_id` 24-char hex by length alone.
+
+        Returns the first valid `(group_id, group_name)` found, or `{}`.
         """
         try:
             from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: PLC0415, E501
@@ -796,23 +804,36 @@ class AjaxNotificationListener:
             _LOGGER.debug("DisplayGroups proto not available")
             return {}
 
-        group_class = display_groups_pb2.DisplayGroups.Group
+        display_class = display_groups_pb2.DisplayGroups
+        max_id_len = AjaxNotificationListener._MAX_GROUP_HEX_ID_LEN
+        hex_chars = AjaxNotificationListener._HEX_CHARS
+        # Scan for `0x0a` (DisplayGroups.groups wire tag, field 1
+        # length-delim). Window up to 200 bytes per candidate gives enough
+        # room for one Group entry plus the outer length prefix.
         for i in range(len(raw) - 5):
             if raw[i] != 0x0A:
                 continue
-            for end in range(i + 4, min(i + 80, len(raw) + 1)):
+            for end in range(i + 6, min(i + 200, len(raw) + 1)):
                 try:
-                    group = group_class()
-                    group.ParseFromString(raw[i:end])
+                    display = display_class()
+                    display.ParseFromString(raw[i:end])
                 except Exception:
                     continue
-                if not group.group_hex_id or not group.group_name:
+                if not display.groups:
                     continue
-                if not group.group_hex_id.isprintable():
-                    continue
-                if not group.group_name.isprintable():
-                    continue
-                return {"group_id": group.group_hex_id, "group_name": group.group_name}
+                for group in display.groups:
+                    if not group.group_hex_id or not group.group_name:
+                        continue
+                    if not group.group_name.isprintable():
+                        continue
+                    if len(group.group_hex_id) > max_id_len:
+                        continue
+                    if not all(c in hex_chars for c in group.group_hex_id):
+                        continue
+                    return {
+                        "group_id": group.group_hex_id,
+                        "group_name": group.group_name,
+                    }
         return {}
 
     @staticmethod

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -248,29 +248,13 @@ class TestNotificationListener:
         result = AjaxNotificationListener._extract_space_source_info(b"\x00\x01\x02\x03")
         assert result == {}
 
-    def test_extract_space_group_info_resolves_group_from_display_groups(self) -> None:
-        """Real production fix (#148): Ajax actually carries the group_id in
-        `additional_data.space_display_groups` → `DisplayGroups.Group`, not
-        in the `SpaceNotificationSource` the previous extractor scanned.
-        Confirmed against a wire capture from beta.6's WARNING dump.
+    def test_extract_space_group_info_resolves_from_display_groups(self) -> None:
+        """Real production fix (#148): Ajax carries the group_id in
+        `additional_data.space_display_groups` → `DisplayGroups`. Real
+        payloads always wrap the Group in the parent message (confirmed
+        from beta.6 + beta.8 wire captures), so the extractor parses the
+        parent — not the inner Group directly — to stay specific.
         """
-        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: E501
-            display_groups_pb2,
-        )
-
-        group = display_groups_pb2.DisplayGroups.Group(
-            group_hex_id="00000001", group_name="Out House"
-        )
-        # Test against the inner-Group bytes (the wire shape we land on
-        # mid-payload after scanning).
-        raw = group.SerializeToString()
-        result = AjaxNotificationListener._extract_space_group_info(raw)
-        assert result == {"group_id": "00000001", "group_name": "Out House"}
-
-    def test_extract_space_group_info_resolves_from_wrapped_display_groups(self) -> None:
-        """The extractor must also work when the Group bytes are embedded
-        inside the parent `DisplayGroups`'s repeated `groups` field — that's
-        the actual wire shape in a real push payload."""
         from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: E501
             display_groups_pb2,
         )
@@ -286,25 +270,73 @@ class TestNotificationListener:
         # Pad with leading bytes so the scan also has to walk past noise.
         raw = b"\x99\x88" + display.SerializeToString() + b"\x77"
         result = AjaxNotificationListener._extract_space_group_info(raw)
-        # First populated group wins — that's the one Ajax pushes for the
-        # specific event (the others are context).
+        # First valid group wins — that's the one Ajax pushes for the
+        # specific event (the others are context for the rest of the UI).
         assert result == {"group_id": "00000001", "group_name": "Out House"}
 
     def test_extract_space_group_info_returns_empty_for_no_match(self) -> None:
         assert AjaxNotificationListener._extract_space_group_info(b"\x00\x01\x02\x03") == {}
 
-    def test_extract_space_group_info_rejects_binary_garbage_in_strings(self) -> None:
-        """If a `0x0a` lands somewhere that ParseFromString succeeds but
-        fills the strings with non-printable bytes (the OUTER
-        `DisplayGroups.groups` tag absorbs the entire Group as a binary
-        string), the printable-only check must reject it. Otherwise we'd
-        return junk as `group_id`."""
-        # 0x0a + length + Group-bytes starting with another 0x0a (binary):
-        binary_blob = b"\x0a\x12\x0a\x08aaaaaaaa\x12\x06xxxxxx"  # outer wrap
-        result = AjaxNotificationListener._extract_space_group_info(binary_blob)
-        # First 0x0a (outer): group_hex_id would contain `\x0a\x08aaaaaaaa…`
-        # which fails isprintable() — must skip and try inner 0x0a at index 2.
-        assert result == {"group_id": "aaaaaaaa", "group_name": "xxxxxx"}
+    def test_extract_space_group_info_rejects_long_hex_id_like_space_id(self) -> None:
+        """Regression for #148 1.5.0-beta.8: the extractor used to latch
+        onto the 24-char `space_id` (also a hex string, encoded as field
+        1 string of some unrelated message) and return it as `group_id`,
+        which then failed to match any real Group in
+        `coordinator.spaces[].groups`. Length cap + parent-DisplayGroups
+        parse together reject that path. Reproducer: forge a Group with
+        a 24-char hex `group_hex_id` (looks exactly like a `space_id`)
+        and confirm the extractor refuses it.
+        """
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: E501
+            display_groups_pb2,
+        )
+
+        display = display_groups_pb2.DisplayGroups(
+            groups=[
+                display_groups_pb2.DisplayGroups.Group(
+                    group_hex_id="68f94162415a39f8b8df2e5d",  # real space_id from #148 capture
+                    group_name="169 WA",
+                )
+            ]
+        )
+        result = AjaxNotificationListener._extract_space_group_info(display.SerializeToString())
+        assert result == {}, "must not surface a 24-char hex string as group_id"
+
+    def test_extract_space_group_info_rejects_non_hex_id(self) -> None:
+        """Ajax `group_hex_id` is always hex chars — letters g-z signal
+        we landed on an unrelated (string, string) pair and must skip."""
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: E501
+            display_groups_pb2,
+        )
+
+        display = display_groups_pb2.DisplayGroups(
+            groups=[
+                display_groups_pb2.DisplayGroups.Group(group_hex_id="hello", group_name="world")
+            ]
+        )
+        assert AjaxNotificationListener._extract_space_group_info(display.SerializeToString()) == {}
+
+    def test_extract_space_group_info_picks_next_group_when_first_invalid(self) -> None:
+        """If the first Group in a DisplayGroups payload fails sanity
+        (e.g. a long hex_id), the extractor must check the next entry
+        rather than returning empty — defends against any payload that
+        leads with a context Group and follows with the real one."""
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.commonmodels.notification.space.additional.data import (  # noqa: E501
+            display_groups_pb2,
+        )
+
+        display = display_groups_pb2.DisplayGroups(
+            groups=[
+                display_groups_pb2.DisplayGroups.Group(
+                    group_hex_id="68f94162415a39f8b8df2e5d", group_name="169 WA"
+                ),
+                display_groups_pb2.DisplayGroups.Group(
+                    group_hex_id="00000001", group_name="Out House"
+                ),
+            ]
+        )
+        result = AjaxNotificationListener._extract_space_group_info(display.SerializeToString())
+        assert result == {"group_id": "00000001", "group_name": "Out House"}
 
     @pytest.mark.asyncio
     async def test_on_notification_extracts_notification_id(self) -> None:


### PR DESCRIPTION
## Summary

Beta.8's extractor parsed bytes as `DisplayGroups.Group` directly, so any (printable_string, printable_string) pair could be mistaken for a Group. On Arsh's install (#148, beta.8 logs) the scan latched onto the 24-char `space_id` instead of the 8-char `group_id`, returning `group_id=68f94162415a39f8b8df2e5d` — which then never matched any real group in `coordinator.spaces[].groups`, so the per-group panel **still** didn't update.

Two reinforcements:

- Parse the PARENT `DisplayGroups` (not inner Group). Requires the bytes to look like a length-delimited list of Group sub-messages, not just one matched pair.
- Sanity-check resolved `group_hex_id`: ≤ 16 chars + hex-only. Matches Ajax's observed format ("00000001"-style) and excludes the 24-char `space_id` by length alone.

Walks every entry in the matched DisplayGroups so a context-first sibling doesn't shadow the real one.

## Test plan

- [x] `make check` inside a freshly-rebuilt Docker image — 1310 passed, coverage 86.18%, lint/format/typecheck/vulture all green.
- [x] Test changes: drops the unrealistic inner-Group-only positive case (real payloads always wrap), keeps the wrapped happy path, adds 3 regressions — 24-char hex-id reject (the actual beta.8 bug), non-hex id reject, "second-group wins after first fails sanity" probe.
- [ ] Ship as `1.5.0-beta.9`, ask ArshSoni to retest.

Refs #148