### PR TITLE
feat(switch): add per-device bypass (deactivation) switch

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -403,8 +403,42 @@ class DevicesApi:
             await self._device_off(command)
         elif command.action == "brightness":
             await self._device_brightness(command)
+        elif command.action == "bypass":
+            await self._device_bypass(command)
         else:
             raise DeviceCommandError(f"Unknown device command action: {command.action}")
+
+    async def _device_bypass(self, command: DeviceCommand) -> None:
+        """Deactivate (bypass) or reactivate a device via DeviceCommandDeviceBypass.
+
+        `bypass_enable=True` → permanent (engineering) whole-device
+        deactivation, matching the `bypassed` flag the snapshot reports;
+        `False` → clear the bypass (`BYPASS_UNSPECIFIED`).
+        """
+        from v3.mobilegwsvc.service.device_command_device_bypass import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        bypass_type = (
+            request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_ENGINEERING_DISABLE
+            if command.bypass_enable
+            else request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_UNSPECIFIED
+        )
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.DeviceCommandDeviceBypassServiceStub(channel)
+        request = request_pb2.DeviceCommandDeviceBypassRequest(
+            hub_id=command.hub_id,
+            device_id=command.device_id,
+            object_type=_build_object_type(command.device_type),
+            bypass_type=bypass_type,
+        )
+        response = await stub.execute(request, metadata=metadata, timeout=15)
+        if response.HasField("failure"):
+            error = response.failure.WhichOneof("error") or "unknown"
+            raise DeviceCommandError(f"bypass: {error}")
+        _LOGGER.debug("Device %s bypass=%s OK", command.device_id, bool(command.bypass_enable))
 
     async def _device_on(self, command: DeviceCommand) -> None:
         from v3.mobilegwsvc.service.device_command_device_on import (  # noqa: PLC0415

--- a/custom_components/aegis_ajax/api/models.py
+++ b/custom_components/aegis_ajax/api/models.py
@@ -166,6 +166,9 @@ class DeviceCommand:
     device_type: str
     channels: list[int] = field(default_factory=list)
     brightness: int | None = None
+    # True = deactivate (bypass) the device, False = reactivate it. Only set
+    # for action="bypass".
+    bypass_enable: bool | None = None
 
     @classmethod
     def on(
@@ -207,4 +210,15 @@ class DeviceCommand:
             device_type=device_type,
             channels=channels or [],
             brightness=brightness,
+        )
+
+    @classmethod
+    def bypass(cls, hub_id: str, device_id: str, device_type: str, enable: bool) -> DeviceCommand:
+        """Deactivate (`enable=True`) or reactivate (`enable=False`) a device."""
+        return cls(
+            action="bypass",
+            hub_id=hub_id,
+            device_id=device_id,
+            device_type=device_type,
+            bypass_enable=enable,
         )

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Channel 2"
+            },
+            "bypass": {
+                "name": "Bypass"
             }
         }
     },

--- a/custom_components/aegis_ajax/switch.py
+++ b/custom_components/aegis_ajax/switch.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
@@ -47,7 +48,8 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
-    entities: list[AjaxSwitch] = []
+    hub_ids = {space.hub_id for space in coordinator.spaces.values() if space.hub_id}
+    entities: list[SwitchEntity] = []
     for device_id, device in coordinator.devices.items():
         num_channels = SWITCH_DEVICE_TYPES.get(device.device_type, 0)
         for ch in range(1, num_channels + 1):
@@ -58,6 +60,16 @@ async def async_setup_entry(
                     hub_id=device.hub_id,
                     device_type=device.device_type,
                     channel=ch,
+                )
+            )
+        # Every non-hub device can be deactivated (bypassed) before arming.
+        if device_id not in hub_ids:
+            entities.append(
+                AjaxBypassSwitch(
+                    coordinator=coordinator,
+                    device_id=device_id,
+                    hub_id=device.hub_id,
+                    device_type=device.device_type,
                 )
             )
     async_add_entities(entities)
@@ -121,6 +133,66 @@ class AjaxSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):
             device_id=self._device_id,
             device_type=self._device_type,
             channels=[self._channel],
+        )
+        await self.coordinator.devices_api.send_command(cmd)
+        await self.coordinator.async_request_refresh()
+
+
+class AjaxBypassSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):
+    """Deactivate (bypass) a device so it's excluded while the system is armed.
+
+    `on` = device bypassed/deactivated (permanent, "engineering"), `off` =
+    active. Mirrors the `bypassed` flag the snapshot reports.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "bypass"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: AjaxCobrandedCoordinator,
+        device_id: str,
+        hub_id: str,
+        device_type: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._hub_id = hub_id
+        self._device_type = device_type
+        self._attr_unique_id = f"aegis_ajax_{device_id}_bypass"
+        device = coordinator.devices.get(device_id)
+        if device:
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
+
+    @property
+    def _device(self) -> Device | None:
+        return self.coordinator.devices.get(self._device_id)
+
+    @property
+    def available(self) -> bool:
+        device = self._device
+        return device is not None and device.is_online
+
+    @property
+    def is_on(self) -> bool | None:
+        device = self._device
+        if device is None:
+            return None
+        return bool(device.bypassed)
+
+    async def async_turn_on(self, **kwargs: object) -> None:
+        await self._set_bypass(enable=True)
+
+    async def async_turn_off(self, **kwargs: object) -> None:
+        await self._set_bypass(enable=False)
+
+    async def _set_bypass(self, *, enable: bool) -> None:
+        cmd = DeviceCommand.bypass(
+            hub_id=self._hub_id,
+            device_id=self._device_id,
+            device_type=self._device_type,
+            enable=enable,
         )
         await self.coordinator.devices_api.send_command(cmd)
         await self.coordinator.async_request_refresh()

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Canal 2"
+            },
+            "bypass": {
+                "name": "Bypass"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Kanál 2"
+            },
+            "bypass": {
+                "name": "Vyřazení"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Kanal 2"
+            },
+            "bypass": {
+                "name": "Überbrückung"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -418,6 +418,9 @@
             },
             "channel_2": {
                 "name": "Channel 2"
+            },
+            "bypass": {
+                "name": "Bypass"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -418,6 +418,9 @@
             },
             "channel_2": {
                 "name": "Canal 2"
+            },
+            "bypass": {
+                "name": "Bypass"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Canal 2"
+            },
+            "bypass": {
+                "name": "Contournement"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Canale 2"
+            },
+            "bypass": {
+                "name": "Esclusione"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Kanaal 2"
+            },
+            "bypass": {
+                "name": "Overbruggen"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Kanał 2"
+            },
+            "bypass": {
+                "name": "Pominięcie"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Canal 2"
+            },
+            "bypass": {
+                "name": "Ignorar"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Canal 2"
+            },
+            "bypass": {
+                "name": "Ignorar"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Canal 2"
+            },
+            "bypass": {
+                "name": "Excludere"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Kanal 2"
+            },
+            "bypass": {
+                "name": "Atlama"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -402,6 +402,9 @@
             },
             "channel_2": {
                 "name": "Канал 2"
+            },
+            "bypass": {
+                "name": "Обхід"
             }
         },
         "update": {

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1200,6 +1200,146 @@ class TestSendCommand:
         with pytest.raises(DeviceCommandError):
             await api.send_command(cmd)
 
+    @pytest.mark.asyncio
+    async def test_send_command_dispatches_bypass(self) -> None:
+        api = DevicesApi(MagicMock())
+        api._device_on = AsyncMock()
+        api._device_bypass = AsyncMock()
+        cmd = DeviceCommand.bypass(
+            hub_id="h1", device_id="d1", device_type="door_protect", enable=True
+        )
+
+        await api.send_command(cmd)
+
+        api._device_bypass.assert_awaited_once_with(cmd)
+        api._device_on.assert_not_called()
+
+
+class TestDeviceBypassCommand:
+    """`device_command_device_bypass` — deactivate/reactivate a device (#bypass)."""
+
+    def test_bypass_factory_enable(self) -> None:
+        cmd = DeviceCommand.bypass(
+            hub_id="h1", device_id="d1", device_type="motion_protect", enable=True
+        )
+        assert cmd.action == "bypass"
+        assert cmd.bypass_enable is True
+
+    def test_bypass_factory_disable(self) -> None:
+        cmd = DeviceCommand.bypass(
+            hub_id="h1", device_id="d1", device_type="motion_protect", enable=False
+        )
+        assert cmd.action == "bypass"
+        assert cmd.bypass_enable is False
+
+    def _make_api(self) -> DevicesApi:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        return DevicesApi(client)
+
+    @pytest.mark.asyncio
+    async def test_enable_sends_engineering_disable(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_device_bypass import (
+            endpoint_pb2_grpc,
+            request_pb2,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        ok = response_pb2.DeviceCommandDeviceBypassResponse(success=common_response_pb2.Success())
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                async def _execute(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return ok
+
+                self.execute = AsyncMock(side_effect=_execute)
+
+        with patch.object(endpoint_pb2_grpc, "DeviceCommandDeviceBypassServiceStub", _StubFactory):
+            await api.send_command(
+                DeviceCommand.bypass(
+                    hub_id="hub-1", device_id="dev-1", device_type="door_protect", enable=True
+                )
+            )
+
+        assert len(captured) == 1
+        req = captured[0]
+        assert req.hub_id == "hub-1"
+        assert req.device_id == "dev-1"
+        assert req.object_type.WhichOneof("type") == "door_protect"
+        assert (
+            req.bypass_type
+            == request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_ENGINEERING_DISABLE
+        )
+
+    @pytest.mark.asyncio
+    async def test_disable_sends_unspecified(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_device_bypass import (
+            endpoint_pb2_grpc,
+            request_pb2,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        ok = response_pb2.DeviceCommandDeviceBypassResponse(success=common_response_pb2.Success())
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                async def _execute(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return ok
+
+                self.execute = AsyncMock(side_effect=_execute)
+
+        with patch.object(endpoint_pb2_grpc, "DeviceCommandDeviceBypassServiceStub", _StubFactory):
+            await api.send_command(
+                DeviceCommand.bypass(
+                    hub_id="hub-1", device_id="dev-1", device_type="door_protect", enable=False
+                )
+            )
+
+        assert (
+            captured[0].bypass_type
+            == request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_UNSPECIFIED
+        )
+
+    @pytest.mark.asyncio
+    async def test_bypass_failure_raises(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_device_bypass import (
+            endpoint_pb2_grpc,
+            response_pb2,
+        )
+
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        api = self._make_api()
+        failure = response_pb2.DeviceCommandDeviceBypassResponse(
+            failure=response_pb2.DeviceCommandDeviceBypassResponse.Failure(
+                permission_denied=common_response_pb2.Error(),
+            )
+        )
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.execute = AsyncMock(return_value=failure)
+
+        with (
+            patch.object(endpoint_pb2_grpc, "DeviceCommandDeviceBypassServiceStub", _StubFactory),
+            pytest.raises(DeviceCommandError, match="permission_denied"),
+        ):
+            await api.send_command(
+                DeviceCommand.bypass(
+                    hub_id="hub-1", device_id="dev-1", device_type="door_protect", enable=True
+                )
+            )
+
 
 class TestBuildObjectType:
     """`_build_object_type` must mark the right ObjectType.type oneof case."""

--- a/tests/unit/test_switch.py
+++ b/tests/unit/test_switch.py
@@ -186,3 +186,105 @@ class TestAjaxSwitch:
         coordinator.devices_api.send_command.assert_called_once()
         cmd = coordinator.devices_api.send_command.call_args[0][0]
         assert cmd.action == "off"
+
+
+class TestAjaxBypassSwitch:
+    """Per-device bypass (deactivation) switch (#bypass)."""
+
+    def _make(
+        self, device_type: str = "door_protect", bypassed: bool = False
+    ) -> tuple[object, MagicMock]:
+        from custom_components.aegis_ajax.switch import AjaxBypassSwitch
+
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        device = MagicMock()
+        device.device_type = device_type
+        device.bypassed = bypassed
+        device.is_online = True
+        coordinator.devices = {"d1": device}
+        sw = AjaxBypassSwitch(
+            coordinator=coordinator, device_id="d1", hub_id="h1", device_type=device_type
+        )
+        return sw, coordinator
+
+    def test_unique_id(self) -> None:
+        sw, _ = self._make()
+        assert sw.unique_id == "aegis_ajax_d1_bypass"
+
+    def test_translation_key(self) -> None:
+        sw, _ = self._make()
+        assert sw._attr_translation_key == "bypass"
+
+    def test_is_config_entity(self) -> None:
+        from homeassistant.helpers.entity import EntityCategory
+
+        sw, _ = self._make()
+        assert sw._attr_entity_category == EntityCategory.CONFIG
+
+    def test_is_on_reflects_bypassed_true(self) -> None:
+        sw, _ = self._make(bypassed=True)
+        assert sw.is_on is True
+
+    def test_is_on_reflects_bypassed_false(self) -> None:
+        sw, _ = self._make(bypassed=False)
+        assert sw.is_on is False
+
+    @pytest.mark.asyncio
+    async def test_turn_on_sends_bypass_enable(self) -> None:
+        sw, coordinator = self._make()
+        coordinator.devices_api.send_command = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+
+        await sw.async_turn_on()
+
+        cmd = coordinator.devices_api.send_command.call_args[0][0]
+        assert cmd.action == "bypass"
+        assert cmd.bypass_enable is True
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_sends_bypass_disable(self) -> None:
+        sw, coordinator = self._make(bypassed=True)
+        coordinator.devices_api.send_command = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+
+        await sw.async_turn_off()
+
+        cmd = coordinator.devices_api.send_command.call_args[0][0]
+        assert cmd.action == "bypass"
+        assert cmd.bypass_enable is False
+
+
+class TestBypassSwitchSetup:
+    """`async_setup_entry` adds a bypass switch to every non-hub device."""
+
+    @pytest.mark.asyncio
+    async def test_creates_bypass_for_non_hub_not_hub(self) -> None:
+        from custom_components.aegis_ajax.switch import AjaxBypassSwitch, async_setup_entry
+
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        hub = MagicMock()
+        hub.device_type = "hub_two_plus"
+        hub.hub_id = "hub-1"
+        sensor = MagicMock()
+        sensor.device_type = "door_protect"
+        sensor.hub_id = "hub-1"
+        coordinator.devices = {"hub-1": hub, "d1": sensor}
+        space = MagicMock()
+        space.hub_id = "hub-1"
+        coordinator.spaces = {"s1": space}
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+
+        def _add(entities: list, *a: object, **k: object) -> None:
+            added.extend(entities)
+
+        await async_setup_entry(MagicMock(), entry, _add)
+
+        bypass = [e for e in added if isinstance(e, AjaxBypassSwitch)]
+        device_ids = {e._device_id for e in bypass}
+        assert device_ids == {"d1"}  # sensor gets one, hub does not


### PR DESCRIPTION
## What

Adds a **bypass** switch to every non-hub Ajax device, so users can deactivate (exclude) a sensor before arming — a common alarm workflow — directly from Home Assistant. The `bypassed` flag was already read from the snapshot but only ever displayed; now it's controllable.

- New `AjaxBypassSwitch` (an `EntityCategory.CONFIG` entity) on each non-hub device. `on` = device bypassed/deactivated, `off` = active. State mirrors the `bypassed` flag, so it stays in sync with the Ajax app.
- `DeviceCommand.bypass(enable=…)` + `DevicesApi._device_bypass` wire the v3 `device_command_device_bypass` service. Enable → permanent ("engineering") whole-device deactivation (`BYPASS_ENGINEERING_DISABLE`), matching the persistent `bypassed` flag; disable → clear (`BYPASS_UNSPECIFIED`).
- `bypass` switch-entity name translated across all 14 locales.

## Scope decisions

- **Which devices:** all non-hub devices (Ajax allows deactivating almost any device). Hub devices are excluded.
- **Bypass type:** permanent (engineering), to match the persistent `bypassed` flag the snapshot reports. (One-time / until-next-disarm bypass was considered and left out for now.)

## Note for review / verification

The deactivation enum (`BYPASS_ENGINEERING_DISABLE`) maps to the Ajax app's permanent-deactivation option. The **reactivation** value (`BYPASS_UNSPECIFIED`) is the natural "clear" value but has **not yet been confirmed against a live hub** — worth a quick live check on a real device (bvis-home has bypassable sensors) before promoting past beta. The entity/command/wire logic is fully unit-tested regardless of the exact enum.

## Tests

TDD throughout. `make check` passes in the no-mount CI image: lint, format, mypy, vulture, 1442 unit tests, coverage 88%.