### PR TITLE
feat(devices): unredact tiny unsupported LightDevice protos (refs #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.8] - 2026-05-24
+
+### Internal
+- **Unsupported-LightDevice probe now skips ASCII redaction on tiny protos (≤ 16 bytes total)** so short protocol codes come through (#179 follow-up). @SaetanSaDiablo's `1.5.3-beta.6` capture validated the probe added in beta.6 — 18 events fired during the load-toggle test window, all 7 bytes long with the shape `f5={f2:<3 ASCII chars>}`, lining up temporally with `off → load start` transitions but not with sustained-load periods. The 3-byte inner string is exactly what we need to identify (status code like `OFF`/`ON`? hub-id suffix? device-type tag?), but the redaction threshold of ≥ 3 ASCII chars introduced in `1.5.3-beta.2` for the HTS probe masked it as `<text:3b>`. A 7-byte proto has no room for a user-set device name / room name / email anyway, so raw hex is privacy-safe at this size. Larger LightDevices (real device records that CAN carry user-set names) keep the original redaction unchanged. The hypothesis from beta.6 (a new `LightDevice.device` oneof case carrying Outlet live readings) doesn't fit the data — these tiny events aren't carrying load values, more likely state-change notifications. A new capture on beta.8 will surface the actual 3-char content and let us decide where to look next.
+
 ## [1.5.3-beta.7] - 2026-05-24
 
 ### Fixed

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+# Protos under this byte threshold are considered protocol-level state
+# messages (no room for user-set names, rooms, or other PII inside a
+# ≤16-byte envelope) and are logged as raw hex in `parse_device`'s
+# unsupported-LightDevice probe so short ASCII codes come through.
+# Larger protos go through `_redact_proto_bytes_to_hex` unchanged.
+_TINY_PROTO_THRESHOLD = 16
+
+
 def _decode_proto_wire_shape(data: bytes) -> str:
     """Render a one-line structural summary of protobuf wire-format bytes.
 
@@ -559,10 +567,28 @@ class DevicesApi:
                     len(raw),
                     _decode_proto_wire_shape(raw),
                 )
+                # Tiny protos (≤ TINY_PROTO_THRESHOLD bytes total) are
+                # protocol-level state messages, not user-data payloads —
+                # there's no room for a device name / room / email inside
+                # that envelope. Render them with raw hex so short ASCII
+                # codes (3-char status strings like `OFF`/`ON`, hub-id
+                # suffixes, device-type tags) come through directly.
+                # Larger protos (real device records that DO carry
+                # user-set names) keep the ≥3-byte ASCII redaction. From
+                # #179: beta.6 capture showed 18 events with the shape
+                # `f5={f2:<3 ASCII chars>}` lining up with Outlet load
+                # transitions — but redaction hid exactly the 3 chars
+                # needed to identify whether they encode state or just
+                # a device-id reference.
+                bytes_str = (
+                    raw.hex()
+                    if len(raw) <= _TINY_PROTO_THRESHOLD
+                    else _redact_proto_bytes_to_hex(raw)
+                )
                 _LOGGER.debug(
                     "Unsupported LightDevice (%db) bytes: %s",
                     len(raw),
-                    _redact_proto_bytes_to_hex(raw),
+                    bytes_str,
                 )
         return None
 

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.7"
+    "version": "1.5.3-beta.8"
 }

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -76,6 +76,43 @@ class TestParseDevice:
         proto_device.WhichOneof.return_value = "video_edge"
         assert DevicesApi.parse_device(proto_device) is None
 
+    def test_parse_unsupported_oneof_tiny_proto_logs_raw_hex(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Tiny protos (≤16 bytes total) bypass redaction so 3-char protocol
+        codes come through (#179 follow-up).
+
+        The original probe in beta.6 redacted any printable-ASCII run ≥3
+        chars, which hid exactly the 3-char strings we needed to identify
+        whether SaetanSaDiablo's 18 unsupported LightDevice events were
+        encoding state codes (`OFF`/`ON`/etc) or just a device-id reference.
+        A 7-byte proto has no room for a user-set name / room / email
+        anyway, so raw hex is privacy-safe at this size.
+        """
+        import logging as _logging  # noqa: PLC0415
+
+        from v3.mobilegwsvc.commonmodels.space.device.light import (  # noqa: PLC0415
+            light_device_pb2,
+        )
+
+        # 7-byte proto mimicking the actual capture shape: field=5
+        # length-delimited (5 bytes) → field=2 length-delimited (3 ASCII
+        # bytes 'O', 'F', 'F').
+        unknown_field = bytes([0x2A, 0x05, 0x12, 0x03, 0x4F, 0x46, 0x46])
+        proto_device = light_device_pb2.LightDevice()
+        proto_device.MergeFromString(unknown_field)
+        assert proto_device.WhichOneof("device") is None
+
+        with caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"):
+            DevicesApi.parse_device(proto_device)
+
+        bytes_line = next(record.message for record in caplog.records if "bytes:" in record.message)
+        # Full raw hex must be visible — no `<text:Nb>` masking on a tiny
+        # protocol-state envelope.
+        assert "2a051203" in bytes_line
+        assert "4f4646" in bytes_line  # 'OFF' in ASCII bytes
+        assert "<text:" not in bytes_line
+
     def test_parse_unsupported_oneof_with_unknown_field_logs_probe(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
## Summary
- Unsupported-LightDevice probe in `parse_device` now skips the ≥3-byte ASCII redaction when the whole proto is ≤16 bytes total. Larger protos (real device records that CAN carry user-set names / rooms / emails) keep the original redaction.
- 1.5.3-beta.8 bump.

## Why now
@SaetanSaDiablo's `1.5.3-beta.6` capture validated the probe added in beta.6 — the 18 unsupported LightDevice events fired during the load-toggle window all have the same shape: 7 bytes total, `f5={f2:<3 ASCII chars>}`, lining up temporally with `off → load start` transitions but NOT with sustained-load periods. The 3-char inner string is exactly what we need to identify — status code (`OFF`/`ON`?), device-id reference, hub-id suffix? — but the redaction threshold introduced in `1.5.3-beta.2` for the HTS probe masked it as `<text:3b>`. A 7-byte protobuf envelope has no room for a user-set name or any other PII, so raw hex is privacy-safe at this size.

The previous hypothesis (Outlet readings travel via a new `LightDevice.device` oneof case) doesn't fit the data — if these events were carrying load values, the proto would be much bigger and we'd see continuous events during sustained load. They're more likely state-change notifications. A fresh capture on beta.8 will surface the actual 3-char content and let us decide where to look next.

## Test plan
- [x] New `test_parse_unsupported_oneof_tiny_proto_logs_raw_hex`: 7-byte proto carrying `'OFF'` as the inner string → log line contains `4f4646` (raw ASCII bytes) with NO `<text:`  marker, demonstrating the unredaction path.
- [x] Existing `test_parse_unsupported_oneof_with_unknown_field_logs_probe` still passes: 20-byte proto (header + 18-byte "Living Room Outlet" name) is above the threshold, redaction still applies, the cleartext name does NOT appear in the log.
- [x] `test_parse_unsupported_oneof_with_empty_proto_logs_nothing`: empty proto still skips both probe lines (no `<empty>` line clutter for heartbeats).
- [x] All `_redact_proto_bytes_to_hex` unit tests unchanged — the threshold applies in `parse_device`, not in the helper, so the helper still works the same for the HTS probe.
- [x] Full unit suite: 1356 passed (+1 net), coverage 86.24%.
- [x] `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all green on the rebuilt Docker image without volume mount.