### PR TITLE
chore: make manifest.json the single source for the release version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "aegis-ajax-hass"
-version = "1.2.1"
+# Mirror of manifest.json's version (the source of truth HA reads). Kept in
+# sync by tests/unit/test_version_consistency.py — bump both when releasing.
+version = "1.6.2-beta.2"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -1,0 +1,37 @@
+"""Guard against version drift between manifest.json and pyproject.toml.
+
+``manifest.json`` is the authoritative version — it is what Home Assistant
+reads at runtime. ``pyproject.toml`` carries a copy only for tooling/audits and
+is not used to build or publish (there is no ``[build-system]`` table). The two
+silently drifted (manifest at 1.6.2-beta.2 while pyproject sat at 1.2.1 for many
+releases); this test makes manifest the single source of truth by failing CI the
+moment the copy falls out of sync.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MANIFEST = _REPO_ROOT / "custom_components" / "aegis_ajax" / "manifest.json"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _manifest_version() -> str:
+    return json.loads(_MANIFEST.read_text())["version"]
+
+
+def _pyproject_version() -> str:
+    return tomllib.loads(_PYPROJECT.read_text())["project"]["version"]
+
+
+def test_pyproject_version_matches_manifest() -> None:
+    """pyproject.toml must mirror the authoritative manifest.json version."""
+    assert _pyproject_version() == _manifest_version(), (
+        "pyproject.toml version is out of sync with manifest.json "
+        f"({_pyproject_version()!r} != {_manifest_version()!r}). "
+        "manifest.json is the source of truth — update pyproject.toml to match "
+        "whenever you bump the release version."
+    )


### PR DESCRIPTION
Implements the version-desync finding from the code review as a proper
single-source guard rather than a one-off manual sync.

## Background

`pyproject.toml`'s `version` had silently drifted to `1.2.1` while
`manifest.json` (the version HA actually reads) advanced to `1.6.2-beta.2`,
unnoticed across many releases.

There is no `[build-system]` table, so `pyproject.toml` is never built or
published — its version is purely informational for tooling/audits. A dynamic
Python `__version__` source isn't viable either, because HA parses
`manifest.json` directly as static JSON.

## Change

- Declare `manifest.json` the authoritative source of truth.
- Add `tests/unit/test_version_consistency.py`, which fails CI the moment the
  `pyproject.toml` mirror drifts from `manifest.json`.
- Sync the mirror to `1.6.2-beta.2`.

Release process is unchanged except that bumping the version now touches both
files (the guard test enforces it instead of letting them silently diverge).

## Tests

New guard test confirmed RED at the drifted state (`1.2.1` vs `1.6.2-beta.2`)
and GREEN after sync. Full suite green; ruff / format / mypy / vulture clean.