### PR TITLE
feat(devices): probe unknown LightDeviceStatus oneof cases (refs #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.9] - 2026-05-24
+
+### Internal
+- **Probe added for unknown `LightDeviceStatus.status` oneof cases** (#179 follow-up). @SaetanSaDiablo's beta.8 capture confirmed the `1.5.3-beta.6` LightDevice probe was firing on a *constant* 7-byte protocol marker (decoded payload: literal `"5_0"` repeated across every event regardless of load state), not the Outlet's live electrical readings. The readings must be riding a different channel; the next strongest candidate is a NEW `LightDeviceStatus.status` oneof case at a higher field number than the ones we compile against (the proto reserves 45/46/49/81/84/85/86/87 — strong hint Ajax has been adding cases over time). Previously, when `status.WhichOneof("status")` returned None, `api/devices.py:_handle_update` silently returned, dropping the message without trace. The new DEBUG-gated probe logs a single line carrying `device_id`, `wire-shape`, and `bytes` (with the same tiny-proto-unredact behaviour as the LightDevice probe — protos ≤ 16 bytes total render as raw hex, larger payloads pass through the ≥ 3-byte ASCII redaction). Default-level installs pay nothing. One more capture on beta.9 should surface whether the Outlet pushes status updates with an unknown oneof case, and if so, what its field number and payload shape are.
+
 ## [1.5.3-beta.8] - 2026-05-24
 
 ### Internal

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -756,6 +756,33 @@ class DevicesApi:
             status = update.status_update.status
             status_name = status.WhichOneof("status")
             if status_name is None:
+                # The proto carried a `status` oneof case our compiled
+                # `.proto` doesn't know — the same pattern as the
+                # unknown-LightDevice oneof case `parse_device` probes
+                # (#179, beta.6). When DEBUG is on, surface the inner
+                # `status` proto's wire-shape + bytes so the new field
+                # number is identifiable from a capture. Tiny protos
+                # bypass redaction for the same reason as `parse_device`:
+                # a ≤ 16-byte envelope has no room for PII.
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    try:
+                        raw = status.SerializeToString()
+                    except Exception:  # noqa: BLE001
+                        return
+                    if raw:
+                        bytes_str = (
+                            raw.hex()
+                            if len(raw) <= _TINY_PROTO_THRESHOLD
+                            else _redact_proto_bytes_to_hex(raw)
+                        )
+                        _LOGGER.debug(
+                            "Unsupported LightDeviceStatus on device %s (%db) "
+                            "wire-shape: %s, bytes: %s",
+                            device_id,
+                            len(raw),
+                            _decode_proto_wire_shape(raw),
+                            bytes_str,
+                        )
                 return
 
             op = int(update.status_update.update_type)

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.8"
+    "version": "1.5.3-beta.9"
 }

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -161,6 +161,60 @@ class TestParseDevice:
         assert "Living Room Outlet" not in bytes_line
         assert f"<text:{len(device_name)}b>" in bytes_line
 
+    def test_handle_update_unknown_status_oneof_logs_probe(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When `LightDeviceStatus.WhichOneof("status") is None` (the cloud
+        emitted a status oneof case our compiled `.proto` doesn't know),
+        a DEBUG probe surfaces device_id + wire-shape + bytes (#179
+        follow-up). Same shape as the LightDevice-level probe added in
+        beta.6, one level deeper — the suspect channel for the Outlet
+        Type E live readings that doesn't ride any current `status.*`
+        case (gsm_status, signal_strength, sim_status, etc.) we handle.
+        """
+        import logging as _logging  # noqa: PLC0415
+
+        from v3.mobilegwsvc.commonmodels.space.device.light import (  # noqa: PLC0415
+            light_device_status_pb2,
+        )
+        from v3.mobilegwsvc.service.stream_light_devices import (  # noqa: PLC0415
+            response_pb2,
+        )
+
+        # Synthetic LightDeviceStatus carrying an unknown oneof case at
+        # field=200 — well beyond the highest known field (95) and far
+        # from any reserved range — with a 4-byte payload, mirroring
+        # the small-envelope shape seen in the actual #179 capture.
+        # Varint tag for (200<<3)|2 = 1602 encodes as 0xC2 0x0C; then
+        # length 0x04; then the 4 payload bytes.
+        unknown_status_bytes = bytes([0xC2, 0x0C, 0x04, 0xDE, 0xAD, 0xBE, 0xEF])
+        unknown_status = light_device_status_pb2.LightDeviceStatus()
+        unknown_status.MergeFromString(unknown_status_bytes)
+        assert unknown_status.WhichOneof("status") is None
+
+        update = response_pb2.StreamLightDevicesResponse.Success.Update()
+        update.device_id.hub_light_device_id.device_id = "30427616"
+        update.status_update.status.CopyFrom(unknown_status)
+        update.status_update.update_type = 2  # UPDATE
+
+        api = DevicesApi(MagicMock())
+
+        with caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"):
+            api._handle_update(
+                update,
+                on_devices_snapshot=lambda _: None,
+                on_status_update=lambda _d, _s, _p: None,
+            )
+
+        # The probe line names the device id, the field number, and the
+        # bytes so a single capture identifies the new status oneof case.
+        probe_lines = [
+            r.message for r in caplog.records if "Unsupported LightDeviceStatus" in r.message
+        ]
+        assert len(probe_lines) == 1
+        assert "30427616" in probe_lines[0]
+        assert "deadbeef" in probe_lines[0]
+
     def test_parse_unsupported_oneof_with_empty_proto_logs_nothing(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
## Summary
- Adds a DEBUG-gated probe in `_handle_update` that fires when `LightDeviceStatus.WhichOneof("status") is None` — a new status oneof case the cloud emits that our compiled `.proto` doesn't know.
- Probe logs one line per event with `device_id`, `wire-shape: f<N>=bytes(<len>),…`, and `bytes: <hex>` (tiny protos ≤ 16 bytes unredacted, larger ones masked at ≥ 3 ASCII chars, same policy as the LightDevice probe from beta.6/beta.8).
- 1.5.3-beta.9 bump.

## Why now
@SaetanSaDiablo's beta.8 capture decoded the previously-redacted 3-char content of the 18 unsupported-LightDevice events as the literal string `"5_0"` — identical across every event regardless of load state, time, or transition direction. That's a constant protocol marker, NOT the live electrical readings.

The next strongest candidate channel for the readings is a NEW oneof case at a higher field number than the ones we compile against, inside the `LightDeviceStatus.status` oneof — the proto file explicitly reserves field numbers `45/46/49/81/84/85/86/87`, which is a strong hint that Ajax has been adding status cases over time and some may not be in our build. Previously when `status.WhichOneof("status")` returned None, `_handle_update` silently returned with no trace, so a brand-new case would just disappear. This probe surfaces it.

## Test plan
- [x] New `test_handle_update_unknown_status_oneof_logs_probe`: synthetic `LightDeviceStatus` with field=200 + 4-byte payload merged into a real `Update` proto via `MergeFromString` → assert the DEBUG line carries the device id (`30427616`), the wire-shape (`f200=bytes(4)`), and the raw payload hex (`deadbeef`).
- [x] All existing tests still green: 1357 passed (+1 net), coverage 86.28%.
- [x] `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all green on the rebuilt Docker image without volume mount.