### PR TITLE
fix(fcm): relax fcm_app_id hash-length range to match Firebase spec (refs #182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.7] - 2026-05-24
+
+### Fixed
+- **`fcm_app_id` shape validator no longer false-positives against the official Ajax Play Store APK** (#182 follow-up, reported by @zwagerzaken on `1.5.3-beta.5`). The pre-flight check added in `1.5.3-beta.4` rejected `fcm_app_id` values whose hex tail was outside a 30..64-char range, but that range was inferred from a single data point and isn't part of Firebase's actual spec — Firebase's own example in [the init-options troubleshooting guide](https://firebase.google.com/support/guides/init-options) is `1:1234567890:android:321abc456def7890` (a 16-char tail), and the iOS SDK's [historical validator](https://github.com/firebase/firebase-ios-sdk/pull/2529) used `^\d+:ios:[a-f0-9]+$` with no length constraint. The current Ajax build ships a 16-char hex tail and was getting blocked from registering with the `fcm_app_id hash chunk is 16 chars; expected ~40` Repair card. The validator now mirrors Firebase: shape `1:<digits>:android:<hex>` with `[0-9a-fA-F]+` on the tail (any length ≥ 1 char), `sender_id` matches the digit chunk byte-for-byte, `api_key` matches `AIza` + 35 chars (Google's standard API key format), `project_id` non-empty. The extreme paste-truncation cases (zero-char tail, or a tail with non-hex characters) are still caught and surface a Repair naming `fcm_app_id`; subtler truncations that leave a 1+ char hex tail now fall through to Google's 403 like before #182 — the right trade-off given that false-positives block legit users entirely.
+
 ## [1.5.3-beta.6] - 2026-05-24
 
 ### Internal

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.6"
+    "version": "1.5.3-beta.7"
 }

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -60,15 +60,16 @@ NOTIFICATION_DEDUPE_WINDOW_SECONDS = 5.0
 STALE_PUSH_THRESHOLD_SECONDS = 120.0
 
 
+# Shape regex mirrors Firebase's own iOS-SDK validator (`^\\d+:ios:[a-f0-9]+$`,
+# https://github.com/firebase/firebase-ios-sdk/pull/2529): one-or-more hex
+# chars on the tail with NO length constraint. Firebase docs canonical example
+# is `1:1234567890:android:321abc456def7890` (a 16-char tail), and real Ajax
+# co-branded builds ship the same length — earlier shipping `_validate_fcm_shape`
+# enforced a 30..64-char range that false-positived against the official Ajax
+# Play Store APK (#182 follow-up, @zwagerzaken). We accept both upper- and
+# lower-case hex to be lenient against transcripts that uppercase content.
 _FCM_APP_ID_RE = re.compile(r"^1:(\d+):android:([0-9a-fA-F]+)$")
 _FCM_API_KEY_RE = re.compile(r"^AIza[0-9A-Za-z_-]{35}$")
-# Firebase emits Android app_ids whose hash tail is 40 hex characters. We
-# accept anything in [30, 64] to leave a paranoia-margin for future Firebase
-# format tweaks while still catching the half-pasted values that cause
-# `androidPackage: <empty>` 403s server-side. Tail shorter than this is the
-# truncation pattern observed in #155 and #182.
-_FCM_APP_ID_HASH_MIN = 30
-_FCM_APP_ID_HASH_MAX = 64
 
 
 def _validate_fcm_shape(
@@ -86,6 +87,14 @@ def _validate_fcm_shape(
     / `androidPackage: <empty>` from Google — accurate but unactionable,
     because the API key isn't actually the problem (#155, #182).
 
+    Validation rules mirror Firebase's own client-side checks; we don't
+    add tighter constraints because doing so false-positived against the
+    real Ajax Play Store APK in 1.5.3-beta.4 (#182 follow-up). What we
+    keep: shape (`1:<digits>:android:<hex>` for app_id, `AIza` + 35 for
+    api_key), digit-chunk consistency between sender_id and app_id, and
+    a non-empty project_id. What we dropped: a hash-length range, which
+    Firebase itself doesn't enforce.
+
     Returns a short English description of the first problem found
     (suitable for a Repair card `{problem}` placeholder), or `None`
     when every shape is coherent. We surface one problem at a time so
@@ -98,15 +107,7 @@ def _validate_fcm_shape(
     app_id_match = _FCM_APP_ID_RE.match(fcm_app_id)
     if app_id_match is None:
         return 'fcm_app_id does not match the expected shape "1:<digits>:android:<hex>"'
-    app_id_sender, app_id_hash = app_id_match.group(1), app_id_match.group(2)
-    if len(app_id_hash) < _FCM_APP_ID_HASH_MIN:
-        return (
-            f"fcm_app_id hash chunk is {len(app_id_hash)} chars; expected ~40 (truncated on paste?)"
-        )
-    if len(app_id_hash) > _FCM_APP_ID_HASH_MAX:
-        return (
-            f"fcm_app_id hash chunk is {len(app_id_hash)} chars; expected ~40 (extra characters?)"
-        )
+    app_id_sender = app_id_match.group(1)
 
     if not _FCM_API_KEY_RE.match(fcm_api_key):
         return (

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -516,21 +516,40 @@ class TestValidateFcmShape:
         assert problem is not None
         assert "fcm_app_id" in problem
 
-    def test_app_id_truncated_hex_tail_is_rejected(self) -> None:
-        # ~half the canonical hash length — the user's paste was cut.
-        problem = _validate_fcm_shape(
-            **{**_VALID_FCM_SHAPES, "fcm_app_id": "1:991608156148:android:" + "a" * 18},
+    def test_app_id_canonical_16_char_hash_passes(self) -> None:
+        # Firebase docs example is `1:1234567890:android:321abc456def7890`
+        # — a 16-char hex tail. Real Ajax Play Store APK ships the same
+        # length. An earlier version of this validator enforced a 30..64
+        # char range and false-positived against the official Ajax APK
+        # (#182 follow-up, @zwagerzaken). We mirror Firebase's own iOS
+        # SDK validator (`^\\d+:ios:[a-f0-9]+$` — no length constraint;
+        # firebase-ios-sdk PR #2529).
+        assert (
+            _validate_fcm_shape(
+                **{
+                    **_VALID_FCM_SHAPES,
+                    "fcm_app_id": "1:991608156148:android:1be5b6c08d8fc6d7",
+                }
+            )
+            is None
         )
-        assert problem is not None
-        assert "fcm_app_id" in problem
-        # The hint should name the truncated chunk so the next-action
-        # is "re-paste the app_id", not "check the api_key".
-        lower = problem.lower()
-        assert "hash" in lower or "truncat" in lower or "short" in lower
 
     def test_app_id_non_hex_tail_is_rejected(self) -> None:
         problem = _validate_fcm_shape(
             **{**_VALID_FCM_SHAPES, "fcm_app_id": "1:991608156148:android:" + "G" * 40},
+        )
+        assert problem is not None
+        assert "fcm_app_id" in problem
+
+    def test_app_id_empty_hex_tail_is_rejected(self) -> None:
+        # The regex's `+` quantifier rejects a zero-char tail — the most
+        # extreme paste truncation (where the user clipped right after
+        # the `:android:` separator). Any other length ≥ 1 hex char
+        # passes shape validation by design (Firebase itself doesn't
+        # enforce a length range); paste truncations that leave 1+ hex
+        # chars still fall through to Google's 403 like before #182.
+        problem = _validate_fcm_shape(
+            **{**_VALID_FCM_SHAPES, "fcm_app_id": "1:991608156148:android:"},
         )
         assert problem is not None
         assert "fcm_app_id" in problem


### PR DESCRIPTION
## Summary
- Drops the 30..64-char range check on the `fcm_app_id` hex tail introduced in `1.5.3-beta.4`. The range was inferred from a single data point and isn't part of Firebase's actual spec.
- New shape constraint mirrors Firebase's official validators: regex `^1:(\d+):android:([0-9a-fA-F]+)$` — any hex tail length ≥ 1 char. Every other branch is preserved (sender_id matches digit chunk, api_key matches `AIza` + 35, project_id non-empty).
- 1.5.3-beta.7 bump.

## Why now
@zwagerzaken hit this on `1.5.3-beta.5`: the official Ajax Play Store APK ships a `fcm_app_id` with a 16-char hex tail (`1:991608156148:android:1be5b6c08d8fc6d7`), which is structurally identical to Firebase's own [canonical example in the init-options troubleshooting guide](https://firebase.google.com/support/guides/init-options) (`1:1234567890:android:321abc456def7890`). The 30..64-char range I added in `1.5.3-beta.4` blocked them outright with the `fcm_app_id hash chunk is 16 chars; expected ~40` Repair card.

The actual Firebase client-side validation is much looser:
- [`firebase-ios-sdk` PR #2529](https://github.com/firebase/firebase-ios-sdk/pull/2529): pre-refactor regex was `^\d+:ios:[a-f0-9]+$` — `+` quantifier, no length constraint.
- Current NSScanner-based replacement in `FIRApp.m`: scans `<version>:<project>:<platform>:<hex>` with no length check on the hex tail either.

So Firebase itself accepts any 1+ char hex tail. The right move is to do the same.

The extreme paste-truncation cases (zero-char tail, non-hex tail) are still caught and surface a Repair naming `fcm_app_id`. Subtler truncations that leave a 1+ char hex tail now fall through to Google's 403 like before #182 — the right trade-off given that false-positives block legit users entirely.

## Test plan
- [x] New `test_app_id_canonical_16_char_hash_passes`: validates `1:991608156148:android:1be5b6c08d8fc6d7` (the real Ajax APK shape and Firebase example shape) — would have caught the regression before shipping.
- [x] Renamed / repurposed `test_app_id_truncated_hex_tail_is_rejected` → `test_app_id_empty_hex_tail_is_rejected`: the `+` quantifier still rejects a zero-char tail, the most extreme paste-truncation. Anything ≥ 1 hex char now passes by design.
- [x] Existing tests cover: missing `:android:` segment, non-hex tail, sender mismatch, api_key wrong shape, project_id empty, multi-field garbage. All still green.
- [x] Full unit suite: 1355 passed (+1 net vs `1.5.3-beta.6`), coverage 86.23%.
- [x] `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all green on the rebuilt Docker image without volume mount.