### PR TITLE
fix(hts): redact ASCII-text sub-keys in DEBUG probe (refs #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.2] - 2026-05-23
+
+### Internal
+- **HTS DEBUG probe redacts ASCII-text sub-keys** (#179 follow-up). The value-logging introduced in `1.5.3-beta.1` made device names (`0x09`), user emails / phone numbers (`0x01`–`0x03` on user records) trivially decodable hex in the log line — risky the moment a user pastes a DEBUG capture into a public issue. Values whose bytes are ≥3 long and all printable ASCII now render as `0x09=<text:8b>` (length preserved, content masked); numeric readings (electrical counters, flag bytes) keep their full hex value because they always contain at least one non-printable byte. Net effect: a bug report can be pasted as-is without leaking the user's device names or contact info, but every electrical sub-key needed for #179 mapping stays visible.
+
 ## [1.5.3-beta.1] - 2026-05-23
 
 ### Fixed

--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -62,20 +62,46 @@ AUTH_TIMEOUT = 20
 MAX_CONSECUTIVE_READ_TIMEOUTS = 3
 
 
+def _redact_if_text(value: bytes) -> str:
+    """Return `value.hex()` unless the bytes look like printable ASCII text,
+    in which case return a length-preserving redacted marker.
+
+    SETTINGS sub-keys carry PII as raw text: device names (`0x09`), user
+    names / emails / phones (`0x01`/`0x02`/`0x03` on user records). The
+    previous size-only DEBUG format (`0x09(8b)`) hid that content
+    incidentally; the post-#179 value format would surface it as trivially
+    decodable hex (`0x09=46494e20484142` = "FIN HAB") and end up in
+    publicly-pasted bug reports. Detecting text by "all bytes printable
+    ASCII, length ≥ 3" replaces values like that with `<text:8b>` so the
+    byte-shape information remains useful for protocol analysis while
+    the contents stay private. Numeric readings (electrical counters,
+    flag bytes) always contain at least one non-printable byte (0x00
+    being the most common) so they keep their hex value — exactly what
+    we need to map the unknown Outlet sub-keys.
+    """
+    if len(value) >= 3 and all(0x20 <= b <= 0x7E for b in value):
+        return f"<text:{len(value)}b>"
+    return value.hex()
+
+
 def _format_non_hub_kv_summary(
     non_hub: list[tuple[bytes, dict[int, bytes]]],
 ) -> str:
     """Render a STATUS/SETTINGS body or per-device push as a one-line DEBUG
-    string with the raw hex value of every sub-key.
+    string with the raw hex value of every sub-key (PII redacted, see
+    `_redact_if_text`).
 
-    Format: `DEVICE_ID=[0x37=00112233,0x73=deadbeef…]`. Before #179 the line
-    only showed sub-key sizes; mapping an unknown device family then
-    required a second user round-trip with bespoke tracing. Logging the
-    values directly lets a single capture under a known load pin every
-    reading to its sub-key.
+    Format: `DEVICE_ID=[0x37=00112233,0x09=<text:8b>,0x73=deadbeef…]`.
+    Before #179 the line only showed sub-key sizes; mapping an unknown
+    device family then required a second user round-trip with bespoke
+    tracing. Logging the values directly lets a single capture under a
+    known load pin every reading to its sub-key without leaking the
+    user's device names / contact info.
     """
     return ", ".join(
-        f"{did.hex().upper()}=[" + ",".join(f"0x{k:02x}={kvs[k].hex()}" for k in sorted(kvs)) + "]"
+        f"{did.hex().upper()}=["
+        + ",".join(f"0x{k:02x}={_redact_if_text(kvs[k])}" for k in sorted(kvs))
+        + "]"
         for did, kvs in non_hub
     )
 

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.1"
+    "version": "1.5.3-beta.2"
 }

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -675,6 +675,62 @@ class TestHandleUpdateNonHubProbe:
         assert "0x73=deadbeef0102030405060708090a0b0c" in text
 
     @pytest.mark.asyncio
+    async def test_text_looking_values_are_redacted(self, caplog: pytest.LogCaptureFixture) -> None:
+        """#179 follow-up: PII (device names, user emails, phone numbers)
+        live in SETTINGS sub-keys as raw text bytes. When a user shares a
+        DEBUG log publicly to help debug an unmapped device family, those
+        values must NOT surface as easily-decodable hex. Replace anything
+        that looks like ASCII text with a length-preserving placeholder
+        so the byte shape stays visible but the content does not."""
+        import logging
+
+        caplog.set_level(logging.DEBUG, logger="custom_components.aegis_ajax.api.hts.client")
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x05",  # sub-key 5 = SETTINGS_BODY
+                    bytes.fromhex("12345678"),
+                    b"\x48",
+                    b"\x02",
+                    bytes.fromhex("AABBCCDD"),
+                    b"\x09",
+                    b"FIN HAB",  # 7-byte device name = text → redact
+                    b"\x02",
+                    b"alice@example.com",  # email = text → redact
+                    b"\x37",
+                    b"\x00\x11\x22\x33",  # numeric, 0x00 NUL not printable → keep hex
+                    b"\x73",
+                    b"\x00" * 16,  # all-zero counter → keep hex
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        probe_lines = [r for r in caplog.records if "#123 probe" in r.getMessage()]
+        assert probe_lines, "expected one #123 probe DEBUG line"
+        text = probe_lines[0].getMessage()
+        # Text values redacted, length preserved.
+        assert "0x09=<text:7b>" in text
+        assert "0x02=<text:17b>" in text
+        # And the raw text bytes are NOT in the log under any encoding.
+        assert "FIN HAB" not in text
+        assert "alice" not in text
+        assert b"FIN HAB".hex() not in text
+        assert b"alice@example.com".hex() not in text
+        # Numeric / blob values still visible (these are the #179 readings).
+        assert "0x37=00112233" in text
+        assert "0x73=00000000000000000000000000000000" in text
+
+    @pytest.mark.asyncio
     async def test_on_device_kv_fires_once_per_non_hub_device(self) -> None:
         client = _make_client()
         client._hubs = [MagicMock(hub_id="12345678")]


### PR DESCRIPTION
## Summary

- Refs #179. The value-logging shipped in `1.5.3-beta.1` was correct for the Outlet mapping goal but accidentally turned SETTINGS sub-keys that carry text — device name `0x09`, user name `0x01`, email `0x02`, phone `0x03` — into trivially decodable hex. The moment a user pastes a DEBUG capture into a public issue, that PII goes with it.
- Add `_redact_if_text(value)`: bytes ≥ 3 long and entirely printable ASCII (0x20–0x7E) render as `<text:Nb>`. Length stays visible; content is masked. Numeric readings (electrical counters, flag bytes, the 0x73/0x74 blobs we still need to map for the Outlet) always include at least one non-printable byte so they keep their full hex value untouched.

## Concrete impact

Observed on the test install after deploying `1.5.3-beta.1`:

```
0x09=46494e20484142            → "FIN HAB"        (device name)
0x09=504f525441                → "PORTA"
0x02=626173696c696f2e76657261…  → an email
0x03=2b3334363236393031353634   → a phone number
```

After this PR:

```
0x09=<text:7b>
0x09=<text:5b>
0x02=<text:32b>
0x03=<text:13b>
```

The Outlet electrical sub-keys we need for the #179 mapping (`0x37=00112233`, `0x73=000000…`, `0x05=0064`, …) all contain at least one non-printable byte so the heuristic leaves them as full hex.

## Tests

- New `test_text_looking_values_are_redacted` builds a SETTINGS_BODY payload mixing a 7-byte text value (`b"FIN HAB"`), a 17-byte email, a 4-byte numeric blob with a NUL, and a 16-byte zero counter; asserts the text fields render as `<text:Nb>` and the original hex doesn't surface anywhere, while the numeric/zero values keep their hex.
- Existing `test_non_hub_device_subkeys_log_includes_hex_values` still passes — its fixture uses `\x00\x11\x22\x33` (0x00 NUL is not printable) so no false redaction.

`make check` clean. 1325 tests pass. Coverage 86.23%.

## Why this matters before pinging the user on #179

Without this change, asking @SaetanSaDiablo for a DEBUG log of his Outlet under known loads would publish his device names + Ajax-account email + phone in the issue thread. With this change, the same log can be pasted as-is and contains only the byte-shape information the parser fix actually needs.