### PR TITLE
fix(fcm): send X-Android-Package on Firebase Installations calls (refs #155, refs #182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3-beta.10] - 2026-05-24
+
+### Fixed
+- **FCM registration now sends the `X-Android-Package` header on Firebase Installations calls** (#155, #182, reported by @aitrus22, @alt-BadBatch, and @zwagerzaken — independently in three separate threads over three weeks). The Ajax co-branded api-key on Project B has Google's Android-app package restriction enabled: requests without an `X-Android-Package` header come through with `androidPackage: <empty>` on Google's side and get refused with `API_KEY_ANDROID_APP_BLOCKED`. The `firebase_messaging` Python library doesn't send the header at all (it works for api-keys without that restriction — Tesla, Roomba, etc. — but loses for restricted ones), so Ajax co-brand users were stuck behind a 403 that the validator added in `1.5.3-beta.4` couldn't fix because the credentials were structurally fine to begin with. @alt-BadBatch's original report identified this root cause on day one; I dismissed it back then because I'd seen the library work for other integrations and assumed the api-key restriction wasn't in play, then went down a long paste-truncation path that produced a validator (beta.4 / beta.5 / beta.7) which improves the error-reporting surface but never addressed the actual cause. Apologies to all three reporters for the runaround.
+
+The integration now maps `app_label` to the matching Android package id via a new `APP_LABEL_TO_ANDROID_PACKAGE` constant in `const.py` and threads the value through `coordinator.async_start_push_notifications` to the notification listener. When the app_label has a known package mapping, the listener creates an `aiohttp.ClientSession` with `X-Android-Package` as a default header and passes it to `FcmRegister` via the library's existing `http_client_session` parameter. aiohttp merges per-request headers on top, so `firebase_messaging`'s own `x-firebase-client` / `x-goog-api-key` stay untouched, and every Firebase Installations call (registration + refresh) carries the package id. Co-brands without a mapping fall back to the pre-`1.5.3-beta.10` behaviour (no session passed, no header), so the change is no-op for any user who was already working.
+
+The mapping ships with the entries verified end-to-end against the catalogue documented in our cobranded-firebase project memory: `Ajax → com.ajaxsystems`, `ajax_pro → com.ajaxsystems.pro`, `AIKO → com.ajaxsystems.aiko`, `Protegim_alarma → com.ajaxsystems.protegim`. Other co-brands will be added as users confirm — leaving the mapping fail-open preserves the existing working setups while the table fills in.
+
 ## [1.5.3-beta.9] - 2026-05-24
 
 ### Internal

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -348,6 +348,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
             fcm_api_key=_get_fcm("fcm_api_key"),
             fcm_sender_id=_get_fcm("fcm_sender_id"),
             entry_id=entry.entry_id,
+            app_label=str(entry.data.get("app_label", "")),
         ),
         name=f"aegis_ajax_fcm_start_{entry.entry_id}",
     )

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -96,6 +96,32 @@ KNOWN_APP_LABELS = [
     "Protecta",
     "ajax_pro",
 ]
+# Maps `app_label` (the gRPC `application-label` header value the user
+# picked in the config flow) to the Android package id of the
+# corresponding co-branded APK. Used as the `X-Android-Package` header
+# the integration sends on Firebase Installations calls so Google's
+# api-key package restriction doesn't refuse the request with
+# `API_KEY_ANDROID_APP_BLOCKED` + `androidPackage: <empty>` (#155,
+# #182). The `firebase_messaging` library doesn't send that header
+# itself — for api-keys without restriction it works fine, but the
+# Ajax co-branded key on Project B (`elite-dreamer-676`,
+# `mws-mobile-client---2` for some variants) has package restriction
+# enabled and blocks blank-package requests outright.
+#
+# Verified end-to-end: only "Ajax" → `com.ajaxsystems` (zwagerzaken's
+# beta.8 capture in #182, alt-BadBatch's original). The other entries
+# are best-effort derived from the libnative-lib.so catalogue
+# documented in the cobranded-firebase project memory. Add an entry
+# only after confirming with the user that their `strings.xml` is in
+# the actual APK named here. Missing entries fall back to no header,
+# i.e. the pre-1.5.3-beta.10 behaviour.
+APP_LABEL_TO_ANDROID_PACKAGE: dict[str, str] = {
+    "Ajax": "com.ajaxsystems",
+    "ajax_pro": "com.ajaxsystems.pro",
+    "AIKO": "com.ajaxsystems.aiko",
+    "Protegim_alarma": "com.ajaxsystems.protegim",
+}
+
 CLIENT_DEVICE_MODEL = "SM-A536B"  # Galaxy A53 — paired with CLIENT_VERSION="3.30"
 CLIENT_DEVICE_TYPE = "MOBILE"
 CLIENT_APP_TYPE = "USER"

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -819,6 +819,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         fcm_api_key: str = "",
         fcm_sender_id: str = "",
         entry_id: str = "",
+        app_label: str = "",
     ) -> None:
         """Start FCM push notification listener."""
         from custom_components.aegis_ajax.notification import (
@@ -833,6 +834,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             fcm_api_key=fcm_api_key,
             fcm_sender_id=fcm_sender_id,
             entry_id=entry_id,
+            app_label=app_label,
         )
         await self._notification_listener.async_start()
 

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.5.3-beta.9"
+    "version": "1.5.3-beta.10"
 }

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -194,6 +194,7 @@ class AjaxNotificationListener:
         fcm_api_key: str,
         fcm_sender_id: str,
         entry_id: str = "",
+        app_label: str = "",
     ) -> None:
         self._hass = hass
         self._coordinator = coordinator
@@ -202,6 +203,7 @@ class AjaxNotificationListener:
         self._fcm_api_key = fcm_api_key
         self._fcm_sender_id = fcm_sender_id
         self._entry_id = entry_id
+        self._app_label = app_label
         self._push_client: Any = None
         self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
         self._credentials: dict[str, Any] | None = None
@@ -305,8 +307,37 @@ class AjaxNotificationListener:
 
         if not self._credentials:
             _LOGGER.debug("Registering with FCM...")
+            # Inject `X-Android-Package` on Firebase Installations calls when
+            # we know the user's co-branded Android package. The Ajax co-brand
+            # api-key on Project B has Google package restriction enabled, so
+            # the default `firebase_messaging` request (no package header)
+            # gets refused with `API_KEY_ANDROID_APP_BLOCKED` /
+            # `androidPackage: <empty>` (#155, #182). We attach the header as
+            # a default on a session passed via `http_client_session` —
+            # aiohttp merges per-request headers on top, so the library's own
+            # `x-firebase-client` / `x-goog-api-key` keys are untouched and
+            # every request we initiate (`fcm_install`, refresh, register)
+            # carries the package id. Co-brands without a mapping fall back
+            # to the pre-1.5.3-beta.10 behaviour (no header, no session).
+            import aiohttp  # noqa: PLC0415
+
+            from custom_components.aegis_ajax.const import (  # noqa: PLC0415
+                APP_LABEL_TO_ANDROID_PACKAGE,
+            )
+
+            android_package = APP_LABEL_TO_ANDROID_PACKAGE.get(self._app_label)
+            fcm_session: aiohttp.ClientSession | None = None
+            if android_package:
+                fcm_session = aiohttp.ClientSession(headers={"X-Android-Package": android_package})
+                _LOGGER.debug(
+                    "FCM registration will carry X-Android-Package: %s",
+                    android_package,
+                )
             try:
-                registerer = FcmRegister(config=fcm_config)
+                if fcm_session is not None:
+                    registerer = FcmRegister(config=fcm_config, http_client_session=fcm_session)
+                else:
+                    registerer = FcmRegister(config=fcm_config)
                 # register() may be sync or async depending on library version
                 if asyncio.iscoroutinefunction(registerer.register):
                     raw_result: Any = await registerer.register()  # noqa: ANN401
@@ -320,6 +351,9 @@ class AjaxNotificationListener:
                 if self._entry_id:
                     async_register_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)
                 return
+            finally:
+                if fcm_session is not None:
+                    await fcm_session.close()
 
         # Extract FCM token and register with Ajax servers
         fcm_data = self._credentials.get("fcm", {})

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -605,6 +605,121 @@ class TestValidateFcmShape:
         assert problem is not None
 
 
+class TestAsyncStartFcmAndroidPackageHeader:
+    """`async_start` injects `X-Android-Package` on Firebase Installations
+    calls for known co-brands so Google's api-key package restriction
+    doesn't refuse the request with `API_KEY_ANDROID_APP_BLOCKED` /
+    `androidPackage: <empty>` (#155, #182). The header rides as a
+    default on a session passed to `FcmRegister` via
+    `http_client_session`; aiohttp merges per-request headers on top so
+    the library's own `x-firebase-client` / `x-goog-api-key` stay
+    untouched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ajax_cobrand_passes_custom_session_with_package_header(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(return_value={})
+        coordinator = MagicMock()
+        listener = AjaxNotificationListener(
+            hass=hass,
+            coordinator=coordinator,
+            **_VALID_FCM_SHAPES,
+            entry_id="entry-x",
+            app_label="Ajax",
+        )
+        listener._store.async_load = AsyncMock(return_value=None)
+        listener._register_push_token = AsyncMock()
+
+        register_cls = MagicMock()
+        instance = MagicMock()
+        instance.register = MagicMock(side_effect=RuntimeError("boom"))  # bail before push start
+        register_cls.return_value = instance
+
+        with (
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_invalid"
+            ),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_credentials_invalid"),
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_malformed"
+            ),
+            patch(
+                "custom_components.aegis_ajax.notification.async_clear_fcm_credentials_malformed"
+            ),
+            patch("custom_components.aegis_ajax.notification.async_register_fcm_not_configured"),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_not_configured"),
+        ):
+            await listener.async_start()
+
+        # FcmRegister must be constructed with a session whose default
+        # headers include `X-Android-Package: com.ajaxsystems` so
+        # Firebase Installations sees the package id and the api-key
+        # restriction passes.
+        assert register_cls.call_count == 1
+        kwargs = register_cls.call_args.kwargs
+        session = kwargs["http_client_session"]
+        assert session is not None
+        # aiohttp.ClientSession exposes default headers via its `headers`
+        # property — accept either dict-like (`["X-Android-Package"]`)
+        # or attr-style depending on the aiohttp version.
+        header_value = (
+            session.headers.get("X-Android-Package")
+            if hasattr(session.headers, "get")
+            else session.headers["X-Android-Package"]
+        )
+        assert header_value == "com.ajaxsystems"
+
+    @pytest.mark.asyncio
+    async def test_unknown_cobrand_passes_no_session(self) -> None:
+        """Co-brand labels without a known Android package mapping fall
+        back to the pre-1.5.3-beta.10 behaviour: FcmRegister gets the
+        default constructor (no `http_client_session`), so we don't
+        emit an empty / unrelated session that would never satisfy
+        Google's restriction anyway.
+        """
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(return_value={})
+        coordinator = MagicMock()
+        listener = AjaxNotificationListener(
+            hass=hass,
+            coordinator=coordinator,
+            **_VALID_FCM_SHAPES,
+            entry_id="entry-x",
+            app_label="some_brand_we_dont_map_yet",
+        )
+        listener._store.async_load = AsyncMock(return_value=None)
+        listener._register_push_token = AsyncMock()
+
+        register_cls = MagicMock()
+        instance = MagicMock()
+        instance.register = MagicMock(side_effect=RuntimeError("boom"))
+        register_cls.return_value = instance
+
+        with (
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_invalid"
+            ),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_credentials_invalid"),
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_malformed"
+            ),
+            patch(
+                "custom_components.aegis_ajax.notification.async_clear_fcm_credentials_malformed"
+            ),
+            patch("custom_components.aegis_ajax.notification.async_register_fcm_not_configured"),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_not_configured"),
+        ):
+            await listener.async_start()
+
+        # FcmRegister called without `http_client_session` — kwargs
+        # dict must not carry that key.
+        assert register_cls.call_count == 1
+        assert "http_client_session" not in register_cls.call_args.kwargs
+
+
 class TestAsyncStartFcmShapePreflight:
     """`async_start` runs shape validation BEFORE invoking firebase_messaging.
 


### PR DESCRIPTION
## Summary
- Adds `APP_LABEL_TO_ANDROID_PACKAGE` in `const.py` mapping verified co-brands to their Android package ids (`Ajax → com.ajaxsystems`, `ajax_pro → com.ajaxsystems.pro`, `AIKO → com.ajaxsystems.aiko`, `Protegim_alarma → com.ajaxsystems.protegim`).
- Threads `app_label` through `coordinator.async_start_push_notifications` and into `AjaxNotificationListener.__init__`.
- When the app_label has a known mapping, the listener constructs an `aiohttp.ClientSession` with `X-Android-Package` as a default header and passes it to `FcmRegister` via the library's `http_client_session` parameter. aiohttp merges per-request headers on top, so the library's own `x-firebase-client` / `x-goog-api-key` stay untouched and every Firebase Installations call (registration + refresh) carries the package id.
- Co-brands without a mapping fall back to the pre-`1.5.3-beta.10` behaviour (no session passed, no header), so the change is no-op for already-working setups.
- 1.5.3-beta.10 bump.

## Why now
@alt-BadBatch's original #182 report identified the missing header as the cause on day one. I dismissed it then based on "the library works for Tesla / Roomba / etc., so the api-key restriction can't be in play" — that inference was wrong, the restriction is per-key, not per-library. Three reports across three weeks (@aitrus22 in #155, @alt-BadBatch in #182, @zwagerzaken in #182) all carry the same `API_KEY_ANDROID_APP_BLOCKED` 403 with `consumer: projects/991608156148` and `androidPackage: <empty>` against the official Ajax co-brand API key on Project B (`elite-dreamer-676`). The validator added in `1.5.3-beta.4 → .5 → .7` improves error-reporting for paste-truncation but cannot fix this case because the credentials are structurally pristine.

The integration now sends what the Ajax mobile app sends — its own Android package id as a header — so Google's package restriction is satisfied and registration goes through.

## Test plan
- [x] New `test_ajax_cobrand_passes_custom_session_with_package_header`: listener with `app_label="Ajax"` constructs `FcmRegister` with a session whose default headers include `X-Android-Package: com.ajaxsystems`. Tolerant of aiohttp's two header access styles (`session.headers.get(...)` / `session.headers[...]`).
- [x] New `test_unknown_cobrand_passes_no_session`: listener with an unmapped `app_label` constructs `FcmRegister` without passing `http_client_session` — `kwargs` dict must not carry that key. Preserves the pre-fix behaviour for any co-brand we haven't catalogued yet.
- [x] Existing FCM tests (`TestAsyncStartFcmShapePreflight`, `TestAsyncStartFcmRepairs`, `TestClassifyFcmFailure`, `TestValidateFcmShape`) all still green — the new session injection sits in the registration path and is skipped when credentials are already loaded from `Store`.
- [x] Full unit suite: 1359 passed (+2 net), coverage 86.57% (+0.33% vs `1.5.3-beta.9`).
- [x] `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all green on the rebuilt Docker image without volume mount.