### PR TITLE
fix(devices): evict cached video-doorbell ghost on snapshot merge (refs #173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.2] - 2026-05-26
+## [1.6.2-beta.1] - 2026-05-27
 
 ### Fixed
 - **Duplicate MotionCam Video Doorbell card no longer survives restarts** (#173, follow-up — diagnostics from @brunovdw68 on `ajax_pro`). The `1.5.2` dedup drops the `motion_cam_video_*` Jeweller-side twin when its `video_edge_*` sibling is in the same snapshot, but the coordinator *merges* each stream snapshot into its device set rather than replacing it (so multi-space installs don't wipe each other). A ghost that had been persisted to the warm-start cache before its sibling appeared was therefore never removed by the merge — it reloaded from cache on every restart, kept its spurious `malfunctions=1` bubbling up to the space malfunction counter, and couldn't be deleted by the user because the integration was still providing it. The dedup now re-runs across the full merged device set (on cache load and after every stream snapshot), and any dropped ghost is also evicted from Home Assistant's device registry so its card and entities disappear automatically — no manual deletion needed. The unbalanced #119 case (only the hub_device twin present, no `video_edge_*` sibling) is unchanged: that doorbell is kept. (Note: the separate report in this thread that doorbell and motion events don't arrive is being tracked independently — it's an event-routing question, not the duplicate.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-05-26
+
+### Fixed
+- **Duplicate MotionCam Video Doorbell card no longer survives restarts** (#173, follow-up — diagnostics from @brunovdw68 on `ajax_pro`). The `1.5.2` dedup drops the `motion_cam_video_*` Jeweller-side twin when its `video_edge_*` sibling is in the same snapshot, but the coordinator *merges* each stream snapshot into its device set rather than replacing it (so multi-space installs don't wipe each other). A ghost that had been persisted to the warm-start cache before its sibling appeared was therefore never removed by the merge — it reloaded from cache on every restart, kept its spurious `malfunctions=1` bubbling up to the space malfunction counter, and couldn't be deleted by the user because the integration was still providing it. The dedup now re-runs across the full merged device set (on cache load and after every stream snapshot), and any dropped ghost is also evicted from Home Assistant's device registry so its card and entities disappear automatically — no manual deletion needed. The unbalanced #119 case (only the hub_device twin present, no `video_edge_*` sibling) is unchanged: that doorbell is kept. (Note: the separate report in this thread that doorbell and motion events don't arrive is being tracked independently — it's an event-routing question, not the duplicate.)
+
 ## [1.6.1] - 2026-05-26
 
 ### Changed

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -442,6 +443,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.debug("Failed to load devices cache", exc_info=True)
         if cached_devices:
             self.devices = cached_devices
+            # A cache written before the #173 dedup (or before the
+            # video_edge sibling first appeared) can carry a stale
+            # motion_cam_video_* ghost. Drop it on load if the sibling is
+            # also cached; otherwise the first stream snapshot resolves it.
+            self._dedupe_video_doorbells()
         else:
             initial_devices: dict[str, Device] = {}
             for space_id in self.spaces:
@@ -799,12 +805,52 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Handle initial snapshot or full device snapshot update from stream."""
         for device in devices:
             self.devices[device.id] = device
+        # `DevicesApi` dedups video-doorbell twins per snapshot, but the merge
+        # above only ever *adds* keys — a `motion_cam_video_*` ghost that was
+        # warm-started from the cache before its `video_edge_*` sibling
+        # appeared would never be removed, so it survives every restart and
+        # keeps bubbling its `malfunctions=1` to the space counter (#173).
+        # Re-run the dedup across the whole device set now that this snapshot
+        # may have brought the sibling in.
+        self._dedupe_video_doorbells()
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         # Refresh the persisted cache so the next restart can warm-start
         # from real data instead of the previous boot's snapshot (#114).
         # Debounced — bursts of stream snapshots coalesce into one write.
         if self._devices_cache is not None:
             self._devices_cache.async_schedule_save(self.devices)
+
+    def _dedupe_video_doorbells(self) -> None:
+        """Re-apply the video-doorbell dedup across `self.devices` and evict
+        any dropped ghost from HA's device registry.
+
+        `DevicesApi._dedupe_video_doorbells` is the source of truth for which
+        twin to drop; here we apply it to the merged device set (not a single
+        snapshot) so a ghost that entered `self.devices` via the warm-start
+        cache is removed once its `video_edge_*` sibling shows up. Devices the
+        dedup drops are also removed from the device registry so their card
+        and entities disappear without the user having to delete them by hand
+        (the original #173 complaint — HA won't let you delete a device an
+        active integration still provides).
+        """
+        current = list(self.devices.values())
+        deduped = DevicesApi._dedupe_video_doorbells(current)
+        if len(deduped) == len(current):
+            return
+        kept_ids = {d.id for d in deduped}
+        dropped = [d for d in current if d.id not in kept_ids]
+        self.devices = {d.id: d for d in deduped}
+        device_reg = dr.async_get(self.hass)
+        for ghost in dropped:
+            reg_device = device_reg.async_get_device(identifiers={(DOMAIN, ghost.id)})
+            if reg_device is not None:
+                _LOGGER.info(
+                    "Removing duplicate video-doorbell ghost %s (%s) from the "
+                    "device registry — a video_edge sibling now represents it (#173)",
+                    ghost.id,
+                    ghost.device_type,
+                )
+                device_reg.async_remove_device(reg_device.id)
 
     def _handle_status_update(self, device_id: str, status_name: str, data: dict[str, Any]) -> None:
         """Handle real-time status update from the persistent stream.

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.6.1"
+    "version": "1.6.2"
 }

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.6.2"
+    "version": "1.6.2-beta.1"
 }

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -678,6 +678,75 @@ class TestStreamHandlers:
         coordinator._handle_devices_snapshot([updated])
         assert coordinator.devices["d1"] is updated
 
+    @staticmethod
+    def _make_doorbell(device_id: str, device_type: str, name: str = "Deurbel") -> Device:
+        return Device(
+            id=device_id,
+            hub_id="hub-1",
+            name=name,
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=1 if device_type.startswith("motion_cam_video") else 0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    def test_snapshot_evicts_cached_ghost_when_sibling_arrives(self) -> None:
+        """#173 — a motion_cam_video ghost warm-started from cache is dropped
+        once the video_edge sibling arrives in a later snapshot, and removed
+        from the device registry so its card disappears."""
+        coordinator = self._make_coordinator_with_stream()
+        # Ghost was warm-started from the cache; sibling not present yet.
+        coordinator.devices["310A8DF4"] = self._make_doorbell(
+            "310A8DF4", "motion_cam_video_doorbell"
+        )
+
+        reg_device = MagicMock()
+        reg_device.id = "reg-ghost"
+        device_reg = MagicMock()
+        device_reg.async_get_device.return_value = reg_device
+
+        sibling = self._make_doorbell("9c756e2bca39-0", "video_edge_doorbell")
+        with patch(
+            "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg
+        ):
+            coordinator._handle_devices_snapshot([sibling])
+
+        assert "310A8DF4" not in coordinator.devices
+        assert "9c756e2bca39-0" in coordinator.devices
+        device_reg.async_remove_device.assert_called_once_with("reg-ghost")
+
+    def test_snapshot_keeps_ghost_when_no_sibling(self) -> None:
+        """Unbalanced #119 case: only the hub_device twin exists — keep it."""
+        coordinator = self._make_coordinator_with_stream()
+        ghost = self._make_doorbell("310A8DF4", "motion_cam_video_doorbell")
+
+        with patch("custom_components.aegis_ajax.coordinator.dr.async_get") as mock_get:
+            coordinator._handle_devices_snapshot([ghost])
+
+        assert "310A8DF4" in coordinator.devices
+        mock_get.assert_not_called()
+
+    def test_snapshot_skips_registry_when_ghost_not_registered(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["310A8DF4"] = self._make_doorbell(
+            "310A8DF4", "motion_cam_video_doorbell"
+        )
+        device_reg = MagicMock()
+        device_reg.async_get_device.return_value = None
+
+        sibling = self._make_doorbell("9c756e2bca39-0", "video_edge_doorbell")
+        with patch(
+            "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg
+        ):
+            coordinator._handle_devices_snapshot([sibling])
+
+        assert "310A8DF4" not in coordinator.devices
+        device_reg.async_remove_device.assert_not_called()
+
     def test_handle_status_update_add_sets_status_true(self) -> None:
         coordinator = self._make_coordinator_with_stream()
         coordinator.devices["d1"] = _make_device("d1")


### PR DESCRIPTION
## Summary

- Fixes the duplicate MotionCam Video Doorbell card persisting across restarts even after the `1.5.2` dedup.
- The coordinator now re-runs `_dedupe_video_doorbells` across the **full merged device set** — on warm-start cache load and after every stream snapshot — instead of relying solely on the per-snapshot dedup in `DevicesApi`.
- Any dropped ghost is also evicted from the HA **device registry**, so its card and entities disappear automatically (no manual deletion).

Shipping as **`1.6.2-beta.1`**: the fix can't be verified on the maintainer's hardware (no `video_edge` doorbell to reproduce the ghost) and it removes devices from the registry, so it goes to the reporter as a beta first and is promoted to stable `1.6.2` once confirmed.

## Root cause

@brunovdw68's diagnostics (#173, `ajax_pro`, 1.6.0, restarted) showed the `motion_cam_video_doorbell` twin (`malfunctions=1`) still present next to its canonical `video_edge_doorbell` sibling — both named "Deurbel".

`DevicesApi._dedupe_video_doorbells` dedups each snapshot, but `coordinator._handle_devices_snapshot` **merges** snapshots into `self.devices` (only adds keys, never removes absent ones — deliberate, so multi-space streams don't wipe each other). A ghost that reached `self.devices` via the warm-start cache before its `video_edge` sibling appeared was never removed: it reloaded from cache on every restart, kept bubbling its `malfunctions=1` to the space counter, and couldn't be deleted by the user because the integration was still providing it.

## Fix

- New `coordinator._dedupe_video_doorbells()` applies the existing `DevicesApi` dedup to the whole `self.devices` set and removes any dropped ghost from the device registry.
- Called from `_first_startup_init` (after cache load) and `_handle_devices_snapshot` (after merge).
- The unbalanced #119 case (only the hub_device twin, no `video_edge` sibling) is untouched.

## Out of scope

The separate report in the same thread — doorbell **and** motion events not arriving — is an event-routing question, not the duplicate. Tracked independently; awaiting FCM debug logs from the reporter.

## Test plan

- [x] `tests/unit/test_coordinator.py::TestStreamHandlers` — 3 new tests: ghost evicted + registry removal when sibling arrives; ghost kept when no sibling (registry untouched); registry removal skipped when ghost isn't registered.
- [x] Full suite 1388 → 1391 passing, coverage 87.8%.
- [x] Lint + format + mypy + vulture clean in a freshly built dev image (no volume mount).
- [ ] Live confirmation from @brunovdw68 after upgrading to `1.6.2-beta.1`: the `motion_cam_video_doorbell` card disappears and space malfunctions drops to 0. Promote to stable `1.6.2` once confirmed.

Refs #173.