### PR TITLE
feat(doorbell): surface ring + motion on the doorbell device card (#173)

### DIFF
--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -137,6 +137,10 @@ STREAM_RECONNECT_MAX_BACKOFF = 60  # seconds
 MIN_POLL_INTERVAL = 60  # seconds
 MAX_POLL_INTERVAL = 300  # seconds
 DEFAULT_POLL_INTERVAL = 300  # seconds fallback (stream handles real-time updates)
+# Auto-off window for a device `motion_detected` status set from an FCM motion
+# push (#173). Video-edge devices only report motion over FCM, so the binary
+# sensor has no "cleared" event — we self-clear it like a PIR detector.
+MOTION_PUSH_AUTO_OFF_SECONDS = 30
 GRPC_TIMEOUT = 10.0  # seconds
 GRPC_STREAM_TIMEOUT = 30.0  # seconds
 MAX_RETRIES = 3
@@ -454,3 +458,18 @@ ALL_EVENT_TYPES: list[str] = sorted(
     | set(VIDEO_EVENT_TAG_MAP.values())
     | set(SMARTLOCK_EVENT_TAG_MAP.values())
 )
+
+# Device types that get their own per-device doorbell `event` entity on their
+# device card (#173). The ring event is also fired on the hub-level event
+# entity for backwards compatibility; this surfaces it where users look first.
+DOORBELL_DEVICE_TYPES: frozenset[str] = frozenset(
+    {
+        "video_edge_doorbell",
+        "motion_cam_video_doorbell",
+    }
+)
+
+# HA event_type fired by the per-device doorbell event entity (#173).
+DOORBELL_EVENT_TYPE = "doorbell_pressed"
+# HA event_type for motion pushes; used to flip a device's motion sensor (#173).
+MOTION_EVENT_TYPE = "motion"

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -31,6 +31,7 @@ from custom_components.aegis_ajax.const import (
     DOMAIN,
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
+    MOTION_PUSH_AUTO_OFF_SECONDS,
     ConnectionStatus,
 )
 from custom_components.aegis_ajax.device_cache import DevicesCache
@@ -135,6 +136,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._stream_tasks: list[asyncio.Task[None]] = []
         self._streams_started: bool = False
         self._event_entities: dict[str, Any] = {}
+        # device_id -> per-device doorbell event entity (#173)
+        self._device_event_entities: dict[str, Any] = {}
+        # device_id -> cancel handle for a pending motion auto-off timer (#173)
+        self._motion_off_cancels: dict[str, Any] = {}
         self.last_photo_urls: dict[str, str] = {}
         # space_id -> (expiry_time, security_state)
         self._optimistic_space_states: dict[str, tuple[float, Any]] = {}
@@ -920,6 +925,70 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entity.handle_event(event_type, data)
         else:
             _LOGGER.debug("No event entity for space %s", space_id)
+
+    def register_device_event_entity(self, device_id: str, entity: object) -> None:
+        """Register a per-device doorbell event entity (#173)."""
+        self._device_event_entities[device_id] = entity
+
+    def fire_push_device_event(self, device_id: str, event_type: str, data: dict[str, Any]) -> bool:
+        """Dispatch a push event to a per-device event entity (#173).
+
+        Returns True when a matching device entity handled it, so the caller
+        can tell whether the event landed on the device card (vs only the
+        hub-level event entity).
+        """
+        entity = self._device_event_entities.get(device_id)
+        if entity is None:
+            return False
+        entity.handle_event(event_type, data)
+        return True
+
+    def apply_push_device_motion(self, device_id: str) -> None:
+        """Flip a device's `motion_detected` status on from an FCM motion push.
+
+        Video doorbells (and other video-edge devices) only report motion over
+        FCM — never in the gRPC snapshot — so their `motion` binary_sensor
+        stayed `off` forever. This sets `motion_detected=True` immediately,
+        records the detection time, and schedules an auto-off after
+        `MOTION_PUSH_AUTO_OFF_SECONDS` so the sensor self-clears like a PIR
+        detector. No-ops for unknown devices. (#173)
+        """
+        import time  # noqa: PLC0415
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        from homeassistant.helpers.event import async_call_later  # noqa: PLC0415
+
+        device = self.devices.get(device_id)
+        if device is None:
+            return
+        new_statuses = dict(device.statuses)
+        new_statuses["motion_detected"] = True
+        new_statuses["motion_detected_at"] = int(time.time())
+        self.devices[device_id] = dc_replace(device, statuses=new_statuses)
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
+        # Re-trigger extends the window: cancel a pending auto-off first.
+        cancel = self._motion_off_cancels.pop(device_id, None)
+        if cancel is not None:
+            cancel()
+        self._motion_off_cancels[device_id] = async_call_later(
+            self.hass,
+            MOTION_PUSH_AUTO_OFF_SECONDS,
+            lambda _now: self._clear_device_motion(device_id),
+        )
+
+    def _clear_device_motion(self, device_id: str) -> None:
+        """Reset a device's `motion_detected` status to off (auto-off). (#173)"""
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        self._motion_off_cancels.pop(device_id, None)
+        device = self.devices.get(device_id)
+        if device is None or not device.statuses.get("motion_detected"):
+            return
+        new_statuses = dict(device.statuses)
+        new_statuses["motion_detected"] = False
+        self.devices[device_id] = dc_replace(device, statuses=new_statuses)
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     async def async_start_push_notifications(
         self,

--- a/custom_components/aegis_ajax/event.py
+++ b/custom_components/aegis_ajax/event.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.event import EventEntity
+from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aegis_ajax.const import ALL_EVENT_TYPES, DOMAIN, MANUFACTURER
+from custom_components.aegis_ajax.const import (
+    ALL_EVENT_TYPES,
+    DOMAIN,
+    DOORBELL_DEVICE_TYPES,
+    DOORBELL_EVENT_TYPE,
+    MANUFACTURER,
+)
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 from custom_components.aegis_ajax.entity import build_device_info
 
@@ -29,9 +35,16 @@ async def async_setup_entry(
         AjaxSecurityEvent(coordinator=coordinator, space_id=space_id)
         for space_id in coordinator.spaces
     ]
-    async_add_entities(entities)
+    doorbell_entities = [
+        AjaxDoorbellEvent(coordinator=coordinator, device_id=device_id)
+        for device_id, device in coordinator.devices.items()
+        if device.device_type in DOORBELL_DEVICE_TYPES
+    ]
+    async_add_entities([*entities, *doorbell_entities])
     for entity in entities:
         coordinator.register_event_entity(entity._space_id, entity)
+    for doorbell in doorbell_entities:
+        coordinator.register_device_event_entity(doorbell._device_id, doorbell)
 
 
 class AjaxSecurityEvent(CoordinatorEntity[AjaxCobrandedCoordinator], EventEntity):
@@ -73,6 +86,54 @@ class AjaxSecurityEvent(CoordinatorEntity[AjaxCobrandedCoordinator], EventEntity
         self._trigger_event(event_type, data)
         self.async_write_ha_state()
         # Fire bus event for logbook descriptions
+        self.hass.bus.async_fire(
+            f"{DOMAIN}_event",
+            {"event_type": event_type, **data},
+        )
+
+
+class AjaxDoorbellEvent(CoordinatorEntity[AjaxCobrandedCoordinator], EventEntity):
+    """Per-device doorbell event entity living on the doorbell device card (#173).
+
+    The hub-level `AjaxSecurityEvent` already fires `doorbell_pressed`, but it
+    lives on the hub card so users watching the doorbell device saw no
+    activity. This mirrors the ring onto the doorbell's own card with the
+    idiomatic HA `doorbell` device class.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "doorbell"
+    _attr_device_class = EventDeviceClass.DOORBELL
+    _attr_event_types = [DOORBELL_EVENT_TYPE]
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._attr_unique_id = f"aegis_ajax_{device_id}_doorbell_event"
+        device = coordinator.devices.get(device_id)
+        if device is not None:
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, device_id)},
+                manufacturer=MANUFACTURER,
+            )
+
+    @property
+    def event_types(self) -> list[str]:
+        return self._attr_event_types
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister from coordinator when removed."""
+        self.coordinator._device_event_entities.pop(self._device_id, None)
+        await super().async_will_remove_from_hass()
+
+    def handle_event(self, event_type: str, data: dict[str, Any]) -> None:
+        """Called by coordinator when a doorbell push for this device arrives."""
+        if event_type != DOORBELL_EVENT_TYPE:
+            return
+        self._trigger_event(event_type, data)
+        self.async_write_ha_state()
         self.hass.bus.async_fire(
             f"{DOMAIN}_event",
             {"event_type": event_type, **data},

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -15,6 +15,9 @@ from homeassistant.helpers.storage import Store
 from custom_components.aegis_ajax import notification_event_parser
 from custom_components.aegis_ajax.const import (
     DOMAIN,
+    DOORBELL_DEVICE_TYPES,
+    DOORBELL_EVENT_TYPE,
+    MOTION_EVENT_TYPE,
     RAW_TAG_TO_GROUP_SECURITY_STATE,
     RAW_TAG_TO_SECURITY_STATE,
 )
@@ -54,6 +57,39 @@ NOTIFICATION_DEDUPE_WINDOW_SECONDS = 5.0
 # measured (sub-second) but short enough that a replay from any prior session
 # is rejected.
 STALE_PUSH_THRESHOLD_SECONDS = 120.0
+
+# A run of this many consecutive printable-ASCII bytes in a redacted hex dump
+# is treated as text (likely a device name / label) and masked. Shorter runs
+# stay as hex — too short to leak meaningful PII, and often coincidental.
+_MIN_PRINTABLE_RUN = 3
+
+
+def _redact_printable(data: bytes) -> str:
+    """Hex-encode `data`, masking runs of >=3 printable-ASCII bytes as
+    `<text:Nb>` (#173). Debug payload dumps can carry user device labels;
+    this keeps the binary shape visible for diagnosis without leaking PII
+    when a user pastes the log publicly. See [[feedback_pii_in_debug_logs]].
+    """
+    out: list[str] = []
+    run: list[int] = []
+
+    def flush() -> None:
+        if not run:
+            return
+        if len(run) >= _MIN_PRINTABLE_RUN:
+            out.append(f"<text:{len(run)}b>")
+        else:
+            out.append(bytes(run).hex())
+        run.clear()
+
+    for byte in data:
+        if 0x20 <= byte <= 0x7E:
+            run.append(byte)
+        else:
+            flush()
+            out.append(f"{byte:02x}")
+    flush()
+    return "".join(out)
 
 
 # FCM credentials validation + library-error classifier extracted to
@@ -561,8 +597,75 @@ class AjaxNotificationListener:
                     for space_id in self._coordinator._space_ids:
                         self._coordinator.fire_push_event(space_id, event_type, event_data)
                         self._apply_security_state_from_event(space_id, event_data)
+                # Surface doorbell ring / motion on the source device's own
+                # card, in addition to the hub-level event entity (#173).
+                self._dispatch_event_to_device(event_type, event_data, raw)
         except Exception:
             _LOGGER.debug("Failed to parse event from push notification", exc_info=True)
+
+    def _dispatch_event_to_device(
+        self, event_type: str, event_data: dict[str, Any], raw: bytes
+    ) -> None:
+        """Mirror a doorbell ring / motion push onto the source device (#173).
+
+        Resolves the source device from the `device_id` carried in the push
+        (`_extract_source_info`). For doorbell rings, when no usable device id
+        is present we fall back to the sole doorbell device in the install —
+        the common single-doorbell case — so users still see the ring on the
+        doorbell card. Motion has no such fallback: the `motion` event_type is
+        shared with PIR detectors, so an unattributed motion push must not be
+        guessed onto an arbitrary device.
+
+        The instrumentation log below is intentional: it records exactly what
+        device attribution the parser resolved (or failed to), so if a user's
+        firmware turns out to ship a source shape we don't decode, the next
+        debug capture shows it without another code round-trip.
+        """
+        if event_type not in (DOORBELL_EVENT_TYPE, MOTION_EVENT_TYPE):
+            return
+
+        devices = getattr(self._coordinator, "devices", {}) or {}
+        device_id = event_data.get("device_id")
+        resolved = device_id if device_id in devices else None
+
+        if resolved is None and event_type == DOORBELL_EVENT_TYPE:
+            doorbells = [
+                dev_id
+                for dev_id, dev in devices.items()
+                if getattr(dev, "device_type", None) in DOORBELL_DEVICE_TYPES
+            ]
+            if len(doorbells) == 1:
+                resolved = doorbells[0]
+
+        # device_name is intentionally omitted — it's a user label (PII) and
+        # debug logs get pasted publicly. The hardware id + type are enough to
+        # confirm attribution.
+        _LOGGER.debug(
+            "Push device attribution: event_type=%s extracted_device_id=%s "
+            "device_type=%s resolved=%s",
+            event_type,
+            device_id,
+            event_data.get("device_type"),
+            resolved,
+        )
+
+        if resolved is None:
+            # Capped, PII-redacted hex of the payload so an unattributed
+            # doorbell/motion push can still be diagnosed from a debug log.
+            _LOGGER.debug(
+                "Push %s not attributed to a device; source missing or unknown. "
+                "Payload (hex, redacted, capped 512b): %s",
+                event_type,
+                _redact_printable(raw[:512]),
+            )
+            return
+
+        if event_type == DOORBELL_EVENT_TYPE:
+            self._coordinator.fire_push_device_event(resolved, event_type, event_data)
+        elif event_type == MOTION_EVENT_TYPE and self._hass.loop and self._hass.loop.is_running():
+            self._hass.loop.call_soon_threadsafe(
+                self._coordinator.apply_push_device_motion, resolved
+            )
 
     def _apply_security_state_from_event(self, space_id: str, event_data: dict[str, Any]) -> None:
         """If the push event implies a new security_state, push it now (#68 / #148).

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -269,6 +269,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Doorbell",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Doorbell pressed"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Timbre",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Timbre premut"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Zvonek",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Stisknutí zvonku"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Türklingel",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Klingel gedrückt"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -273,6 +273,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Doorbell",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Doorbell pressed"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -273,6 +273,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Timbre",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Timbre pulsado"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Sonnette",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Sonnette appuyée"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Campanello",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Campanello premuto"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Deurbel",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Bel ingedrukt"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Dzwonek",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Naciśnięto dzwonek"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Campainha",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Campainha tocada"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Campainha",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Campainha tocada"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Sonerie",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Sonerie apăsată"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Kapı zili",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Zile basıldı"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -257,6 +257,16 @@
                         }
                     }
                 }
+            },
+            "doorbell": {
+                "name": "Дзвінок",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "doorbell_pressed": "Натиснуто дзвінок"
+                        }
+                    }
+                }
             }
         },
         "binary_sensor": {

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1319,6 +1319,99 @@ class TestApplyPushSecurityState:
         coordinator.async_set_updated_data.assert_called_once()
 
 
+class TestApplyPushDeviceMotion:
+    """Per-device motion flips from FCM motion pushes (#173).
+
+    Video doorbells (and other video-edge devices) only report motion over
+    FCM, never in the gRPC snapshot, so their `motion` binary_sensor never
+    turned on. `apply_push_device_motion` flips it on immediately and
+    schedules an auto-off so it self-clears like a PIR sensor.
+    """
+
+    def _make_coordinator_with_device(
+        self, device_type: str = "video_edge_doorbell"
+    ) -> AjaxCobrandedCoordinator:  # noqa: F821
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        hass = MagicMock()
+        client = MagicMock()
+        with patch(
+            "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+            return_value=None,
+        ):
+            coordinator = AjaxCobrandedCoordinator(
+                hass=hass, client=client, space_ids=["s1"], poll_interval=300
+            )
+        coordinator.hass = hass
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.devices = {
+            "doorbell-1": Device(
+                id="doorbell-1",
+                hub_id="hub-1",
+                name="Deurbel",
+                device_type=device_type,
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={"signal_strength": 3},
+                battery=None,
+            )
+        }
+        return coordinator
+
+    def test_motion_push_sets_motion_detected_true(self) -> None:
+        coordinator = self._make_coordinator_with_device()
+
+        with patch("homeassistant.helpers.event.async_call_later"):
+            coordinator.apply_push_device_motion("doorbell-1")
+
+        assert coordinator.devices["doorbell-1"].statuses["motion_detected"] is True
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_motion_push_records_detected_at(self) -> None:
+        coordinator = self._make_coordinator_with_device()
+
+        with patch("homeassistant.helpers.event.async_call_later"):
+            coordinator.apply_push_device_motion("doorbell-1")
+
+        assert "motion_detected_at" in coordinator.devices["doorbell-1"].statuses
+
+    def test_motion_push_preserves_other_statuses(self) -> None:
+        coordinator = self._make_coordinator_with_device()
+
+        with patch("homeassistant.helpers.event.async_call_later"):
+            coordinator.apply_push_device_motion("doorbell-1")
+
+        assert coordinator.devices["doorbell-1"].statuses["signal_strength"] == 3
+
+    def test_motion_push_unknown_device_no_op(self) -> None:
+        coordinator = self._make_coordinator_with_device()
+
+        with patch("homeassistant.helpers.event.async_call_later"):
+            coordinator.apply_push_device_motion("nonexistent")
+
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_auto_off_clears_motion_detected(self) -> None:
+        coordinator = self._make_coordinator_with_device()
+
+        with patch("homeassistant.helpers.event.async_call_later"):
+            coordinator.apply_push_device_motion("doorbell-1")
+        coordinator._clear_device_motion("doorbell-1")
+
+        assert coordinator.devices["doorbell-1"].statuses["motion_detected"] is False
+
+    def test_motion_push_schedules_auto_off(self) -> None:
+        coordinator = self._make_coordinator_with_device()
+
+        with patch("homeassistant.helpers.event.async_call_later") as call_later:
+            coordinator.apply_push_device_motion("doorbell-1")
+
+        call_later.assert_called_once()
+
+
 class TestApplyPushGroupSecurityState:
     """Per-group arm/disarm push updates (#148): only the matching Group is
     refreshed instantly, the space-level state stays put until the next poll

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from custom_components.aegis_ajax.const import ALL_EVENT_TYPES, HUB_EVENT_TAG_MAP
-from custom_components.aegis_ajax.event import AjaxSecurityEvent
+from custom_components.aegis_ajax.event import AjaxDoorbellEvent, AjaxSecurityEvent
 
 
 class TestAjaxSecurityEvent:
@@ -84,6 +84,98 @@ class TestAjaxSecurityEvent:
         entity = self._make_event_entity()
         assert entity._attr_device_info is not None
         assert ("aegis_ajax", "hub-1") in entity._attr_device_info["identifiers"]
+
+
+class TestAjaxDoorbellEvent:
+    """Per-device doorbell event entity living on the doorbell card (#173)."""
+
+    def _make_doorbell_entity(self) -> AjaxDoorbellEvent:
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        coordinator.devices = {
+            "doorbell-1": MagicMock(
+                id="doorbell-1",
+                name="Deurbel",
+                device_type="video_edge_doorbell",
+                room_id=None,
+            ),
+        }
+        return AjaxDoorbellEvent(coordinator=coordinator, device_id="doorbell-1")
+
+    def test_unique_id(self) -> None:
+        entity = self._make_doorbell_entity()
+        assert entity.unique_id == "aegis_ajax_doorbell-1_doorbell_event"
+
+    def test_has_entity_name(self) -> None:
+        entity = self._make_doorbell_entity()
+        assert entity._attr_has_entity_name is True
+
+    def test_device_class_is_doorbell(self) -> None:
+        from homeassistant.components.event import EventDeviceClass
+
+        entity = self._make_doorbell_entity()
+        assert entity._attr_device_class == EventDeviceClass.DOORBELL
+
+    def test_event_types_contains_doorbell_pressed(self) -> None:
+        entity = self._make_doorbell_entity()
+        assert "doorbell_pressed" in entity.event_types
+
+    def test_handle_event_triggers_and_writes(self) -> None:
+        entity = self._make_doorbell_entity()
+        entity._trigger_event = MagicMock()
+        entity.async_write_ha_state = MagicMock()
+        entity.hass = MagicMock()
+
+        entity.handle_event("doorbell_pressed", {"raw_tag": "ring_button_pressed"})
+
+        entity._trigger_event.assert_called_once_with(
+            "doorbell_pressed", {"raw_tag": "ring_button_pressed"}
+        )
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_handle_event_ignores_non_doorbell_type(self) -> None:
+        entity = self._make_doorbell_entity()
+        entity._trigger_event = MagicMock()
+        entity.async_write_ha_state = MagicMock()
+
+        entity.handle_event("motion", {})
+
+        entity._trigger_event.assert_not_called()
+
+    def test_device_info_targets_doorbell_device(self) -> None:
+        entity = self._make_doorbell_entity()
+        assert entity._attr_device_info is not None
+        assert ("aegis_ajax", "doorbell-1") in entity._attr_device_info["identifiers"]
+
+
+class TestDeviceEventDispatch:
+    def test_register_and_fire_device_event(self) -> None:
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = MagicMock(spec=AjaxCobrandedCoordinator)
+        coordinator._device_event_entities = {}
+
+        AjaxCobrandedCoordinator.register_device_event_entity(
+            coordinator, "doorbell-1", MagicMock()
+        )
+        entity = coordinator._device_event_entities["doorbell-1"]
+
+        handled = AjaxCobrandedCoordinator.fire_push_device_event(
+            coordinator, "doorbell-1", "doorbell_pressed", {"x": 1}
+        )
+        assert handled is True
+        entity.handle_event.assert_called_once_with("doorbell_pressed", {"x": 1})
+
+    def test_fire_device_event_no_entity_returns_false(self) -> None:
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = MagicMock(spec=AjaxCobrandedCoordinator)
+        coordinator._device_event_entities = {}
+
+        handled = AjaxCobrandedCoordinator.fire_push_device_event(
+            coordinator, "unknown", "doorbell_pressed", {}
+        )
+        assert handled is False
 
 
 class TestEventConstants:

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1648,6 +1648,129 @@ class TestParseAndFireEventLogging:
         assert not [r for r in caplog.records if r.levelname == "WARNING"]
 
 
+class TestRedactPrintable:
+    """`_redact_printable` masks ASCII text runs in a hex dump (#173, PII)."""
+
+    def test_replaces_long_printable_run_with_marker(self) -> None:
+        from custom_components.aegis_ajax.notification import _redact_printable
+
+        out = _redact_printable(b"Deurbel")
+        assert "Deurbel" not in out
+        assert "<text:7b>" in out
+
+    def test_keeps_binary_bytes_as_hex(self) -> None:
+        from custom_components.aegis_ajax.notification import _redact_printable
+
+        out = _redact_printable(b"\x00\x01\x02")
+        assert out == "000102"
+
+    def test_short_printable_run_not_masked(self) -> None:
+        from custom_components.aegis_ajax.notification import _redact_printable
+
+        # 2 printable bytes stay as hex (too short to be meaningful PII)
+        out = _redact_printable(b"\x00AB\x00")
+        assert "<text:" not in out
+        assert out == "004142" + "00"
+
+    def test_mixed_binary_and_text(self) -> None:
+        from custom_components.aegis_ajax.notification import _redact_printable
+
+        out = _redact_printable(b"\xff\xfeHELLO\x00")
+        assert out == "fffe" + "<text:5b>" + "00"
+
+
+class TestParseAndFireEventDeviceRouting:
+    """A doorbell/motion push is surfaced on the source device's own card (#173).
+
+    The hub-level event entity still fires for every event; on top of that,
+    when the push carries (or resolves to) a device id, the ring is mirrored
+    onto a per-device doorbell event entity and motion flips the device's
+    motion binary_sensor.
+    """
+
+    def _make_listener(self, devices: dict) -> tuple[AjaxNotificationListener, MagicMock]:
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.is_running.return_value = True
+        coordinator = MagicMock()
+        coordinator._space_ids = []
+        coordinator.devices = devices
+        coordinator.fire_push_device_event = MagicMock(return_value=True)
+        coordinator.apply_push_device_motion = MagicMock()
+        listener = AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
+        return listener, coordinator
+
+    def _doorbell_device(self, device_id: str = "310A8DF4") -> MagicMock:
+        dev = MagicMock()
+        dev.id = device_id
+        dev.device_type = "video_edge_doorbell"
+        return dev
+
+    def _fire(self, listener: AjaxNotificationListener, event_type: str, source: dict) -> None:
+        encoded = base64.b64encode(b"any-payload").decode()
+        raw_tag = {
+            "doorbell_pressed": "ring_button_pressed",
+            "motion": "human_detected",
+            "alarm": "intrusion_alarm",
+        }[event_type]
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=(event_type, {"raw_tag": raw_tag}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value=source),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+    def test_doorbell_with_matching_device_id_fires_device_event(self) -> None:
+        listener, coordinator = self._make_listener({"310A8DF4": self._doorbell_device()})
+
+        self._fire(
+            listener, "doorbell_pressed", {"device_id": "310A8DF4", "device_name": "Deurbel"}
+        )
+
+        coordinator.fire_push_device_event.assert_called_once()
+        args = coordinator.fire_push_device_event.call_args[0]
+        assert args[0] == "310A8DF4"
+        assert args[1] == "doorbell_pressed"
+
+    def test_motion_with_matching_device_id_schedules_device_motion(self) -> None:
+        listener, coordinator = self._make_listener({"310A8DF4": self._doorbell_device()})
+
+        self._fire(listener, "motion", {"device_id": "310A8DF4", "device_name": "Deurbel"})
+
+        listener._hass.loop.call_soon_threadsafe.assert_any_call(
+            coordinator.apply_push_device_motion, "310A8DF4"
+        )
+
+    def test_doorbell_without_device_id_falls_back_to_single_doorbell(self) -> None:
+        listener, coordinator = self._make_listener({"310A8DF4": self._doorbell_device()})
+
+        self._fire(listener, "doorbell_pressed", {})
+
+        coordinator.fire_push_device_event.assert_called_once()
+        assert coordinator.fire_push_device_event.call_args[0][0] == "310A8DF4"
+
+    def test_motion_without_device_id_does_not_schedule_motion(self) -> None:
+        listener, coordinator = self._make_listener({"310A8DF4": self._doorbell_device()})
+
+        self._fire(listener, "motion", {})
+
+        for call in listener._hass.loop.call_soon_threadsafe.call_args_list:
+            assert call[0][0] is not coordinator.apply_push_device_motion
+
+    def test_unrelated_event_does_not_dispatch_to_device(self) -> None:
+        listener, coordinator = self._make_listener({"310A8DF4": self._doorbell_device()})
+
+        self._fire(listener, "alarm", {"device_id": "310A8DF4"})
+
+        coordinator.fire_push_device_event.assert_not_called()
+        for call in listener._hass.loop.call_soon_threadsafe.call_args_list:
+            assert call[0][0] is not coordinator.apply_push_device_motion
+
+
 class TestNotificationDedupe:
     """Issue #80: Ajax dispatches two FCM messages per security transition with
     identical notification_id; the second must not double-fire automations."""


### PR DESCRIPTION
## Context

Issue #173. Bruno's debug log (with `custom_components.aegis_ajax: debug`) confirmed the doorbell ring and motion pushes **do arrive and parse correctly** — `event_type=doorbell_pressed raw_tag=ring_button_pressed` and `event_type=motion raw_tag=human_detected`, no errors, on `MainThread`.

The real cause of "no activity on the doorbell card":

- There is exactly **one** `event` entity per space, attached to the **hub** device (`event.py`). All events (ring, motion, doors, alarms) fire there, never on the doorbell device card.
- The doorbell's `motion` binary_sensor reads `device.statuses["motion_detected"]`, which is only populated from the gRPC snapshot. Video-edge doorbells report motion **only over FCM**, so that status was never set and the sensor stayed `off`.
- The source `device_id` carried in the push (`_extract_source_info`) was never used to route the event to the device. Verified empirically that `VideoNotificationSource` and `HubNotificationSource` share the same `type/id/name` wire layout, so the id is already extractable when present.

The arm-state hypothesis is ruled out: the space was `DISARMED` and the motion push still arrived.

## Changes

- **Per-device doorbell `event` entity** (`AjaxDoorbellEvent`, `device_class: doorbell`) on the doorbell device card, in addition to the hub-level event entity.
- **Motion routing**: a `motion`/`human_detected` push flips the source device's `motion_detected` status with a 30 s auto-off, so the binary_sensor behaves like a PIR detector.
- **Attribution**: by the extracted `device_id`; for ring events, fall back to the sole doorbell in the install when no id is present. Motion has no fallback (the `motion` type is shared with PIR detectors).
- **Instrumentation**: DEBUG log of the resolved device attribution (`extracted_device_id / device_type / resolved`), plus a PII-redacted hex dump (`_redact_printable`) when a doorbell/motion push can't be attributed — so an unexpected source shape is diagnosable from the next log without a code round-trip.
- **i18n**: `doorbell` event entity name + state across all 14 locales.

## Open dependency

The raw bytes of the reporter's push weren't captured (the log only carried the parsed summary), so end-to-end attribution on that specific firmware is unverified. If the push carries the source it works directly; if not, the new instrumentation surfaces `resolved=None` + the redacted hex for follow-up.

## Tests

TDD throughout. `make check` passes in the no-mount CI image (lint, format, mypy, vulture, 1420 unit tests, coverage 88%).

Refs #173.