### PR TITLE
feat(devices): probe unsupported LightDevice oneof cases (refs #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.6] - 2026-05-24
+
+### Internal
+- **`parse_device` now logs the wire-shape + PII-redacted bytes of LightDevice protos that don't match any known `device` oneof case** (#179 follow-up, @SaetanSaDiablo's load-calibrated Outlet Type E capture). The capture showed zero per-device HTS deltas during a 10-minute toggle window (where WallSwitches push their live electrical readings) but 18 gRPC `LightDevice` pushes arriving with `WhichOneof("device") = None` — i.e. the proto had unknown-field bytes the cloud emitted under a field number not present in our compiled `.proto`. Strong hypothesis: Ajax cloud started emitting Outlet Type E live readings via a NEW oneof case (likely field 5+, beyond our current `hub_device`/`video_edge`/`video_edge_channel`/`smart_lock` set) and our parser silently drops them. The new DEBUG probe emits two lines per unsupported LightDevice: `wire-shape: f<N>=bytes(<len>),…` (structural only, no values — safe to paste anywhere) and `bytes: <hex>` with printable-ASCII runs ≥3 chars masked as `<text:Nb>` (same 3-byte threshold as the HTS probe from `1.5.3-beta.2`, so device names / ids stay private while numeric readings stay visible). Default-level installs pay nothing — both lines are gated on DEBUG. The pair lets a single capture under known load identify the new field number AND the structure of its payload, so the next mapping iteration can land without another user round-trip.
+
 ## [1.5.3-beta.5] - 2026-05-24
 
 ### Fixed

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -17,6 +17,109 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _decode_proto_wire_shape(data: bytes) -> str:
+    """Render a one-line structural summary of protobuf wire-format bytes.
+
+    Walks the top-level fields, emitting `field=<num>,wt=<wire>,len=<n>`
+    (or `=varint`/`=i32`/`=i64` for fixed-size cases) for each one. No
+    values are surfaced — only field numbers and shapes — so this output
+    is safe to paste even when the original proto carries device names
+    or other PII. Used to spot a new oneof case (e.g. `field=5`) on a
+    `LightDevice` that our compiled `.proto` doesn't yet know about (#179
+    Outlet Type E hypothesis).
+    """
+    parts: list[str] = []
+    i = 0
+    while i < len(data):
+        try:
+            tag, i = _decode_varint(data, i)
+        except ValueError:
+            parts.append("<truncated>")
+            break
+        field = tag >> 3
+        wire = tag & 0x07
+        if wire == 0:
+            try:
+                _, i = _decode_varint(data, i)
+            except ValueError:
+                parts.append(f"f{field}=varint<truncated>")
+                break
+            parts.append(f"f{field}=varint")
+        elif wire == 1:
+            i += 8
+            parts.append(f"f{field}=i64")
+        elif wire == 2:
+            try:
+                length, i = _decode_varint(data, i)
+            except ValueError:
+                parts.append(f"f{field}=bytes<truncated>")
+                break
+            i += length
+            parts.append(f"f{field}=bytes({length})")
+        elif wire == 5:
+            i += 4
+            parts.append(f"f{field}=i32")
+        else:
+            parts.append(f"f{field}=wt{wire}?")
+            break
+    return ",".join(parts) if parts else "<empty>"
+
+
+def _decode_varint(data: bytes, i: int) -> tuple[int, int]:
+    """Read a protobuf varint at offset `i`, returning `(value, next_offset)`.
+
+    Raises `ValueError` on truncation or an unreasonably long encoding —
+    the caller surfaces this as a `<truncated>` marker in the wire-shape
+    summary so a partial / corrupt buffer doesn't blow up the log line.
+    """
+    value = 0
+    shift = 0
+    while i < len(data):
+        b = data[i]
+        i += 1
+        value |= (b & 0x7F) << shift
+        if not (b & 0x80):
+            return value, i
+        shift += 7
+        if shift >= 64:
+            msg = "varint too long"
+            raise ValueError(msg)
+    msg = "truncated varint"
+    raise ValueError(msg)
+
+
+def _redact_proto_bytes_to_hex(data: bytes) -> str:
+    """Render protobuf bytes as hex with printable-ASCII runs masked.
+
+    Scans `data` for contiguous runs of printable ASCII bytes (length ≥ 3)
+    and replaces each run with `<text:Nb>`; everything else renders as
+    its two-character hex value. The chosen 3-byte threshold mirrors the
+    HTS DEBUG probe (`_redact_if_text` in api/hts/client.py) — short
+    incidental ASCII bytes (e.g. a single 0x41 byte that happens to be
+    `'A'`) still come through as hex, while real text fields (device
+    names, ids, emails) are length-preserving redacted. Numeric values
+    almost always contain at least one non-printable byte (`0x00` is the
+    most common), so electrical readings stay fully visible — exactly
+    what we need to map an unknown LightDevice oneof case (#179) from a
+    public bug-report log.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(data)
+    while i < n:
+        j = i
+        while j < n and 0x20 <= data[j] <= 0x7E:
+            j += 1
+        run_len = j - i
+        if run_len >= 3:
+            out.append(f"<text:{run_len}b>")
+            i = j
+        else:
+            out.append(f"{data[i]:02x}")
+            i += 1
+    return "".join(out)
+
+
 class SmartLockError(Exception):
     """Raised when a SwitchSmartLockService call fails."""
 
@@ -434,6 +537,33 @@ class DevicesApi:
         if device_kind == "video_edge_channel":
             return DevicesApi._parse_video_edge_channel(proto_light_device.video_edge_channel)
         _LOGGER.debug("Skipping unsupported device type: %s", device_kind)
+        # `device_kind is None` means the LightDevice proto's `device`
+        # oneof didn't match any case we know (`hub_device`,
+        # `video_edge`, `video_edge_channel`, `smart_lock`). The bytes
+        # are preserved as protobuf unknown fields — most likely a NEW
+        # oneof case the cloud started emitting for a device family
+        # we haven't pulled into the local `.proto` yet (#179 Outlet
+        # Type E hypothesis: 18 of these landed during a load-toggle
+        # capture with zero matching HTS deltas). Surface enough
+        # structure to identify the new field number AND the redacted
+        # contents so the case can be reconstructed from a single
+        # capture without another user round-trip.
+        if device_kind is None and _LOGGER.isEnabledFor(logging.DEBUG):
+            try:
+                raw = proto_light_device.SerializeToString()
+            except Exception:  # noqa: BLE001
+                return None
+            if raw:
+                _LOGGER.debug(
+                    "Unsupported LightDevice (%db) wire-shape: %s",
+                    len(raw),
+                    _decode_proto_wire_shape(raw),
+                )
+                _LOGGER.debug(
+                    "Unsupported LightDevice (%db) bytes: %s",
+                    len(raw),
+                    _redact_proto_bytes_to_hex(raw),
+                )
         return None
 
     # MotionCam Video Doorbell / Indoor / Base hardware can arrive in a

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.5"
+    "version": "1.5.3-beta.6"
 }

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -15,8 +15,10 @@ import pytest
 
 from custom_components.aegis_ajax.api.devices import (
     DevicesApi,
+    _decode_proto_wire_shape,
     _encode_string_field,
     _encode_varint_field,
+    _redact_proto_bytes_to_hex,
 )
 from custom_components.aegis_ajax.api.models import Device, DeviceCommand
 from custom_components.aegis_ajax.const import DeviceState
@@ -73,6 +75,151 @@ class TestParseDevice:
         proto_device = MagicMock()
         proto_device.WhichOneof.return_value = "video_edge"
         assert DevicesApi.parse_device(proto_device) is None
+
+    def test_parse_unsupported_oneof_with_unknown_field_logs_probe(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When `device_kind is None` and the proto has unknown-field bytes
+        (a NEW oneof case the cloud emits but our `.proto` doesn't know),
+        a DEBUG probe surfaces the wire-shape AND a PII-redacted hex dump
+        so the new field number can be identified from a single capture.
+
+        Hypothesis behind #179 (SaetanSaDiablo's Outlet Type E): the cloud
+        is pushing live readings via a NEW `LightDevice.device` oneof
+        case at e.g. field 5+, which protobuf silently drops because we
+        only have fields 1-4 in the compiled proto. The probe stays at
+        DEBUG so a default-level install pays nothing.
+        """
+        import logging as _logging  # noqa: PLC0415
+
+        # A real LightDevice with a synthetic field-5 bytes payload that
+        # carries the user's device name in ASCII to verify the redaction
+        # path. Built via raw wire-format encoding so the proto class
+        # doesn't need to know about field 5.
+        from v3.mobilegwsvc.commonmodels.space.device.light import (  # noqa: PLC0415
+            light_device_pb2,
+        )
+
+        device_name = b"Living Room Outlet"
+        # Tag for field=5, wire_type=2 (length-delimited) is (5<<3)|2 = 42 = 0x2A
+        # Followed by varint length and the bytes.
+        unknown_field = bytes([0x2A, len(device_name), *device_name])
+        proto_device = light_device_pb2.LightDevice()
+        proto_device.MergeFromString(unknown_field)
+        # Confirm WhichOneof returns None even though raw bytes were merged.
+        assert proto_device.WhichOneof("device") is None
+
+        with caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"):
+            result = DevicesApi.parse_device(proto_device)
+
+        assert result is None
+        # Wire-shape line names the new field number with no contents.
+        assert any(
+            "wire-shape" in record.message and "f5=bytes" in record.message
+            for record in caplog.records
+        )
+        # Bytes line includes the redaction marker — the device name
+        # MUST NOT appear in cleartext, only the length stays visible.
+        bytes_line = next(record.message for record in caplog.records if "bytes:" in record.message)
+        assert "Living Room Outlet" not in bytes_line
+        assert f"<text:{len(device_name)}b>" in bytes_line
+
+    def test_parse_unsupported_oneof_with_empty_proto_logs_nothing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An empty `LightDevice` (oneof unset, no unknown fields either)
+        skips the byte probe — there's nothing to surface and we don't
+        want to clutter DEBUG with `<empty>` lines for genuine heartbeats.
+        """
+        import logging as _logging  # noqa: PLC0415
+
+        from v3.mobilegwsvc.commonmodels.space.device.light import (  # noqa: PLC0415
+            light_device_pb2,
+        )
+
+        proto_device = light_device_pb2.LightDevice()
+        with caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"):
+            result = DevicesApi.parse_device(proto_device)
+
+        assert result is None
+        # The "Skipping unsupported" line is always emitted; the byte
+        # probe lines are not, because the serialized form is empty.
+        assert any("Skipping unsupported device type" in r.message for r in caplog.records)
+        assert not any("wire-shape" in r.message for r in caplog.records)
+        assert not any("bytes:" in r.message for r in caplog.records)
+
+
+class TestDecodeProtoWireShape:
+    """Structural decoder used by the `parse_device` probe (#179)."""
+
+    def test_single_length_delimited_field(self) -> None:
+        # field=5, wire_type=2 (length-delimited), 4-byte payload.
+        # Tag byte = (5<<3)|2 = 0x2A.
+        assert _decode_proto_wire_shape(bytes([0x2A, 0x04, 0xDE, 0xAD, 0xBE, 0xEF])) == (
+            "f5=bytes(4)"
+        )
+
+    def test_varint_field(self) -> None:
+        # field=1, wire_type=0 (varint), value=42 (single byte).
+        assert _decode_proto_wire_shape(bytes([0x08, 0x2A])) == "f1=varint"
+
+    def test_i32_field(self) -> None:
+        # field=2, wire_type=5 (i32), 4 bytes payload.
+        assert _decode_proto_wire_shape(bytes([0x15, 0x00, 0x00, 0x00, 0x00])) == "f2=i32"
+
+    def test_i64_field(self) -> None:
+        # field=3, wire_type=1 (i64), 8 bytes payload.
+        assert _decode_proto_wire_shape(bytes([0x19] + [0x00] * 8)) == "f3=i64"
+
+    def test_multiple_fields(self) -> None:
+        # field=1 varint=1, then field=5 length-delimited 2-byte payload.
+        # Used to discriminate a known-oneof message (e.g. hub_device=1)
+        # from a brand-new oneof case (field=5+) appearing alongside it.
+        encoded = bytes([0x08, 0x01, 0x2A, 0x02, 0xAA, 0xBB])
+        assert _decode_proto_wire_shape(encoded) == "f1=varint,f5=bytes(2)"
+
+    def test_truncated_input_does_not_raise(self) -> None:
+        # Truncation in the middle of a varint length must surface as a
+        # marker rather than blowing up the DEBUG log line.
+        # 0x2A = tag (field=5, wire=2); next varint length missing.
+        assert "truncated" in _decode_proto_wire_shape(bytes([0x2A])).lower()
+
+    def test_empty_input(self) -> None:
+        assert _decode_proto_wire_shape(b"") == "<empty>"
+
+
+class TestRedactProtoBytesToHex:
+    """ASCII-aware hex renderer used by the `parse_device` probe (#179)."""
+
+    def test_short_ascii_run_stays_hex(self) -> None:
+        # 2-byte ASCII ("AB") is below the redaction threshold (3) and
+        # comes through as hex — the 3-byte threshold mirrors the HTS
+        # probe so incidental ASCII bytes (a single 0x41 inside a numeric
+        # field) don't get masked.
+        assert _redact_proto_bytes_to_hex(b"\x01AB\x00") == "014142" + "00"
+
+    def test_long_ascii_run_is_masked_with_length(self) -> None:
+        # A device-name field "Living Room Outlet" (18 chars printable
+        # ASCII) is replaced by a length-preserving marker. The byte
+        # offset of the surrounding bytes (here: an empty surround) stays
+        # readable so the redaction doesn't break structural analysis.
+        assert _redact_proto_bytes_to_hex(b"Living Room Outlet") == "<text:18b>"
+
+    def test_mixed_binary_and_ascii(self) -> None:
+        # 4-byte numeric prefix (one printable byte, three non-printable)
+        # + protobuf string header (`\n` + length) + 5-byte ASCII tail.
+        # The numeric prefix stays hex, the ASCII tail gets redacted.
+        data = b"\xde\xad\xbe\xef\n\x05Hello"
+        result = _redact_proto_bytes_to_hex(data)
+        assert "<text:5b>" in result
+        assert "deadbeef" in result
+        assert "Hello" not in result
+
+    def test_all_non_printable(self) -> None:
+        assert _redact_proto_bytes_to_hex(bytes([0x00, 0x01, 0xFF])) == "0001ff"
+
+    def test_empty(self) -> None:
+        assert _redact_proto_bytes_to_hex(b"") == ""
 
     def test_parse_video_edge_channel_doorbell(self) -> None:
         # @Permudious in #119: MotionCam Video Doorbell arrives as a


### PR DESCRIPTION
## Summary
- Adds a DEBUG-gated two-line probe in `parse_device` that fires when `LightDevice.WhichOneof(\"device\") is None` (i.e. the cloud sent an oneof case beyond the four we know: `hub_device`, `video_edge`, `video_edge_channel`, `smart_lock`).
  - **wire-shape**: `f<N>=bytes(<len>),f<N>=varint,…` — structural only, no values, safe to paste anywhere. Pin-points the new field number.
  - **bytes**: full hex with printable-ASCII runs ≥3 chars masked as `<text:Nb>` (same 3-byte threshold as `1.5.3-beta.2`'s HTS probe, see `_redact_if_text` in `api/hts/client.py`). Numeric readings stay fully visible; device names / ids / emails get length-preserving redaction.
- Empty protos skip both lines so heartbeat traffic doesn't pollute logs.
- 1.5.3-beta.6 bump.

## Why now
@SaetanSaDiablo's load-calibrated Outlet Type E capture in #179 showed zero per-device HTS deltas during a 10-minute toggle window where WallSwitches would normally push their live electrical readings — but 18 gRPC `LightDevice` pushes arrived with `WhichOneof(\"device\") = None`, lining up temporally with each load transition (off / Idle / 170W / 2.19kW / 2.15kW / 174W / Idle / off). Strong hypothesis: Ajax cloud emits Outlet Type E live readings via a NEW oneof case (likely `field=5+`) that's not yet in our compiled `.proto`. Protobuf preserves the bytes as unknown-fields, `WhichOneof` returns None, and we drop the message silently.

A single capture under known load now identifies the new field number AND the payload structure, so the next mapping iteration can land without another user round-trip.

## Test plan
- [x] 6 unit tests for `_decode_proto_wire_shape`: single length-delimited / varint / i32 / i64 fields, multi-field encoding, truncated input, empty input.
- [x] 5 unit tests for `_redact_proto_bytes_to_hex`: 2-byte ASCII below threshold stays hex, 18-byte ASCII run gets length-preserving redacted, mixed binary+ASCII keeps binary visible and redacts text, all non-printable, empty.
- [x] 2 integration tests for `parse_device`: empty `LightDevice` skips both probe lines (heartbeat suppression); a `LightDevice` with a synthetic `field=5` unknown-field carrying an 18-char ASCII device name → both probe lines fire, wire-shape names `f5=bytes(…)`, bytes line redacts the device name as `<text:18b>` (cleartext name does NOT appear).
- [x] Full unit suite: 1354 passed (+14 net), coverage 86.23%.
- [x] `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all green on the rebuilt Docker image without volume mount.