### PR TITLE
fix(fcm): name API_KEY_SERVICE_BLOCKED in the wrong-AIza 403 message (refs #194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2-beta.2] - 2026-05-27
+
+### Changed
+- **FCM 403 warning now names `API_KEY_SERVICE_BLOCKED` alongside `API_KEY_ANDROID_APP_BLOCKED`** (#194, reported by @raven2k24). Both 403 sub-codes from Firebase Installations share the same cause — the wrong `AIza…` key — and the same fix: use the FCM-scoped key from `libnative-lib.so`, not the `google_maps_key` in `strings.xml` (which is a real `AIza…` but scoped to Maps and surfaces as `SERVICE_BLOCKED`). The classifier message now explains both so a user hitting `SERVICE_BLOCKED` recognises it's the same wrong-key situation. Confirmed against @raven2k24's extracted values: project / app_id / sender all correct for `com.ajaxsystems` (Project B, `elite-dreamer-676`), only the api_key was a non-FCM `AIza…`.
+
 ## [1.6.2-beta.1] - 2026-05-27
 
 ### Fixed

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.6.2-beta.1"
+    "version": "1.6.2-beta.2"
 }

--- a/custom_components/aegis_ajax/notification_fcm_creds.py
+++ b/custom_components/aegis_ajax/notification_fcm_creds.py
@@ -113,12 +113,16 @@ def _classify_fcm_failure(exc: BaseException) -> str:
         )
     if "unable to register with fcm" in lower:
         return (
-            "Firebase Installations refused the api-key for this Android package "
-            "(HTTP 403 API_KEY_ANDROID_APP_BLOCKED). The Ajax APK's native library "
-            "usually contains several `AIza…` strings — one for FCM and one or more "
-            "for Google Maps / ML Kit. Only the FCM-scoped key is accepted here. "
-            "If you extracted just the first `AIza…` you found, try the others via "
-            "the Repair card under Settings → Repairs. See "
+            "Firebase Installations refused the api-key (HTTP 403 — "
+            "API_KEY_ANDROID_APP_BLOCKED or API_KEY_SERVICE_BLOCKED). Both point "
+            "at the wrong `AIza…` key: the Ajax APK's native library ships several "
+            "`AIza…` strings — one for FCM and one or more for other Google "
+            "services (Maps / ML Kit), and `strings.xml`'s `google_maps_key` is a "
+            "real `AIza…` that is NOT the FCM key. Only the FCM-scoped key from "
+            "`libnative-lib.so` is accepted here; a Maps-scoped key surfaces as "
+            "API_KEY_SERVICE_BLOCKED, a package-restricted one as "
+            "API_KEY_ANDROID_APP_BLOCKED. If you extracted the wrong `AIza…`, try "
+            "the others via the Repair card under Settings → Repairs. See "
             "https://github.com/bvis/aegis-hass#where-the-values-live for the "
             "extraction guide."
         )

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -865,7 +865,11 @@ class TestClassifyFcmFailure:
         # (Maps / ML Kit). Surface that explanation so future users
         # don't go down the paste-truncation rabbit hole.
         msg = _classify_fcm_failure(RuntimeError("Unable to register with fcm"))
+        # Both 403 sub-codes share the same cause (wrong AIza key) and remedy,
+        # so the message names both: ANDROID_APP_BLOCKED (package-restricted
+        # key) and SERVICE_BLOCKED (Maps/other-service key — raven2k24's #194).
         assert "API_KEY_ANDROID_APP_BLOCKED" in msg
+        assert "API_KEY_SERVICE_BLOCKED" in msg
         assert "AIza" in msg  # the wrong-string explanation
         assert "Repair card" in msg
 


### PR DESCRIPTION
## Summary

- Broadens the FCM 403 classifier message to name **both** `API_KEY_ANDROID_APP_BLOCKED` and `API_KEY_SERVICE_BLOCKED`, since both come from the same cause (the wrong `AIza…` key) with the same fix.
- Explains which scope produces which: a Maps-scoped key → `SERVICE_BLOCKED`, a package-restricted key → `ANDROID_APP_BLOCKED`.

## Why

#194 (@raven2k24): `API_KEY_SERVICE_BLOCKED` on `firebaseinstallations` for `com.ajaxsystems`. I verified their extracted values against our records — `project_id` / `fcm_app_id` / `fcm_sender_id` are all correct for the standard Ajax app (Project B, `elite-dreamer-676`, app_id `1:991608156148:android:1be5b6c08d8…`). The only wrong value is the **api_key**: it's a non-FCM `AIza…` string (the APK's `strings.xml` ships a real `google_maps_key` that is NOT the FCM key; the FCM key is in `libnative-lib.so`). A Maps-scoped key restricted away from `firebaseinstallations.googleapis.com` produces exactly `SERVICE_BLOCKED`.

The classifier already fires the wrong-AIza message for this 403, but it only named `ANDROID_APP_BLOCKED`, so a `SERVICE_BLOCKED` reporter wouldn't recognise the message applied to them. Now it names both.

## Test plan

- [x] `tests/unit/test_notification.py::...test_fcm_install_failure_points_at_wrong_aiza_string` — asserts both sub-codes are named.
- [x] Full suite 1391 passing, coverage 87.8%.
- [x] Lint + format + mypy + vulture clean in a freshly built dev image (no volume mount).

Versioned as `1.6.2-beta.2` (rolls the in-flight 1.6.2 beta forward; promoted to stable `1.6.2` together with the #173 doorbell fix once @brunovdw68 confirms beta.1).

Refs #194.