### PR TITLE
fix: gRPC channel cleanup on setup/config-flow failure + full service teardown

### DIFF
--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -92,6 +92,17 @@ PLATFORMS = [
 
 type AjaxCobrandedConfigEntry = ConfigEntry[AjaxCobrandedCoordinator]
 
+# Single source of truth for the domain-level custom services. Registration
+# (async_setup_entry) and teardown (async_unload_entry) both derive from this
+# tuple so the two lists cannot drift — adding a service in one place without
+# the other previously leaked a registered service on unload.
+_CUSTOM_SERVICE_NAMES = (
+    "force_arm",
+    "force_arm_night",
+    "press_panic_button",
+    "set_photo_on_demand_mode",
+)
+
 
 def _resolve_target_space_ids(
     hass: HomeAssistant, call: ServiceCall
@@ -328,7 +339,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
         on_session_persist=_persist_session,
         entry_id=entry.entry_id,
     )
-    await coordinator.async_config_entry_first_refresh()
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except BaseException:
+        # HA retries setup after ConfigEntryNotReady, building a fresh client
+        # each attempt. Close this attempt's channel so retries don't leak one
+        # gRPC channel per failure (also covers cancellation during refresh).
+        await client.close()
+        raise
     entry.runtime_data = coordinator
 
     # Start FCM push notifications if configured (credentials live in data since v2).
@@ -398,12 +416,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
         await _async_handle_set_photo_on_demand_mode(hass, call)
 
     if not hass.services.has_service(DOMAIN, "force_arm"):
-        hass.services.async_register(DOMAIN, "force_arm", _force_arm_handler)
-        hass.services.async_register(DOMAIN, "force_arm_night", _force_arm_night_handler)
-        hass.services.async_register(DOMAIN, "press_panic_button", _press_panic_button_handler)
-        hass.services.async_register(
-            DOMAIN, "set_photo_on_demand_mode", _set_photo_on_demand_mode_handler
-        )
+        service_handlers = {
+            "force_arm": _force_arm_handler,
+            "force_arm_night": _force_arm_night_handler,
+            "press_panic_button": _press_panic_button_handler,
+            "set_photo_on_demand_mode": _set_photo_on_demand_mode_handler,
+        }
+        # KeyError here means a name was added to _CUSTOM_SERVICE_NAMES without a
+        # handler — fail loudly at setup rather than silently skipping it.
+        for name in _CUSTOM_SERVICE_NAMES:
+            hass.services.async_register(DOMAIN, name, service_handlers[name])
 
     # Reload integration when options change (e.g. FCM credentials)
     entry.async_on_unload(entry.add_update_listener(_async_options_update_listener))
@@ -511,9 +533,8 @@ async def _async_options_update_listener(
 async def async_unload_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry) -> bool:
     remaining = hass.config_entries.async_entries(DOMAIN)
     if not any(e.entry_id != entry.entry_id for e in remaining):
-        hass.services.async_remove(DOMAIN, "force_arm")
-        hass.services.async_remove(DOMAIN, "force_arm_night")
-        hass.services.async_remove(DOMAIN, "press_panic_button")
+        for name in _CUSTOM_SERVICE_NAMES:
+            hass.services.async_remove(DOMAIN, name)
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -107,6 +107,22 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         }
         return await self.async_step_user()
 
+    async def _async_close_client(self) -> None:
+        """Close and drop the in-flight gRPC client after a failed login.
+
+        Each retry of async_step_user builds a fresh client, so the failed
+        attempt's channel must be closed or it leaks until garbage collection.
+        Close errors are swallowed — we're already on an error path.
+        """
+        if self._client is None:
+            return
+        try:
+            await self._client.close()
+        except Exception:  # noqa: BLE001 - best-effort cleanup
+            _LOGGER.debug("Ignoring error while closing config-flow client", exc_info=True)
+        finally:
+            self._client = None
+
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
         if user_input is not None:
@@ -126,20 +142,28 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                 await asyncio.wait_for(self._client.login(), timeout=30)
                 return await self.async_step_select_spaces()
             except TwoFactorRequiredError as e:
+                # Channel must stay open: async_step_2fa reuses this client.
                 self._request_id = e.request_id
                 return await self.async_step_2fa()
+            except asyncio.CancelledError:
+                # Re-raise so HA shutdown/reload cancels cleanly (it's a
+                # BaseException, not a user-facing error), but close the channel
+                # we just opened on the way out.
+                _LOGGER.debug("Login cancelled during config flow")
+                await self._async_close_client()
+                raise
             except AuthenticationError as e:
                 _LOGGER.error("Authentication failed: %s", e)
                 errors["base"] = "invalid_auth"
+                await self._async_close_client()
             except (ConnectionError, OSError) as e:
                 _LOGGER.error("Connection failed: %s", e)
                 errors["base"] = "cannot_connect"
+                await self._async_close_client()
             except TimeoutError:
                 _LOGGER.error("Login timed out")
                 errors["base"] = "cannot_connect"
-            except asyncio.CancelledError:
-                _LOGGER.error("Login was cancelled")
-                errors["base"] = "unknown"
+                await self._async_close_client()
             except Exception as e:
                 _LOGGER.error(
                     "Unexpected error during login: %s: %s",
@@ -148,6 +172,7 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                     exc_info=True,
                 )
                 errors["base"] = "unknown"
+                await self._async_close_client()
         return self.async_show_form(step_id="user", data_schema=USER_SCHEMA, errors=errors)
 
     async def async_step_2fa(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -162,6 +162,73 @@ class TestAsyncStepUser:
         assert flow.async_show_form.call_args[1]["errors"]["base"] == "unknown"
 
     @pytest.mark.asyncio
+    async def test_step_user_closes_client_on_login_failure(self) -> None:
+        """A failed login must close the channel; each retry creates a new client."""
+        flow = AjaxCobrandedConfigFlow()
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.login = AsyncMock(side_effect=AuthenticationError("invalid"))
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "custom_components.aegis_ajax.config_flow.AjaxGrpcClient", return_value=mock_client
+        ):
+            await flow.async_step_user({"email": "a@b.com", "password": "bad"})
+
+        assert flow.async_show_form.call_args[1]["errors"]["base"] == "invalid_auth"
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_step_user_reraises_cancelled_error(self) -> None:
+        """CancelledError must propagate so HA shutdown/reload cancels cleanly."""
+        import asyncio
+
+        flow = AjaxCobrandedConfigFlow()
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.login = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_client.close = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.aegis_ajax.config_flow.AjaxGrpcClient", return_value=mock_client
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await flow.async_step_user({"email": "a@b.com", "password": "pass"})
+
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_step_user_keeps_client_open_for_2fa(self) -> None:
+        """The 2FA path reuses the same client, so it must NOT be closed."""
+        flow = AjaxCobrandedConfigFlow()
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.login = AsyncMock(side_effect=TwoFactorRequiredError("req-123"))
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "custom_components.aegis_ajax.config_flow.AjaxGrpcClient", return_value=mock_client
+        ):
+            await flow.async_step_user({"email": "a@b.com", "password": "pass"})
+
+        assert flow._request_id == "req-123"
+        mock_client.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_step_user_2fa_required(self) -> None:
         flow = AjaxCobrandedConfigFlow()
         flow.async_show_form = MagicMock(return_value={"type": "form"})

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -93,6 +93,48 @@ class TestAsyncSetupEntry:
         assert "password" not in call_kwargs or call_kwargs.get("password") is None
 
     @pytest.mark.asyncio
+    async def test_setup_entry_closes_client_when_first_refresh_fails(self) -> None:
+        """A failed first refresh must close the gRPC channel before propagating.
+
+        HA retries setup after ConfigEntryNotReady, creating a fresh client each
+        time. Leaving the previous channel open leaks one channel per retry.
+        """
+        from homeassistant.exceptions import ConfigEntryNotReady
+
+        from custom_components.aegis_ajax import async_setup_entry
+
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.data = {"email": "x@y", "password_hash": "h", "spaces": ["s1"]}
+        entry.options = {}
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.session = MagicMock()
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock(
+            side_effect=ConfigEntryNotReady("server unreachable")
+        )
+
+        with (
+            patch("custom_components.aegis_ajax.AjaxGrpcClient", return_value=mock_client),
+            patch(
+                "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
+                return_value=mock_coordinator,
+            ),
+            pytest.raises(ConfigEntryNotReady),
+        ):
+            await async_setup_entry(hass, entry)
+
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_setup_entry_with_legacy_password(self) -> None:
         """Test backward compatibility: legacy entries with plaintext password still work."""
         from custom_components.aegis_ajax import async_setup_entry

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -109,12 +109,14 @@ class TestServiceRegistration:
             result = await async_setup_entry(hass, entry)
 
         assert result is True
-        # Verify both services were registered
+        # Verify all four custom services were registered
         register_calls = {
             call_args[0][1] for call_args in hass.services.async_register.call_args_list
         }
         assert "force_arm" in register_calls
         assert "force_arm_night" in register_calls
+        assert "press_panic_button" in register_calls
+        assert "set_photo_on_demand_mode" in register_calls
 
     @pytest.mark.asyncio
     async def test_services_removed_on_unload(self) -> None:
@@ -136,5 +138,8 @@ class TestServiceRegistration:
 
         assert result is True
         remove_calls = {call_args[0][1] for call_args in hass.services.async_remove.call_args_list}
+        # Every service registered in async_setup_entry must be removed on unload
         assert "force_arm" in remove_calls
         assert "force_arm_night" in remove_calls
+        assert "press_panic_button" in remove_calls
+        assert "set_photo_on_demand_mode" in remove_calls


### PR DESCRIPTION
Addresses findings from an external code review of the integration. All
verified against the code before fixing — these are real, low-cost issues.

## Fixes

**1. Service not removed on unload.** `async_unload_entry` removed only three
of the four registered domain services; `set_photo_on_demand_mode` (added in
#157) was left registered after the last entry was unloaded. Both registration
and teardown now derive from a single `_CUSTOM_SERVICE_NAMES` tuple, so the two
lists can no longer drift.

**2. gRPC channel leak when first refresh fails.** `async_setup_entry` now
closes the client if `async_config_entry_first_refresh()` raises. HA retries
setup after `ConfigEntryNotReady` with a fresh client each time, so the
previous channel previously leaked once per retry.

**3. gRPC channel leak in config-flow errors.** `async_step_user` now closes
the in-flight client on every error branch — each retry builds a new client,
so the failed attempt's channel leaked until GC.

**4. `CancelledError` treated as a user error.** `async_step_user` mapped
`asyncio.CancelledError` to a user-facing `unknown` error. It now re-raises so
HA shutdown/reload cancels cleanly, matching the coordinator's cancellation
handling.

## Deliberate non-changes

The review suggested closing the client in the **2FA** error branches too.
That path *reuses* the same client across TOTP retries (no new client is
built), so closing it would break the retry. The 2FA step intentionally keeps
the channel open; a regression test guards this.

The version-desync finding (pyproject vs manifest) is handled in a separate PR
with a proper single-source guard test, not bundled here.

## Tests

- Service lifecycle tests extended to assert all four services are registered
  and removed.
- New: setup closes the client when first refresh fails.
- New: config flow closes the client on login failure, re-raises
  `CancelledError`, and keeps the client open on the 2FA path.

Full suite: 1395 passing, 87.9% coverage; ruff / format / mypy / vulture clean
(CI-parity run in Docker without volume mount).