### PR TITLE
feat(fcm): structural pre-flight on credentials before contacting Google (refs #182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.4] - 2026-05-24
+
+### Changed
+- **FCM credentials now get a structural pre-flight check before the integration calls Google** (#182, follow-up to #155 reported by @alt-BadBatch and @aitrus22). A truncated `fcm_app_id` hash tail (the canonical paste error — the `1:<digits>:android:<hex>` form is ~60 chars and easy to clip on the trailing hex) used to surface from Google as `API_KEY_ANDROID_APP_BLOCKED` with `androidPackage: <empty>` — accurate (Google can't decode the package identity from a half-hashed app_id) but unactionable, because the API key isn't actually the problem. The integration now validates the four FCM values offline before contacting Firebase: `fcm_app_id` parses as `1:<digits>:android:<hex>` with a 30..64-char hex tail, `fcm_api_key` matches `AIza` + 35 chars, `fcm_sender_id` is digits and equals the digit chunk in `fcm_app_id`, and `fcm_project_id` is non-empty. If any shape is off, a dedicated `fcm_credentials_malformed` Repair card names the specific field (e.g. "fcm_app_id hash chunk is 18 chars; expected ~40") instead of leaving the user to read Google's 403 in the logs. Same fix-flow as the existing runtime-rejection Repair — re-enter the four values, integration reloads, the check re-runs. Mutually exclusive with `fcm_credentials_invalid` (shapes-bad OR Firebase-rejected, never both). Translations land in all 14 locales.
+
 ## [1.5.3-beta.3] - 2026-05-24
 
 ### Fixed

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.3"
+    "version": "1.5.3-beta.4"
 }

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -24,8 +24,10 @@ from custom_components.aegis_ajax.const import (
 )
 from custom_components.aegis_ajax.repairs import (
     async_clear_fcm_credentials_invalid,
+    async_clear_fcm_credentials_malformed,
     async_clear_fcm_not_configured,
     async_register_fcm_credentials_invalid,
+    async_register_fcm_credentials_malformed,
     async_register_fcm_not_configured,
 )
 
@@ -56,6 +58,71 @@ NOTIFICATION_DEDUPE_WINDOW_SECONDS = 5.0
 # measured (sub-second) but short enough that a replay from any prior session
 # is rejected.
 STALE_PUSH_THRESHOLD_SECONDS = 120.0
+
+
+_FCM_APP_ID_RE = re.compile(r"^1:(\d+):android:([0-9a-fA-F]+)$")
+_FCM_API_KEY_RE = re.compile(r"^AIza[0-9A-Za-z_-]{35}$")
+# Firebase emits Android app_ids whose hash tail is 40 hex characters. We
+# accept anything in [30, 64] to leave a paranoia-margin for future Firebase
+# format tweaks while still catching the half-pasted values that cause
+# `androidPackage: <empty>` 403s server-side. Tail shorter than this is the
+# truncation pattern observed in #155 and #182.
+_FCM_APP_ID_HASH_MIN = 30
+_FCM_APP_ID_HASH_MAX = 64
+
+
+def _validate_fcm_shape(
+    *,
+    fcm_project_id: str,
+    fcm_app_id: str,
+    fcm_api_key: str,
+    fcm_sender_id: str,
+) -> str | None:
+    """Pre-flight structural check on the four FCM values.
+
+    Catches paste-truncation and mixed-projects errors offline, before
+    `firebase_messaging` hits Firebase Installations. Without this, a
+    half-pasted `fcm_app_id` surfaces as `API_KEY_ANDROID_APP_BLOCKED`
+    / `androidPackage: <empty>` from Google — accurate but unactionable,
+    because the API key isn't actually the problem (#155, #182).
+
+    Returns a short English description of the first problem found
+    (suitable for a Repair card `{problem}` placeholder), or `None`
+    when every shape is coherent. We surface one problem at a time so
+    the Repair card has a single concrete next-action; the user
+    re-enters all four values regardless.
+    """
+    if not fcm_project_id:
+        return "fcm_project_id is empty"
+
+    app_id_match = _FCM_APP_ID_RE.match(fcm_app_id)
+    if app_id_match is None:
+        return 'fcm_app_id does not match the expected shape "1:<digits>:android:<hex>"'
+    app_id_sender, app_id_hash = app_id_match.group(1), app_id_match.group(2)
+    if len(app_id_hash) < _FCM_APP_ID_HASH_MIN:
+        return (
+            f"fcm_app_id hash chunk is {len(app_id_hash)} chars; expected ~40 (truncated on paste?)"
+        )
+    if len(app_id_hash) > _FCM_APP_ID_HASH_MAX:
+        return (
+            f"fcm_app_id hash chunk is {len(app_id_hash)} chars; expected ~40 (extra characters?)"
+        )
+
+    if not _FCM_API_KEY_RE.match(fcm_api_key):
+        return (
+            'fcm_api_key does not match the expected shape (starts with "AIza", exactly 39 chars)'
+        )
+
+    if not fcm_sender_id.isdigit():
+        return "fcm_sender_id must contain only digits"
+    if fcm_sender_id != app_id_sender:
+        return (
+            f"fcm_sender_id ({fcm_sender_id}) does not match the digit "
+            f"chunk inside fcm_app_id ({app_id_sender}) — values come "
+            f"from two different Firebase projects"
+        )
+
+    return None
 
 
 def _classify_fcm_failure(exc: BaseException) -> str:
@@ -171,6 +238,7 @@ class AjaxNotificationListener:
         # credentials roundtrip can re-raise it from a clean slate.
         if self._entry_id:
             async_clear_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)
+            async_clear_fcm_credentials_malformed(self._hass, entry_id=self._entry_id)
             async_clear_fcm_not_configured(self._hass, entry_id=self._entry_id)
         if not self._fcm_api_key:
             _LOGGER.warning(
@@ -181,6 +249,33 @@ class AjaxNotificationListener:
             )
             if self._entry_id:
                 async_register_fcm_not_configured(self._hass, entry_id=self._entry_id)
+            return
+
+        # Pre-flight shape check on the four values. A malformed
+        # `fcm_app_id` (truncated hash tail) surfaces server-side as
+        # `API_KEY_ANDROID_APP_BLOCKED` / `androidPackage: <empty>`,
+        # which accurately reports the symptom but hides the culprit —
+        # the user concludes the API key is wrong and keeps re-pasting
+        # it (#155, #182). Catching it offline lets the Repair card
+        # name `fcm_app_id` directly.
+        shape_problem = _validate_fcm_shape(
+            fcm_project_id=self._fcm_project_id,
+            fcm_app_id=self._fcm_app_id,
+            fcm_api_key=self._fcm_api_key,
+            fcm_sender_id=self._fcm_sender_id,
+        )
+        if shape_problem is not None:
+            _LOGGER.warning(
+                "FCM credentials malformed — push notifications disabled. %s. "
+                "Re-extract per the README's 'Where the values live' section "
+                "and re-enter all four values via the Repair card under "
+                "Settings → Repairs.",
+                shape_problem,
+            )
+            if self._entry_id:
+                async_register_fcm_credentials_malformed(
+                    self._hass, entry_id=self._entry_id, problem=shape_problem
+                )
             return
 
         try:

--- a/custom_components/aegis_ajax/repairs.py
+++ b/custom_components/aegis_ajax/repairs.py
@@ -35,6 +35,7 @@ DOCS_BASE_URL = "https://github.com/bvis/aegis-hass#"
 ISSUE_HUB_OFFLINE_24H = "hub_offline_24h"
 ISSUE_HTS_CHRONIC_FAILURE = "hts_chronic_failure"
 ISSUE_FCM_CREDENTIALS_INVALID = "fcm_credentials_invalid"
+ISSUE_FCM_CREDENTIALS_MALFORMED = "fcm_credentials_malformed"
 ISSUE_FCM_NOT_CONFIGURED = "fcm_not_configured"
 ISSUE_GRPCIO_VERSION_MISMATCH = "grpcio_version_mismatch"
 
@@ -126,6 +127,37 @@ def async_register_fcm_credentials_invalid(hass: HomeAssistant, *, entry_id: str
 
 def async_clear_fcm_credentials_invalid(hass: HomeAssistant, *, entry_id: str) -> None:
     ir.async_delete_issue(hass, DOMAIN, _issue_id(ISSUE_FCM_CREDENTIALS_INVALID, entry_id))
+
+
+def async_register_fcm_credentials_malformed(
+    hass: HomeAssistant, *, entry_id: str, problem: str
+) -> None:
+    """FCM credentials failed pre-flight shape validation.
+
+    Distinct from `fcm_credentials_invalid` (Firebase rejected
+    structurally-valid credentials): this fires when the four values
+    can't possibly be a coherent set — e.g. a truncated `fcm_app_id`
+    hash tail (#155, #182) or `fcm_sender_id` that doesn't match the
+    digit chunk inside `fcm_app_id`. The card surfaces the specific
+    problem so the user knows which field to re-paste instead of
+    debugging Google's opaque 403. Same fix-flow as the runtime
+    rejection — re-enter the four values.
+    """
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        _issue_id(ISSUE_FCM_CREDENTIALS_MALFORMED, entry_id),
+        is_fixable=True,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key=ISSUE_FCM_CREDENTIALS_MALFORMED,
+        translation_placeholders={"problem": problem},
+        data={"entry_id": entry_id},
+        learn_more_url=f"{DOCS_BASE_URL}where-the-values-live",
+    )
+
+
+def async_clear_fcm_credentials_malformed(hass: HomeAssistant, *, entry_id: str) -> None:
+    ir.async_delete_issue(hass, DOMAIN, _issue_id(ISSUE_FCM_CREDENTIALS_MALFORMED, entry_id))
 
 
 def async_register_fcm_not_configured(hass: HomeAssistant, *, entry_id: str) -> None:
@@ -268,7 +300,11 @@ async def async_create_fix_flow(
     data: dict[str, str | int | float | None] | None,
 ) -> RepairsFlow:
     """HA discovery hook — returns the right flow for each fixable issue."""
-    for prefix in (ISSUE_FCM_CREDENTIALS_INVALID, ISSUE_FCM_NOT_CONFIGURED):
+    for prefix in (
+        ISSUE_FCM_CREDENTIALS_INVALID,
+        ISSUE_FCM_CREDENTIALS_MALFORMED,
+        ISSUE_FCM_NOT_CONFIGURED,
+    ):
         if issue_id.startswith(f"{prefix}:"):
             entry_id = (data or {}).get("entry_id") or issue_id.split(":", 1)[1]
             return FcmCredentialsRepairFlow(str(entry_id))

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -192,6 +192,26 @@
                 }
             }
         },
+        "fcm_credentials_malformed": {
+            "title": "Push notifications disabled — FCM credentials malformed ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Fix Aegis FCM credentials",
+                        "description": "Aegis caught a structural problem with the configured FCM credentials before contacting Google: {problem}. The four values must come from the same Firebase project — re-extract them from your co-branded Ajax app per the README's 'Where the values live' section, then re-enter all four below. The integration will reload, the shape check will re-run, and the Repair clears once the values are coherent.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "The Aegis account this Repair was raised for is no longer configured. Nothing to fix."
+                }
+            }
+        },
         "grpcio_version_mismatch": {
             "title": "Aegis needs grpcio {required} or newer (found {current})",
             "description": "Aegis depends on `grpcio` for the gRPC channel that talks to the Ajax cloud, and your Home Assistant install ships `grpcio` {current}. Login can fail with cryptic HTTP/2 errors below {required}. On Home Assistant Core or Container the integration manifest pins the version on install, but on Home Assistant OS the runtime ships system-wide grpcio that this manifest cannot influence — you'll typically need to upgrade Home Assistant OS to a build that includes a newer grpcio. The Repair clears automatically on the next reload once the version crosses {required}."

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -181,6 +181,26 @@
             "title": "Notificacions push desactivades: credencials FCM rebutjades",
             "description": "El registre a Firebase Cloud Messaging ha fallat per a aquest compte. Probablement, el FCM Project ID / App ID / API Key / Sender ID configurats no es corresponen amb la teva app Ajax co-branded, o la API key s'ha revocat. Les funcions que depenen del push (estat instantani d'armat/desarmat, entitat security_event, URL de fotos de MotionCam) cauran a polling mes lent fins que es corregeixi. Obre el menu Configurar de la integracio per reintroduir les credencials FCM - consulta la seccio 'How to obtain FCM credentials' del README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Notificacions push desactivades: credencials FCM mal formades ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Reparar les credencials FCM d'Aegis",
+                        "description": "Aegis ha detectat un problema estructural a les credencials FCM configurades abans de contactar Google: {problem}. Els quatre valors han de venir del mateix projecte Firebase. Torna a extreure'ls de la teva app Ajax co-branded segons la seccio 'Where the values live' del README i reintrodueix els quatre a sota. La integracio es recarregara, la comprovacio s'executara de nou i el Repair es tancara quan els valors siguin coherents.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "El compte d'Aegis pel qual s'ha aixecat aquest Repair ja no esta configurat. No hi ha res a reparar."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Notificacions push no configurades — esdeveniments en temps real desactivats",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -181,6 +181,26 @@
             "title": "Push oznameni vypnuta - prihlasovaci udaje FCM odmitnuty",
             "description": "Registrace Firebase Cloud Messaging selhala pro tento ucet. Konfigurovane hodnoty FCM Project ID / App ID / API Key / Sender ID pravdepodobne neodpovidaji vasi co-brandove aplikaci Ajax, nebo byl API klic zneplatnen. Funkce zavisle na pushi (okamzity stav armed/disarmed, entita security_event, URL fotek z MotionCam) prejdou na pomalejsi polling, dokud to nenapravite. Otevrete nabidku Konfigurovat integrace a zadejte znovu prihlasovaci udaje FCM - viz sekce 'How to obtain FCM credentials' v README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Push oznameni vypnuta — udaje FCM jsou poskozene ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Oprava udaju FCM pro Aegis",
+                        "description": "Aegis zjistil strukturalni problem v nakonfigurovanych udajich FCM jeste pred kontaktem na Google: {problem}. Vsechny ctyri hodnoty musi pochazet ze stejneho projektu Firebase. Znovu je extrahuj ze sve co-branded Ajax aplikace podle sekce 'Where the values live' v README a opet zadej vsechny ctyri nize. Integrace se znovu nacte, kontrola se zopakuje a Repair se uzavre, jakmile budou hodnoty konzistentni.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Ucet Aegis, pro ktery byl tento Repair vytvoren, jiz neni nakonfigurovan. Neni co opravovat."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Push notifikace nejsou nakonfigurovany — udalosti v realnem case zakazany",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -181,6 +181,26 @@
             "title": "Push-Benachrichtigungen deaktiviert - FCM-Anmeldedaten abgelehnt",
             "description": "Die Firebase-Cloud-Messaging-Registrierung ist fuer dieses Konto fehlgeschlagen. Die konfigurierten Werte FCM Project ID / App ID / API Key / Sender ID passen vermutlich nicht zu Ihrer Co-Branding-Ajax-App oder der API-Schluessel wurde widerrufen. Push-basierte Funktionen (sofortiger Arm/Disarm-Status, security_event-Entitaet, Foto-URLs von MotionCam) fallen auf langsameres Polling zurueck, bis dies behoben ist. Oeffnen Sie das Konfigurationsmenue der Integration und geben Sie die FCM-Anmeldedaten erneut ein - siehe Abschnitt 'How to obtain FCM credentials' in der README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Push-Benachrichtigungen deaktiviert — FCM-Anmeldedaten fehlerhaft ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Aegis FCM-Anmeldedaten reparieren",
+                        "description": "Aegis hat ein strukturelles Problem mit den konfigurierten FCM-Anmeldedaten festgestellt, bevor Google kontaktiert wurde: {problem}. Die vier Werte muessen aus demselben Firebase-Projekt stammen. Extrahiere sie erneut aus deiner co-branded Ajax-App gemaess dem Abschnitt 'Where the values live' der README und gib alle vier unten erneut ein. Die Integration wird neu geladen, die Pruefung erneut ausgefuehrt, und der Repair schliesst sich, sobald die Werte stimmig sind.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Das Aegis-Konto, fuer das dieser Repair erstellt wurde, ist nicht mehr konfiguriert. Nichts zu reparieren."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Push-Benachrichtigungen nicht konfiguriert — Echtzeit-Ereignisse deaktiviert",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -193,6 +193,26 @@
                 }
             }
         },
+        "fcm_credentials_malformed": {
+            "title": "Push notifications disabled — FCM credentials malformed ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Fix Aegis FCM credentials",
+                        "description": "Aegis caught a structural problem with the configured FCM credentials before contacting Google: {problem}. The four values must come from the same Firebase project — re-extract them from your co-branded Ajax app per the README's 'Where the values live' section, then re-enter all four below. The integration will reload, the shape check will re-run, and the Repair clears once the values are coherent.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "The Aegis account this Repair was raised for is no longer configured. Nothing to fix."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Push notifications not configured — real-time events disabled",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -193,6 +193,26 @@
                 }
             }
         },
+        "fcm_credentials_malformed": {
+            "title": "Notificaciones push desactivadas: credenciales FCM mal formadas ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Reparar credenciales FCM de Aegis",
+                        "description": "Aegis ha detectado un problema estructural en las credenciales FCM configuradas antes de contactar con Google: {problem}. Los cuatro valores deben venir del mismo proyecto Firebase. Vuelve a extraerlos de tu app Ajax co-branded segun la seccion 'Where the values live' del README y reintroduce los cuatro abajo. La integracion se recargara, la comprobacion se ejecutara de nuevo y el Repair se cerrara cuando los valores sean coherentes.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "La cuenta de Aegis para la que se levanto este Repair ya no esta configurada. No hay nada que reparar."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Notificaciones push sin configurar: eventos en tiempo real desactivados",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -181,6 +181,26 @@
             "title": "Notifications push desactivees - identifiants FCM rejetes",
             "description": "L'enregistrement Firebase Cloud Messaging a echoue pour ce compte. Les valeurs FCM Project ID / App ID / API Key / Sender ID configurees ne correspondent probablement pas a votre application Ajax co-brandee, ou la cle API a ete revoquee. Les fonctions dependantes du push (etat instantane d'armement/desarmement, entite security_event, URLs de photos de MotionCam) basculent vers un polling plus lent jusqu'a correction. Ouvrez le menu Configurer de l'integration pour ressaisir les identifiants FCM - voir la section 'How to obtain FCM credentials' du README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Notifications push desactivees — identifiants FCM mal formes ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Reparer les identifiants FCM d'Aegis",
+                        "description": "Aegis a detecte un probleme structurel dans les identifiants FCM configures avant de contacter Google : {problem}. Les quatre valeurs doivent provenir du meme projet Firebase. Re-extrais-les de ton application Ajax co-branded selon la section 'Where the values live' du README, puis ressaisis les quatre ci-dessous. L'integration se rechargera, la verification sera relancee et le Repair se fermera des que les valeurs seront coherentes.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Le compte Aegis pour lequel ce Repair a ete leve n'est plus configure. Rien a reparer."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Notifications push non configurees — evenements temps reel desactives",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -181,6 +181,26 @@
             "title": "Notifiche push disabilitate - credenziali FCM rifiutate",
             "description": "La registrazione Firebase Cloud Messaging non e riuscita per questo account. I valori FCM Project ID / App ID / API Key / Sender ID configurati probabilmente non corrispondono alla tua app Ajax co-branded, oppure la API key e stata revocata. Le funzionalita basate sul push (stato istantaneo di armato/disarmato, entita security_event, URL delle foto da MotionCam) ripiegheranno su polling piu lento finche non viene corretto. Apri il menu Configura dell'integrazione per reinserire le credenziali FCM - consulta la sezione 'How to obtain FCM credentials' del README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Notifiche push disattivate — credenziali FCM malformate ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Riparare le credenziali FCM di Aegis",
+                        "description": "Aegis ha rilevato un problema strutturale nelle credenziali FCM configurate prima di contattare Google: {problem}. I quattro valori devono provenire dallo stesso progetto Firebase. Estraili nuovamente dalla tua app Ajax co-branded come indicato nella sezione 'Where the values live' del README, poi reinserisci tutti e quattro qui sotto. L'integrazione verra ricaricata, il controllo verra rieseguito e il Repair si chiudera quando i valori saranno coerenti.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "L'account Aegis per cui e stato sollevato questo Repair non e piu configurato. Niente da riparare."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Notifiche push non configurate — eventi in tempo reale disattivati",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -181,6 +181,26 @@
             "title": "Pushmeldingen uitgeschakeld - FCM-inloggegevens afgewezen",
             "description": "Firebase Cloud Messaging-registratie is voor dit account mislukt. De ingestelde FCM Project ID / App ID / API Key / Sender ID komen waarschijnlijk niet overeen met je co-branded Ajax-app, of de API-sleutel is ingetrokken. Push-afhankelijke functies (directe arm/disarm-status, security_event-entiteit, foto-URL's van MotionCam) vallen terug op langzamere polling totdat dit is opgelost. Open het menu Configureren van de integratie om de FCM-inloggegevens opnieuw in te voeren - zie de sectie 'How to obtain FCM credentials' in de README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Pushmeldingen uitgeschakeld — FCM-inloggegevens onjuist ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Aegis FCM-inloggegevens herstellen",
+                        "description": "Aegis heeft een structureel probleem in de geconfigureerde FCM-inloggegevens vastgesteld voordat Google werd benaderd: {problem}. De vier waarden moeten uit hetzelfde Firebase-project komen. Haal ze opnieuw uit je co-branded Ajax-app volgens het hoofdstuk 'Where the values live' in de README en voer alle vier hieronder opnieuw in. De integratie laadt opnieuw, de controle wordt opnieuw uitgevoerd en de Repair sluit zodra de waarden samenhangen.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Het Aegis-account waarvoor deze Repair is aangemaakt, is niet langer geconfigureerd. Niets te herstellen."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Pushmeldingen niet geconfigureerd — realtime gebeurtenissen uitgeschakeld",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -181,6 +181,26 @@
             "title": "Powiadomienia push wylaczone - dane FCM odrzucone",
             "description": "Rejestracja Firebase Cloud Messaging nie powiodla sie dla tego konta. Skonfigurowane wartosci FCM Project ID / App ID / API Key / Sender ID najprawdopodobniej nie odpowiadaja Twojej co-brandowej aplikacji Ajax lub klucz API zostal uniewazniony. Funkcje zalezne od push (natychmiastowy stan uzbrojenia/rozbrojenia, encja security_event, URL zdjec z MotionCam) przejda na wolniejszy polling do czasu naprawy. Otworz menu Konfiguruj integracji, aby ponownie wpisac dane FCM - zobacz sekcje 'How to obtain FCM credentials' w README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Powiadomienia push wylaczone — dane FCM nieprawidlowe ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Naprawa danych FCM dla Aegis",
+                        "description": "Aegis wykryl problem strukturalny w skonfigurowanych danych FCM przed kontaktem z Google: {problem}. Wszystkie cztery wartosci musza pochodzic z tego samego projektu Firebase. Wyodrebnij je ponownie z aplikacji Ajax co-branded zgodnie z sekcja 'Where the values live' w README, a nastepnie wprowadz ponownie wszystkie cztery ponizej. Integracja zostanie przeladowana, sprawdzenie zostanie wykonane ponownie, a Repair zamknie sie, gdy wartosci beda spojne.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Konto Aegis, dla ktorego utworzono ten Repair, nie jest juz skonfigurowane. Nie ma czego naprawiac."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Powiadomienia push nie skonfigurowane — zdarzenia w czasie rzeczywistym wylaczone",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -181,6 +181,26 @@
             "title": "Notificacoes push desativadas - credenciais FCM rejeitadas",
             "description": "O registro no Firebase Cloud Messaging falhou para esta conta. Os valores configurados de FCM Project ID / App ID / API Key / Sender ID provavelmente nao correspondem ao seu aplicativo Ajax co-branded, ou a chave da API foi revogada. Os recursos baseados em push (estado instantaneo de armar/desarmar, entidade security_event, URLs de fotos do MotionCam) farao fallback para polling mais lento ate a correcao. Abra o menu Configurar da integracao para inserir novamente as credenciais FCM - consulte a secao 'How to obtain FCM credentials' do README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Notificacoes push desativadas — credenciais FCM malformadas ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Reparar credenciais FCM do Aegis",
+                        "description": "O Aegis detectou um problema estrutural nas credenciais FCM configuradas antes de contatar o Google: {problem}. Os quatro valores precisam vir do mesmo projeto Firebase. Extraia-os novamente do seu app Ajax co-branded conforme a secao 'Where the values live' do README e reinsira os quatro abaixo. A integracao sera recarregada, a verificacao roda de novo e o Repair fecha quando os valores estiverem coerentes.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "A conta Aegis para a qual este Repair foi criado nao esta mais configurada. Nada para reparar."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Notificacoes push nao configuradas — eventos em tempo real desativados",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -181,6 +181,26 @@
             "title": "Notificacoes push desativadas - credenciais FCM rejeitadas",
             "description": "O registo no Firebase Cloud Messaging falhou para esta conta. Os valores configurados de FCM Project ID / App ID / API Key / Sender ID provavelmente nao correspondem a sua aplicacao Ajax co-branded, ou a chave da API foi revogada. As funcionalidades baseadas em push (estado instantaneo de armar/desarmar, entidade security_event, URLs de fotos do MotionCam) caem para polling mais lento ate a correcao. Abra o menu Configurar da integracao para introduzir novamente as credenciais FCM - consulte a seccao 'How to obtain FCM credentials' do README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Notificacoes push desativadas — credenciais FCM mal formadas ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Reparar credenciais FCM do Aegis",
+                        "description": "O Aegis detetou um problema estrutural nas credenciais FCM configuradas antes de contactar a Google: {problem}. Os quatro valores tem de vir do mesmo projeto Firebase. Volta a extrai-los da tua app Ajax co-branded segundo a seccao 'Where the values live' do README e reintroduz os quatro abaixo. A integracao sera recarregada, a verificacao volta a correr e o Repair fecha quando os valores forem coerentes.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "A conta Aegis para a qual este Repair foi criado ja nao esta configurada. Nada para reparar."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Notificacoes push nao configuradas — eventos em tempo real desativados",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -181,6 +181,26 @@
             "title": "Notificarile push dezactivate - credentiale FCM respinse",
             "description": "Inregistrarea Firebase Cloud Messaging a esuat pentru acest cont. Valorile configurate FCM Project ID / App ID / API Key / Sender ID probabil nu corespund aplicatiei tale Ajax co-branded, sau cheia API a fost revocata. Functionalitatile bazate pe push (stare instantanee armat/dezarmat, entitatea security_event, URL-uri de fotografii de la MotionCam) vor cadea pe polling mai lent pana la corectare. Deschide meniul Configureaza al integrarii pentru a reintroduce credentialele FCM - consulta sectiunea 'How to obtain FCM credentials' din README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Notificarile push dezactivate — credentiale FCM malformate ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Reparare credentiale FCM Aegis",
+                        "description": "Aegis a detectat o problema structurala in credentialele FCM configurate inainte de a contacta Google: {problem}. Cele patru valori trebuie sa provina din acelasi proiect Firebase. Extrage-le din nou din aplicatia ta Ajax co-branded conform sectiunii 'Where the values live' din README si reintroduce toate patru mai jos. Integrarea se va reincarca, verificarea va rula din nou si Repair-ul se inchide cand valorile sunt coerente.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Contul Aegis pentru care a fost ridicat acest Repair nu mai este configurat. Nimic de reparat."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Notificarile push nu sunt configurate — evenimente in timp real dezactivate",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -181,6 +181,26 @@
             "title": "Push bildirimleri devre disi - FCM kimlik bilgileri reddedildi",
             "description": "Bu hesap icin Firebase Cloud Messaging kaydi basarisiz oldu. Yapilandirilmis FCM Project ID / App ID / API Key / Sender ID degerleri buyuk olasilikla co-branded Ajax uygulamaniza karsilik gelmiyor veya API anahtari iptal edilmis. Push'a bagimli ozellikler (anlik armed/disarmed durumu, security_event varligi, MotionCam'den foto URL'leri) bu duzeltilene kadar daha yavas polling'e dusecektir. FCM kimlik bilgilerini yeniden girmek icin entegrasyonun Yapilandir menusunu acin - README'deki 'How to obtain FCM credentials' bolumune bakin."
         },
+        "fcm_credentials_malformed": {
+            "title": "Push bildirimleri kapatildi — FCM kimlik bilgileri bozuk ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Aegis FCM kimlik bilgilerini onar",
+                        "description": "Aegis, Google ile iletisime gecmeden once yapilandirilmis FCM kimlik bilgilerinde yapisal bir sorun tespit etti: {problem}. Dort degerin de ayni Firebase projesinden gelmesi gerekir. README'deki 'Where the values live' bolumune gore co-branded Ajax uygulamandan tekrar cikar ve dordunu de asagiya yeniden gir. Entegrasyon yeniden yuklenecek, kontrol tekrar calisacak ve degerler tutarli oldugunda Repair kapanacak.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Bu Repair'in olusturuldugu Aegis hesabi artik yapilandirilmis degil. Onarilacak bir sey yok."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Push bildirimleri yapilandirilmadi — gercek zamanli olaylar devre disi",
             "fix_flow": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -181,6 +181,26 @@
             "title": "Push-сповіщення вимкнено — облікові дані FCM відхилено",
             "description": "Реєстрація Firebase Cloud Messaging не вдалась для цього облікового запису. Налаштовані FCM Project ID / App ID / API Key / Sender ID, ймовірно, не відповідають вашому co-branded додатку Ajax, або API-ключ було відкликано. Функції, що залежать від push (миттєвий стан armed/disarmed, сутність security_event, URL-адреси фото з MotionCam), повернуться до повільнішого polling, доки це не буде виправлено. Відкрийте меню Налаштувати інтеграції, щоб повторно ввести облікові дані FCM — див. розділ 'How to obtain FCM credentials' у README."
         },
+        "fcm_credentials_malformed": {
+            "title": "Push-povidomlennya vimkneni — dani FCM neviernyi ({problem})",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Vidnovyty dani FCM dlya Aegis",
+                        "description": "Aegis vyiavyv strukturnu problemu u nalashtovanykh danykh FCM do zviazku z Google: {problem}. Vsi chotyry znachennia povynni pokhodyty z odnogo proektu Firebase. Vyluchy yikh znovu z dodatka Ajax co-branded zgidno z rozdilom 'Where the values live' u README ta vvedy vsi chotyry nyzhche. Integratsiya zaviantazhytsya znovu, perevirka zapustyt'sya znovu, i Repair zakryietsya, koly znachennia budut' uzgodzheni.",
+                        "data": {
+                            "fcm_project_id": "FCM Project ID",
+                            "fcm_app_id": "FCM App ID",
+                            "fcm_api_key": "FCM API Key",
+                            "fcm_sender_id": "FCM Sender ID"
+                        }
+                    }
+                },
+                "abort": {
+                    "entry_missing": "Akkaunt Aegis, dlya yakogo bulo stvoreno tsei Repair, vzhe ne nalashtovanyi. Nichogo vidnovluvaty."
+                }
+            }
+        },
         "fcm_not_configured": {
             "title": "Push-povidomlennia ne nalashtovano — podii v realnomu chasi vimkneno",
             "fix_flow": {

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -11,14 +11,29 @@ import pytest
 from custom_components.aegis_ajax.notification import (
     AjaxNotificationListener,
     _classify_fcm_failure,
+    _validate_fcm_shape,
 )
 
-_FCM_KWARGS = {
-    "fcm_project_id": "test-project",
-    "fcm_app_id": "test-app",
-    "fcm_api_key": "test-key",
-    "fcm_sender_id": "12345",
+# A coherent four-value FCM set whose shapes pass every validator check:
+# app_id matches `1:<digits>:android:<40 hex>`, sender_id equals the digit
+# chunk byte-for-byte, api_key is `AIza` + 35 chars (39 total). Real values
+# would round-trip to a real Firebase project; these don't, which is fine
+# because shape validation is offline.
+_VALID_FCM_SHAPES = {
+    "fcm_project_id": "mws-mobile-client---2",
+    "fcm_app_id": "1:991608156148:android:" + "a" * 40,
+    "fcm_api_key": "AIza" + "x" * 35,
+    "fcm_sender_id": "991608156148",
 }
+
+# Alias kept for the dozens of listener tests that don't exercise FCM
+# shape validation (notification parsing, photo-on-demand, etc) — they
+# just need any four-tuple that satisfies the constructor. Pre-#182 this
+# was a separate dict with placeholder strings ("test-app", etc.) that
+# would have failed the new shape check the moment any of them invoked
+# `async_start`, so pointing it at the validated set keeps them
+# bulletproof without per-test edits.
+_FCM_KWARGS = _VALID_FCM_SHAPES
 
 # Real ENCODED_DATA from a photo capture push notification (base64)
 _REAL_PUSH_ENCODED_DATA = (
@@ -470,6 +485,217 @@ class TestAsyncStartFcmRepairs:
             await listener.async_start()
 
         reg.assert_called_once_with(hass, entry_id="entry-x")
+
+
+class TestValidateFcmShape:
+    """Pure-function shape checks on the four FCM credentials.
+
+    The validator runs offline (no Firebase round-trip) and returns a
+    short English description of the first shape problem it finds, or
+    `None` when every value is structurally coherent. The point is to
+    catch paste-truncation / mismatched-projects errors BEFORE Google's
+    403 — same error class that surfaced in #155 and #182 with the
+    cryptic `API_KEY_ANDROID_APP_BLOCKED` / `androidPackage: <empty>`
+    message that doesn't name `fcm_app_id` as the culprit.
+    """
+
+    def test_all_valid_returns_none(self) -> None:
+        assert _validate_fcm_shape(**_VALID_FCM_SHAPES) is None
+
+    def test_app_id_missing_android_segment_is_rejected(self) -> None:
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_app_id": "1:991608156148:ios:" + "a" * 40},
+        )
+        assert problem is not None
+        assert "fcm_app_id" in problem
+
+    def test_app_id_missing_sender_chunk_is_rejected(self) -> None:
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_app_id": "1::android:" + "a" * 40},
+        )
+        assert problem is not None
+        assert "fcm_app_id" in problem
+
+    def test_app_id_truncated_hex_tail_is_rejected(self) -> None:
+        # ~half the canonical hash length — the user's paste was cut.
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_app_id": "1:991608156148:android:" + "a" * 18},
+        )
+        assert problem is not None
+        assert "fcm_app_id" in problem
+        # The hint should name the truncated chunk so the next-action
+        # is "re-paste the app_id", not "check the api_key".
+        lower = problem.lower()
+        assert "hash" in lower or "truncat" in lower or "short" in lower
+
+    def test_app_id_non_hex_tail_is_rejected(self) -> None:
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_app_id": "1:991608156148:android:" + "G" * 40},
+        )
+        assert problem is not None
+        assert "fcm_app_id" in problem
+
+    def test_sender_id_mismatch_with_app_id_is_rejected(self) -> None:
+        # The sender chunk inside fcm_app_id is `991608156148`, but
+        # fcm_sender_id was pasted as a different project's id.
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_sender_id": "123456789012"},
+        )
+        assert problem is not None
+        assert "fcm_sender_id" in problem
+
+    def test_sender_id_with_non_digit_is_rejected(self) -> None:
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_sender_id": "99160815614X"},
+        )
+        assert problem is not None
+        assert "fcm_sender_id" in problem
+
+    def test_api_key_wrong_prefix_is_rejected(self) -> None:
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_api_key": "Bzzz" + "x" * 35},
+        )
+        assert problem is not None
+        assert "fcm_api_key" in problem
+
+    def test_api_key_wrong_length_is_rejected(self) -> None:
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_api_key": "AIza" + "x" * 20},
+        )
+        assert problem is not None
+        assert "fcm_api_key" in problem
+
+    def test_project_id_empty_is_rejected(self) -> None:
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_project_id": ""},
+        )
+        assert problem is not None
+        assert "fcm_project_id" in problem
+
+    def test_returns_first_problem_when_multiple_fields_bad(self) -> None:
+        # Both app_id and api_key are bad; the validator returns one
+        # message (the caller surfaces one Repair at a time, not a
+        # bulk diff). The exact field surfaced is deterministic so
+        # the message is stable across runs.
+        problem = _validate_fcm_shape(
+            fcm_project_id="",
+            fcm_app_id="garbage",
+            fcm_api_key="garbage",
+            fcm_sender_id="garbage",
+        )
+        assert problem is not None
+
+
+class TestAsyncStartFcmShapePreflight:
+    """`async_start` runs shape validation BEFORE invoking firebase_messaging.
+
+    When shapes are malformed we raise the dedicated
+    `fcm_credentials_malformed` Repair (one click → re-enter the four
+    values) and skip the Firebase round-trip, so the user gets a
+    precise diagnosis instead of Google's opaque 403. Counterpart of
+    `test_register_failure_raises_repair`, which only fires once the
+    library has been called.
+    """
+
+    @pytest.mark.asyncio
+    async def test_malformed_app_id_short_circuits_firebase_call(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock()
+        coordinator = MagicMock()
+        listener = AjaxNotificationListener(
+            hass=hass,
+            coordinator=coordinator,
+            fcm_project_id="proj",
+            fcm_app_id="1:991608156148:android:short",  # truncated
+            fcm_api_key="AIza" + "x" * 35,
+            fcm_sender_id="991608156148",
+            entry_id="entry-x",
+        )
+        listener._store.async_load = AsyncMock(return_value=None)
+
+        register_cls = MagicMock()
+
+        with (
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_malformed"
+            ) as reg_malformed,
+            patch(
+                "custom_components.aegis_ajax.notification.async_clear_fcm_credentials_malformed"
+            ) as clr_malformed,
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_invalid"
+            ) as reg_invalid,
+            patch(
+                "custom_components.aegis_ajax.notification.async_clear_fcm_credentials_invalid"
+            ) as clr_invalid,
+            patch("custom_components.aegis_ajax.notification.async_register_fcm_not_configured"),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_not_configured"),
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+        ):
+            await listener.async_start()
+
+        # The malformed Repair is raised exactly once with the problem
+        # description as a translation placeholder so the Repair card
+        # names `fcm_app_id` instead of leaving the user to read logs.
+        assert reg_malformed.call_count == 1
+        kwargs = reg_malformed.call_args.kwargs
+        assert kwargs["entry_id"] == "entry-x"
+        assert "fcm_app_id" in kwargs["problem"]
+
+        # Firebase never gets called — shape check happens first.
+        register_cls.assert_not_called()
+
+        # The runtime-rejection Repair stays cleared (mutually
+        # exclusive: shapes-bad OR Google-rejected, never both visible).
+        reg_invalid.assert_not_called()
+        clr_invalid.assert_called_once_with(hass, entry_id="entry-x")
+        # The malformed Repair is also cleared at the top of the
+        # method, then re-registered after the shape check. Mirrors
+        # the existing pattern for `_invalid` / `_not_configured`.
+        clr_malformed.assert_called_once_with(hass, entry_id="entry-x")
+
+    @pytest.mark.asyncio
+    async def test_valid_shapes_skip_malformed_repair_and_call_firebase(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock()
+        coordinator = MagicMock()
+        listener = AjaxNotificationListener(
+            hass=hass, coordinator=coordinator, **_VALID_FCM_SHAPES, entry_id="entry-x"
+        )
+        listener._store.async_load = AsyncMock(return_value=None)
+
+        register_cls = MagicMock()
+        instance = MagicMock()
+        # Library raises after the shape check — we don't care about
+        # the rest of the pipeline here, just that the shape check
+        # didn't short-circuit before the library was reached.
+        instance.register = MagicMock(side_effect=RuntimeError("boom"))
+        register_cls.return_value = instance
+
+        with (
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_malformed"
+            ) as reg_malformed,
+            patch(
+                "custom_components.aegis_ajax.notification.async_clear_fcm_credentials_malformed"
+            ) as clr_malformed,
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_invalid"
+            ),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_credentials_invalid"),
+            patch("custom_components.aegis_ajax.notification.async_register_fcm_not_configured"),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_not_configured"),
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+        ):
+            await listener.async_start()
+
+        # Shape check passed → no malformed Repair raised, only the
+        # standard top-of-method clear fired.
+        reg_malformed.assert_not_called()
+        clr_malformed.assert_called_once_with(hass, entry_id="entry-x")
+
+        # Library was reached.
+        register_cls.assert_called_once()
 
 
 class TestClassifyFcmFailure:


### PR DESCRIPTION
## Summary
- Adds `_validate_fcm_shape()` in `notification.py` that regex-checks the four FCM credentials offline (`fcm_app_id` matches `1:<digits>:android:<30..64 hex>`, `fcm_api_key` matches `AIza`+35, `fcm_sender_id` is digits and matches the digit chunk inside `fcm_app_id`, `fcm_project_id` non-empty) and returns a short English problem description, or `None` when every shape is coherent.
- Hooks the check into `async_start()` **before** constructing `FcmRegisterConfig`. If any shape is off, the integration short-circuits with a dedicated `fcm_credentials_malformed` Repair card whose title names the specific field (e.g. `Push notifications disabled — FCM credentials malformed (fcm_app_id hash chunk is 18 chars; expected ~40)`). Mutually exclusive with `fcm_credentials_invalid` — at most one Repair surfaces per entry.
- Adds `async_register_fcm_credentials_malformed` / `async_clear_fcm_credentials_malformed` in `repairs.py`; reuses the existing `FcmCredentialsRepairFlow` form so the user just re-enters the four values. New issue prefix wired through `async_create_fix_flow`.
- Strings + translations for the new Repair in all 14 locales (best-effort per project policy; the `{problem}` placeholder stays English).
- Bumped to `1.5.3-beta.4` with CHANGELOG entry that references both #182 (alt-BadBatch, 1.5.3-beta.2, the trigger) and #155 (aitrus22, closed unconfirmed — same symptom, same paste-truncation root cause).

## Why now
#155 and #182 both report `API_KEY_ANDROID_APP_BLOCKED` with `androidPackage: <empty>` from Google. The diagnostic is accurate — Google can't decode the Android package identity from a half-hashed `fcm_app_id`, so the API key's Android-app restriction kicks in — but it's unactionable for users because the surface error names the API key, not the truncated `fcm_app_id` that actually caused it. With two independent reports in two months and the integration supporting ~20 cobranded variants (so adding `X-Android-Package` upstream isn't a clean fix), catching the structural problem offline is the right shape.

## Test plan
- [x] 11 unit tests for `_validate_fcm_shape` covering each branch (valid, app_id missing `:android:`, missing sender chunk, truncated hex tail, non-hex tail, sender mismatch, sender non-digit, api_key wrong prefix, api_key wrong length, project_id empty, multi-field garbage).
- [x] 2 integration tests for `async_start`: malformed app_id short-circuits before `FcmRegister`; valid shapes don't trigger the malformed Repair and reach the library.
- [x] Existing FCM test class (`TestAsyncStartFcmRepairs`) keeps passing — the `_FCM_KWARGS` constant now points at a shape-valid set so the dozens of unrelated listener tests don't trip on the new pre-flight check.
- [x] Full unit suite: 1339 passed, coverage 86.30% (up from 86.23%).
- [x] `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all green inside Docker, both with volume mount and on the rebuilt image without volume mount (per project CI policy).
- [x] All 14 locale JSON files parse and carry the new key (verified with a `json.loads` round-trip).