### PR TITLE
fix(hts): route per-device deltas by payload shape, not key heuristic (refs #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.3] - 2026-05-24
+
+### Fixed
+- **Live electrical readings (current / power / energy) now update from per-device HTS deltas, not only the boot-time snapshot** (#179 follow-up). The hub-network-state delta heuristic was over-matching: it ran `_extract_direct_kv` against any non-body `UPDATES` message and any kv dict it produced was tested against `KEY_HUB_POWERED` (`0x03`) and four other hub-level keys. For a per-device payload (`[sub_key, device_id_4b, k, v, k, v, …]`) `_extract_direct_kv` happily pairs up downstream bytes — and the operational state byte `0x03` is so common as a value across Ajax devices that the heuristic fired on essentially every per-device delta, dropping it into the hub-network-state parser instead of the per-device handler. `device_readings` then never received the live update, electrical sensors stayed at whatever the initial STATUS_BODY snapshot had set, and `RestoreSensor` made the stale values look "live" after a restart — masking the bug entirely. The router now classifies by payload shape: a 4-byte `params[1]` means per-device and skips the network-state heuristic completely. WallSwitches and the EU socket family on multi-device hubs (#123 cohort) are the visible beneficiaries.
+
 ## [1.5.3-beta.2] - 2026-05-23
 
 ### Internal

--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -675,20 +675,37 @@ class HtsClient:
         if not hub_id:
             return
 
-        kv = self._extract_direct_kv(params[1:])
-        if kv and self._is_network_state_delta(kv):
-            _LOGGER.debug(
-                "Hub %s: parsed %d keys from delta sub-key %d",
-                hub_id,
-                len(kv),
-                sub_key,
-            )
-            existing = self._hub_states.get(hub_id)
-            new_state = parse_hub_params(kv, existing)
-            self._hub_states[hub_id] = new_state
-            if self._on_state_update:
-                self._on_state_update(hub_id, new_state)
-            return
+        # Discriminate per-device deltas from hub-network-state deltas by
+        # payload shape (#179 follow-up). Network-state deltas carry a
+        # 1-byte key at params[1]; per-device deltas carry a 4-byte
+        # device_id there. Without this guard, `_extract_direct_kv`
+        # happily pairs up later bytes of the per-device payload and
+        # frequently produces a kv dict whose keys contain `0x03`
+        # (`KEY_HUB_POWERED`) because a downstream value byte equals
+        # `0x03` — the operational state byte common to many Ajax
+        # devices. `_is_network_state_delta` then misclassifies every
+        # per-device live reading as a network-state delta, silently
+        # dropping the update before it reaches `_on_device_kv` and
+        # leaving electrical sensors stuck on whatever STATUS_BODY
+        # snapshot last seeded them (`RestoreSensor` then makes the
+        # values look "live" after a restart, masking the bug entirely).
+        is_per_device_shape = len(params) >= 2 and len(params[1]) == 4
+
+        if not is_per_device_shape:
+            kv = self._extract_direct_kv(params[1:])
+            if kv and self._is_network_state_delta(kv):
+                _LOGGER.debug(
+                    "Hub %s: parsed %d keys from delta sub-key %d",
+                    hub_id,
+                    len(kv),
+                    sub_key,
+                )
+                existing = self._hub_states.get(hub_id)
+                new_state = parse_hub_params(kv, existing)
+                self._hub_states[hub_id] = new_state
+                if self._on_state_update:
+                    self._on_state_update(hub_id, new_state)
+                return
 
         # Sub-keys 11 (STATUS_UPDATE) and 12 (SETTINGS_UPDATE) are the
         # hub's per-device push channels: the hub emits one of these

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.2"
+    "version": "1.5.3-beta.3"
 }

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -362,6 +362,60 @@ class TestHandleUpdate:
         client._on_state_update.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_per_device_delta_with_state_byte_routes_to_device_path(self) -> None:
+        """#179 follow-up: STATUS_UPDATE deltas for an individual device
+        must reach `_on_device_kv`, not the hub-network-state parser.
+
+        The bug: `_extract_direct_kv(params[1:])` was being run on every
+        non-body delta to test for the hub-network shape. For a per-device
+        payload `[sub_key, device_id_4b, k1, v1, k2, v2, …]`, the 4-byte
+        device_id at `params[1]` doesn't qualify as a key (length != 1),
+        so the helper happily pairs up later bytes — frequently producing
+        a kv dict whose keys contain `0x03` (`KEY_HUB_POWERED`) because
+        a value byte downstream happens to be `0x03` (the operational
+        state byte common to many Ajax devices). `_is_network_state_delta`
+        then fires the wrong path and every per-device live reading is
+        silently dropped, leaving `device_readings` to only ever be
+        seeded by the initial STATUS_BODY snapshot. The fix routes by
+        payload shape (a 4-byte `params[1]` means per-device) before
+        running the heuristic.
+        """
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        client._on_state_update = MagicMock()
+        captured: list[tuple[str, str, dict[int, bytes]]] = []
+        client._on_device_kv = lambda hub_id, did, kv: captured.append((hub_id, did, kv))
+
+        # Mimics a real Outlet STATUS_UPDATE: 4-byte device_id, then
+        # multiple (k1=byte, v1=byte) pairs where v1 happens to be 0x03 —
+        # the byte that triggered the misroute on SaetanSaDiablo's hub.
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.UPDATES,
+            payload=tlv_encode(
+                [
+                    b"\x0b",  # sub_key 11 = STATUS_UPDATE
+                    bytes.fromhex("30537E4C"),
+                    b"\x02",
+                    b"\x03",  # value byte = 0x03 = KEY_HUB_POWERED
+                    b"\x05",
+                    b"\x07",
+                ]
+            ),
+        )
+
+        await client._handle_update(msg)
+
+        # Per-device path must fire with the real kv from the payload.
+        assert captured == [("12345678", "30537E4C", {0x02: b"\x03", 0x05: b"\x07"})]
+        # Network-state parser must NOT have been called.
+        client._on_state_update.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unknown_hub_update_requests_refresh_once(self) -> None:
         client = _make_client()
         client._hubs = [MagicMock(hub_id="12345678")]


### PR DESCRIPTION
## Summary

- Refs #179. Per-device HTS deltas (`STATUS_UPDATE` / `SETTINGS_UPDATE` for WallSwitches, Outlets, Sockets, anything in the #123 electrical cohort) were silently misrouted to the hub-network-state parser. They never reached `_on_device_kv`, so `device_readings` was only ever populated from the initial `STATUS_BODY` snapshot — and `RestoreSensor` then made the stale values look "live" after every restart, masking the bug entirely.
- Route by payload shape: a 4-byte `params[1]` means per-device → skip the network-state heuristic. Network-state deltas (1-byte key at `params[1]`) keep their current path.

## How @SaetanSaDiablo's log exposed it

The capture they shared for the load test (idle / 173 W / 2.15 kW / back to idle) shows **64** lines of `parsed N keys from delta sub-key 11` and **zero** lines of `STATUS_UPDATE push (#123)`. The per-device probe (the value-rich log we shipped in `1.5.3-beta.1`) never fired for them — every single device delta got swallowed by the hub-network path. Cross-checking against their initial `STATUS_BODY` confirmed the heuristic was the culprit: their Outlet's status payload contains both key `0x03` and value byte `0x03`, and `_extract_direct_kv(params[1:])` reliably produces a kv dict whose keys include `0x03` (`KEY_HUB_POWERED`) for that shape.

## Test

`test_per_device_delta_with_state_byte_routes_to_device_path`:
- Builds a STATUS_UPDATE payload `[0x0b, device_id_4b, 0x02, 0x03, 0x05, 0x07]` — the exact shape that triggers the false positive (value byte 0x03 lines up as a kv-dict key for `_extract_direct_kv`).
- Asserts `_on_device_kv` IS called with `{0x02: b"\x03", 0x05: b"\x07"}`.
- Asserts `_on_state_update` is NOT called.

RED before the routing fix (delta misclassified, `_on_device_kv` never fires). GREEN after.

Existing `test_direct_delta_update_clears_ethernet_and_keeps_wifi` (a genuine network-state delta with `params[1] = b"\x48"`, 1 byte) stays green — it falls through the new shape gate untouched.

`make check` clean, with and without volume mount. 1326 tests pass. Coverage 86.23 %.

## Impact

Once shipped, any WallSwitch / Socket / Outlet that emits live electrical deltas should start updating their current / power / voltage / energy sensors continuously, not only at startup. This is the prerequisite to actually map @SaetanSaDiablo's Outlet Type E sub-keys in a follow-up — the `STATUS_UPDATE push (#123)` probe lines (already value-rich since `1.5.3-beta.1`, with PII auto-redacted since `1.5.3-beta.2`) will now fire when they should, so a single load-test capture pins every reading to its sub-key.