### PR TITLE
fix(config-flow): don't wipe saved fcm_api_key on empty resubmit (refs #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.5] - 2026-05-24
+
+### Fixed
+- **Saved FCM API Key no longer gets wiped by a benign re-submit of the Options form** (#183, reported by @raven2k24). When the user re-opened **Configure → Options** for any reason — verifying values, tweaking the poll interval, toggling `Force arm` — HA's frontend left the `FCM API Key` field blank because password TextSelectors never display saved secrets, even masked. Clicking Submit then sent an empty string for `fcm_api_key`, which the options handler interpreted as "clear this field" and popped the saved key out of `entry.data`. The other three FCM fields survived (text TextSelectors round-trip their saved values via `suggested_value`) so the integration ended up with three of four values and warned `FCM credentials not configured` on the next reload, with no obvious way for the user to tell which value had been wiped. An empty submission on `fcm_api_key` is now treated as "leave alone" — only the explicit `Delete FCM credentials` toggle wipes the key. The other three fields keep their existing clear-via-empty-string behavior because they DO round-trip their values, so an empty submission there reflects an actual user intent (#138 preserved). Symmetric companion to #138's no-can-delete bug: now you can keep what's there AND still delete via the toggle, without the password-selector blind spot biting either way.
+
 ## [1.5.3-beta.4] - 2026-05-24
 
 ### Changed

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -465,11 +465,17 @@ class AjaxCobrandedOptionsFlow(OptionsFlow):
             #      four keys unconditionally — the unambiguous deletion
             #      path, immune to selector-default round-trips.
             #   2. Otherwise, any non-empty value in a FCM field updates
-            #      that key. An empty string also clears the key, but
-            #      only if the field was actually submitted as empty —
-            #      the password selector tends to round-trip its prior
-            #      value, so the toggle above is the recommended way to
-            #      clear credentials (issue #138).
+            #      that key. An empty `fcm_api_key` submission is treated
+            #      as "leave alone" because that field is a password
+            #      TextSelector — HA's frontend never displays a saved
+            #      secret, so re-opening Options shows the API Key blank
+            #      regardless of what was persisted. Without this guard
+            #      a benign re-submit (e.g. to update the poll interval)
+            #      wiped the saved key (#183). The explicit toggle is
+            #      the only path that clears the API Key. The other
+            #      three FCM fields DO round-trip their saved values
+            #      via `suggested_value`, so an empty submission there
+            #      is a deliberate clear and still pops the key (#138).
             clear_fcm = user_input.pop("clear_fcm_credentials", False)
             fcm_input = {k: user_input.pop(k) for k in _FCM_KEYS if k in user_input}
             new_data = {**self._entry.data}
@@ -480,6 +486,8 @@ class AjaxCobrandedOptionsFlow(OptionsFlow):
                 for k, v in fcm_input.items():
                     if v:
                         new_data[k] = v
+                    elif k == "fcm_api_key":
+                        continue
                     else:
                         new_data.pop(k, None)
             if new_data != self._entry.data:

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.4"
+    "version": "1.5.3-beta.5"
 }

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -669,8 +669,16 @@ class TestOptionsFlow:
             assert k not in stored_options
 
     @pytest.mark.asyncio
-    async def test_options_flow_clearing_all_fcm_fields_removes_from_data(self) -> None:
-        """Empty strings for every FCM field remove them from entry.data (issue #138)."""
+    async def test_options_flow_clearing_three_text_fcm_fields_removes_them(self) -> None:
+        """Empty strings for the three text FCM fields remove them (#138).
+
+        `fcm_api_key` is the password TextSelector — see
+        `test_options_flow_empty_api_key_preserves_saved_value` for
+        why an empty submission there is intentionally a no-op (#183).
+        Only the three text fields (project_id, app_id, sender_id)
+        round-trip their saved values via `suggested_value`, so a user
+        actively emptying one of them is a deliberate clear.
+        """
         flow, entry = self._make_flow(
             data={
                 "email": "x@y",
@@ -696,19 +704,67 @@ class TestOptionsFlow:
 
         flow.hass.config_entries.async_update_entry.assert_called_once()
         new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
-        for k in ("fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id"):
+        for k in ("fcm_project_id", "fcm_app_id", "fcm_sender_id"):
             assert k not in new_data, f"{k} should be removed when cleared"
+        # fcm_api_key sticks (use the explicit toggle to wipe it).
+        assert new_data["fcm_api_key"] == "old_key"
         assert new_data["email"] == "x@y"
 
     @pytest.mark.asyncio
-    async def test_options_flow_clearing_one_fcm_field_keeps_others(self) -> None:
-        """Clearing only one FCM field removes that key while keeping the rest."""
+    async def test_options_flow_empty_api_key_preserves_saved_value(self) -> None:
+        """Empty `fcm_api_key` on resubmit must NOT wipe the saved key (#183).
+
+        Reproduces the bug raven2k24 hit on `1.5.1`: HA's frontend
+        leaves password TextSelectors blank when re-opening a form
+        (it won't display saved secrets, even masked), so a benign
+        re-submit — e.g. changing the poll interval — used to wipe the
+        previously-saved API key because the empty submission ran
+        through the `else: pop` branch. After this fix, only the
+        explicit `Delete FCM credentials` toggle wipes the key.
+        """
         flow, entry = self._make_flow(
             data={
-                "fcm_project_id": "old_proj",
-                "fcm_app_id": "old_app",
-                "fcm_api_key": "old_key",
-                "fcm_sender_id": "old_sender",
+                "fcm_project_id": "proj",
+                "fcm_app_id": "1:99:android:abc",
+                "fcm_api_key": "AIza-saved-secret",
+                "fcm_sender_id": "99",
+            }
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init(
+            {
+                "poll_interval": 90,  # the change the user actually came for
+                "use_pin_code": False,
+                "fcm_project_id": "proj",
+                "fcm_app_id": "1:99:android:abc",
+                "fcm_api_key": "",  # password field: blank on re-open
+                "fcm_sender_id": "99",
+            }
+        )
+
+        # async_update_entry only fires when new_data != entry.data.
+        # If we wipe api_key we mutate data and trigger a reload; if we
+        # leave it alone, data is unchanged and no save happens. Either
+        # branch must end with the saved api_key intact, so check both.
+        if flow.hass.config_entries.async_update_entry.called:
+            new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+            assert new_data["fcm_api_key"] == "AIza-saved-secret"
+        else:
+            assert entry.data["fcm_api_key"] == "AIza-saved-secret"
+
+    @pytest.mark.asyncio
+    async def test_options_flow_typed_api_key_still_overwrites_saved_value(self) -> None:
+        """The no-op-on-empty guard only fires for empty submissions —
+        if the user actually re-types the API key, the new value wins.
+        """
+        flow, entry = self._make_flow(
+            data={
+                "fcm_project_id": "proj",
+                "fcm_app_id": "1:99:android:abc",
+                "fcm_api_key": "AIza-old",
+                "fcm_sender_id": "99",
             }
         )
         flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
@@ -718,18 +774,15 @@ class TestOptionsFlow:
             {
                 "poll_interval": 60,
                 "use_pin_code": False,
-                "fcm_project_id": "new_proj",
-                "fcm_app_id": "new_app",
-                "fcm_api_key": "",
-                "fcm_sender_id": "new_sender",
+                "fcm_project_id": "proj",
+                "fcm_app_id": "1:99:android:abc",
+                "fcm_api_key": "AIza-new",
+                "fcm_sender_id": "99",
             }
         )
 
         new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
-        assert new_data["fcm_project_id"] == "new_proj"
-        assert new_data["fcm_app_id"] == "new_app"
-        assert "fcm_api_key" not in new_data
-        assert new_data["fcm_sender_id"] == "new_sender"
+        assert new_data["fcm_api_key"] == "AIza-new"
 
     @pytest.mark.asyncio
     async def test_options_flow_clear_fcm_toggle_removes_all_keys(self) -> None:


### PR DESCRIPTION
## Summary
- Empty `fcm_api_key` on Options Submit is now a no-op instead of clearing the saved key. HA's password TextSelector never displays a saved secret, so re-opening Options shows the field blank regardless of what's persisted — and any benign re-submit (changing poll interval, toggling Force arm, etc.) used to wipe the saved key.
- Only the explicit `Delete FCM credentials` toggle clears the key now. The three text FCM fields (`fcm_project_id`, `fcm_app_id`, `fcm_sender_id`) keep their existing empty-string-clears behavior because they DO round-trip their saved values via `suggested_value` — emptying them on the form is an actual user intent (preserves #138 fix).
- 1.5.3-beta.5 bump.

## Why now
@raven2k24 hit this on 1.5.1 (#183): saved 4 FCM values, re-opened settings to verify, integration warned `FCM credentials not configured` after a reload. Reading the options handler, the password-field blind spot lines up exactly — three of four values would survive, the fourth (API key) would be wiped silently, and the user would see the warning fire with no obvious cause. Symmetric companion to #138 (no-can-delete) — now you can keep what's saved AND still wipe via the toggle.

## Test plan
- [x] New `test_options_flow_empty_api_key_preserves_saved_value`: simulates the re-open-and-submit cycle (poll interval changed, API Key field blank), asserts the saved `fcm_api_key` value survives. Tolerates both code paths — short-circuit (no `async_update_entry`) and write (`async_update_entry` called with preserved value).
- [x] New `test_options_flow_typed_api_key_still_overwrites_saved_value`: a typed value on the API Key field still replaces the saved one. The no-op guard fires only on empty.
- [x] Updated `test_options_flow_clearing_three_text_fcm_fields_removes_them` (was `test_options_flow_clearing_all_fcm_fields_removes_from_data`): empty strings on the three text fields still clear them; `fcm_api_key` stays as the saved value. Use the toggle to wipe the key.
- [x] Removed obsolete `test_options_flow_clearing_one_fcm_field_keeps_others` — its assertion that emptying the API Key on resubmit pops the key was exactly the bug being fixed.
- [x] Full unit suite: 1340 passed (+1 net), coverage 86.31%.
- [x] `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all green on the rebuilt Docker image without volume mount.