### PR TITLE
fix(coordinator): convert sub-call CancelledError to UpdateFailed during refresh

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -436,6 +436,28 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return {"spaces": self.spaces, "devices": self.devices}
         except ConfigEntryAuthFailed:
             raise
+        except asyncio.CancelledError:
+            # A `CancelledError` here typically comes from a sub-call (most
+            # often the gRPC stub) whose channel got closed mid-flight —
+            # e.g. when the user clicks Reload, the previous client's
+            # teardown can race with the new client's first refresh and
+            # the in-flight RPC gets cancelled. `CancelledError` is a
+            # `BaseException`, so the `except Exception` below would
+            # never see it; without this branch it bubbles through
+            # `async_config_entry_first_refresh` and leaves the entry in
+            # a permanent failed state until HA is restarted (#148).
+            #
+            # If OUR task is the one being cancelled (HA shutdown,
+            # reload interrupting us, etc.), we must let the cancellation
+            # propagate — eating it would prevent the coroutine from
+            # ever exiting cleanly. `Task.cancelling()` returns the
+            # pending cancel-request count; non-zero means HA wants us
+            # gone, zero means the cancellation originated below us and
+            # we can surface it as a retryable update failure.
+            current = asyncio.current_task()
+            if current is not None and current.cancelling() > 0:
+                raise
+            raise UpdateFailed("Ajax gRPC call was cancelled mid-flight") from None
         except Exception as err:
             raise UpdateFailed("Error fetching Ajax data") from err
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -239,6 +239,52 @@ class TestAsyncUpdateData:
         assert coordinator.last_update_success_time >= first_ts
 
     @pytest.mark.asyncio
+    async def test_update_data_converts_subcall_cancel_to_update_failed(self) -> None:
+        """Regression for #148: when the gRPC stub raises `CancelledError`
+        mid-flight (most common during a reload race), the coordinator
+        used to let it propagate — and `CancelledError` is a
+        `BaseException`, so HA's first-refresh path marked the entry as
+        permanently failed instead of retrying. Convert to `UpdateFailed`
+        so HA's standard retry-with-backoff applies."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(UpdateFailed, match="cancelled mid-flight"):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_update_data_propagates_external_cancellation(self) -> None:
+        """Counter-test: when HA cancels OUR task (shutdown, options
+        listener reload, etc.) the `CancelledError` must propagate so
+        the coroutine actually exits. Eating it would leave dangling
+        coroutines and prevent HA from completing teardown.
+
+        Setup: run `_async_update_data` inside a separate task and
+        cancel that task before the loop runs it. The first await
+        inside the coroutine delivers `CancelledError` while
+        `cancelling()` is non-zero, hitting the re-raise branch.
+        """
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[])
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        task = asyncio.create_task(coordinator._async_update_data())
+        task.cancel()  # pre-cancel so cancelling() > 0 when the coro first awaits
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
     async def test_update_data_does_not_set_timestamp_on_failure(self) -> None:
         coordinator = _make_coordinator()
         coordinator._client.session.is_authenticated = True


### PR DESCRIPTION
## Summary

Side-effect surfaced by @ArshSoni in #148: when the user clicks Reload, the previous client's teardown can race with the new client's first refresh and the in-flight gRPC RPC gets cancelled. `CancelledError` is a `BaseException`, so the existing `except Exception` handler in `_async_update_data` never caught it — the cancellation bubbled through `async_config_entry_first_refresh` and HA marked the entry as **permanently failed**, requiring a full HA restart to recover.

## Fix

Add an `except asyncio.CancelledError` branch that distinguishes the two cancellation paths:

- **OUR task is cancelling** (`current_task().cancelling() > 0`) — HA shutdown, options listener reload interrupting us, etc. — re-raise. Eating it would leave dangling coroutines.
- **Sub-call cancellation** (gRPC channel torn down during reload) — surface as `UpdateFailed` so HA's standard retry-with-backoff applies and the integration recovers on its own.

## Test plan

- [x] `make check` inside a freshly-rebuilt Docker image — 1312 passed (was 1310), coverage 86.17%, lint/format/typecheck/vulture all green.
- [x] Two new tests in `TestAsyncUpdateData`: sub-call CancelledError → UpdateFailed with "cancelled mid-flight" match; externally-cancelled task → CancelledError re-raised (run in a child task so pytest-asyncio's runner doesn't trip on the test task being cancelled).
- [ ] Bundle into `1.5.0-beta.10` together with the per-group push fix for the same issue.

Refs #148