### PR TITLE
fix: evict orphaned bypass switches + cover HTS auth handshake

### DIFF
--- a/custom_components/aegis_ajax/switch.py
+++ b/custom_components/aegis_ajax/switch.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import EntityCategory
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
@@ -116,7 +117,44 @@ async def async_setup_entry(
                     device_type=device.device_type,
                 )
             )
+    _evict_orphan_bypass_switches(
+        hass,
+        entry,
+        provided={
+            e.unique_id
+            for e in entities
+            if isinstance(e, AjaxBypassSwitch) and e.unique_id is not None
+        },
+    )
     async_add_entities(entities)
+
+
+def _evict_orphan_bypass_switches(
+    hass: HomeAssistant, entry: ConfigEntry, *, provided: set[str]
+) -> None:
+    """Remove bypass-switch entities the current option no longer provides.
+
+    When `bypass_switches` flips to `never`, or `auto` loses `DEVICE_EDIT` on a
+    hub, this run stops creating the corresponding `AjaxBypassSwitch`. HA does
+    NOT evict an entity its platform stopped providing — it lingers in the
+    registry as `unavailable` until the user deletes it by hand. Mirror the
+    video-doorbell device eviction (#173) at the entity-registry level so a
+    stale bypass switch disappears on the reload that drops it (#bypass).
+    """
+    entity_reg = er.async_get(hass)
+    for reg_entry in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
+        unique_id = reg_entry.unique_id
+        if (
+            reg_entry.domain == "switch"
+            and unique_id.endswith("_bypass")
+            and unique_id not in provided
+        ):
+            _LOGGER.info(
+                "Removing orphaned bypass switch %s — the bypass_switches option "
+                "no longer provides it (#bypass)",
+                reg_entry.entity_id,
+            )
+            entity_reg.async_remove(reg_entry.entity_id)
 
 
 class AjaxSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ exclude = ["custom_components/aegis_ajax/proto/"]
 [tool.coverage.run]
 omit = [
     "custom_components/aegis_ajax/proto/*",
-    "custom_components/aegis_ajax/api/hts/client.py",
 ]
 
 [tool.vulture]

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -12,11 +12,17 @@ from custom_components.aegis_ajax.api.hts.client import (
     HTS_HOST,
     HTS_PORT,
     MAX_CONSECUTIVE_READ_TIMEOUTS,
+    HtsAuthError,
     HtsClient,
     HtsConnectionError,
 )
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
-from custom_components.aegis_ajax.api.hts.messages import HtsMessage, MsgType, tlv_encode
+from custom_components.aegis_ajax.api.hts.messages import (
+    AUTH_KEY_AUTHENTICATION_REQUEST,
+    HtsMessage,
+    MsgType,
+    tlv_encode,
+)
 from custom_components.aegis_ajax.api.hts.protocol import ETX, STX
 
 # ---------------------------------------------------------------------------
@@ -1135,3 +1141,208 @@ class TestStatusRefreshLoop:
 
         # Both hubs called in cycle 1 — broken one didn't abort the cycle.
         assert client._send_request_full_status.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _authenticate handshake (was excluded from coverage — see #bypass review)
+# ---------------------------------------------------------------------------
+
+
+def _msg(msg_type: MsgType, payload: bytes, seq: int = 0) -> HtsMessage:
+    return HtsMessage(
+        sender=1,
+        receiver=0,
+        seq_num=seq,
+        link=0,
+        flags=0,
+        msg_type=msg_type,
+        payload=payload,
+    )
+
+
+def _challenge_msg(a: int = 0x12, b: int = 0x34) -> HtsMessage:
+    payload = tlv_encode([bytes([AUTH_KEY_AUTHENTICATION_REQUEST]), bytes([a, b])])
+    return _msg(MsgType.AUTHENTICATION, payload, seq=10)
+
+
+def _connected_msg(seq: int = 20) -> HtsMessage:
+    return _msg(MsgType.USER_REGISTRATION, tlv_encode([b"\x00"]), seq=seq)
+
+
+def _ack_msg() -> HtsMessage:
+    return _msg(MsgType.ACK, b"", seq=5)
+
+
+def _auth_client() -> HtsClient:
+    """A client wired so `_authenticate` exercises real crypto on the response
+    write path while the message exchange is scripted via `_receive_message`."""
+    client = _make_client()
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    client._writer = writer
+    client._send_message = AsyncMock()  # type: ignore[method-assign]
+    client._send_ack = AsyncMock()  # type: ignore[method-assign]
+    return client
+
+
+class TestAuthenticate:
+    @pytest.mark.asyncio
+    async def test_happy_path_sets_connected_state(self) -> None:
+        client = _auth_client()
+        # Leading ACKs before each real reply exercise both skip loops.
+        client._receive_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[_ack_msg(), _challenge_msg(), _ack_msg(), _connected_msg()]
+        )
+        fake = MagicMock()
+        fake.token = b"\xaa\xbb\xcc\xdd"
+        fake.hubs = []
+        with patch(
+            "custom_components.aegis_ajax.api.hts.client.parse_connected_response",
+            return_value=fake,
+        ):
+            result = await client._authenticate()
+
+        assert result is fake
+        assert client._connected is True
+        assert client._connection_token == b"\xaa\xbb\xcc\xdd"
+        client._send_message.assert_awaited_once()  # USER_REGISTRATION sent
+        client._writer.drain.assert_awaited_once()  # challenge response flushed
+
+    @pytest.mark.asyncio
+    async def test_adopts_server_seq_range(self) -> None:
+        client = _auth_client()
+        client._receive_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[_challenge_msg(), _connected_msg(seq=100)]
+        )
+        fake = MagicMock(token=b"\x00\x01\x02\x03", hubs=[])
+        with patch(
+            "custom_components.aegis_ajax.api.hts.client.parse_connected_response",
+            return_value=fake,
+        ):
+            await client._authenticate()
+        assert client._seq_num == (100 + 2) & 0xFFFFFF
+
+    @pytest.mark.asyncio
+    async def test_non_authentication_reply_raises(self) -> None:
+        client = _auth_client()
+        client._receive_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[_connected_msg()]  # USER_REGISTRATION, not AUTHENTICATION
+        )
+        with pytest.raises(HtsAuthError, match="Expected AUTHENTICATION"):
+            await client._authenticate()
+
+    @pytest.mark.asyncio
+    async def test_unexpected_auth_key_raises(self) -> None:
+        client = _auth_client()
+        bad = _msg(MsgType.AUTHENTICATION, tlv_encode([bytes([0x09]), bytes([0x12, 0x34])]))
+        client._receive_message = AsyncMock(side_effect=[bad])  # type: ignore[method-assign]
+        with pytest.raises(HtsAuthError, match="Unexpected auth request"):
+            await client._authenticate()
+
+    @pytest.mark.asyncio
+    async def test_short_challenge_raises(self) -> None:
+        client = _auth_client()
+        short = _msg(
+            MsgType.AUTHENTICATION,
+            tlv_encode([bytes([AUTH_KEY_AUTHENTICATION_REQUEST]), bytes([0x12])]),
+        )
+        client._receive_message = AsyncMock(side_effect=[short])  # type: ignore[method-assign]
+        with pytest.raises(HtsAuthError, match="Challenge too short"):
+            await client._authenticate()
+
+    @pytest.mark.asyncio
+    async def test_writer_gone_before_response_raises(self) -> None:
+        client = _auth_client()
+        client._writer = None
+        client._receive_message = AsyncMock(side_effect=[_challenge_msg()])  # type: ignore[method-assign]
+        with pytest.raises(HtsConnectionError, match="Not connected"):
+            await client._authenticate()
+
+    @pytest.mark.asyncio
+    async def test_connected_parse_failure_raises(self) -> None:
+        client = _auth_client()
+        client._receive_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[_challenge_msg(), _connected_msg()]
+        )
+        with (
+            patch(
+                "custom_components.aegis_ajax.api.hts.client.parse_connected_response",
+                side_effect=ValueError("garbage"),
+            ),
+            pytest.raises(HtsAuthError, match="Failed to parse CONNECTED"),
+        ):
+            await client._authenticate()
+
+    @pytest.mark.asyncio
+    async def test_connected_wrong_type_raises(self) -> None:
+        client = _auth_client()
+        # Second reply is AUTHENTICATION again (not USER_REGISTRATION).
+        client._receive_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[_challenge_msg(), _challenge_msg()]
+        )
+        with pytest.raises(HtsAuthError, match="Expected USER_REGISTRATION"):
+            await client._authenticate()
+
+
+# ---------------------------------------------------------------------------
+# _read_frame buffer extraction + connect() (mockable asyncio I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestReadFrame:
+    @pytest.mark.asyncio
+    async def test_extracts_frame_across_chunks(self) -> None:
+        client = _make_client()
+        reader = MagicMock()
+        # Frame split across two reads; trailing bytes stay buffered.
+        reader.read = AsyncMock(
+            side_effect=[bytes([STX]) + b"AB", b"CD" + bytes([ETX]) + b"leftover"]
+        )
+        client._reader = reader
+        frame = await client._read_frame()
+        assert frame == bytes([STX]) + b"ABCD" + bytes([ETX])
+        assert bytes(client._read_buf) == b"leftover"
+
+    @pytest.mark.asyncio
+    async def test_no_reader_raises(self) -> None:
+        client = _make_client()
+        client._reader = None
+        with pytest.raises(HtsConnectionError, match="Not connected"):
+            await client._read_frame()
+
+    @pytest.mark.asyncio
+    async def test_remote_close_raises_connection_error(self) -> None:
+        client = _make_client()
+        reader = MagicMock()
+        reader.read = AsyncMock(return_value=b"")  # EOF
+        client._reader = reader
+        with pytest.raises(ConnectionError, match="closed by remote"):
+            await client._read_frame()
+
+
+class TestConnect:
+    @pytest.mark.asyncio
+    async def test_connect_failure_wrapped(self) -> None:
+        client = _make_client()
+        with (
+            patch(
+                "custom_components.aegis_ajax.api.hts.client.asyncio.open_connection",
+                side_effect=OSError("refused"),
+            ),
+            pytest.raises(HtsConnectionError, match="Cannot connect"),
+        ):
+            await client.connect()
+
+    @pytest.mark.asyncio
+    async def test_connect_runs_authenticate_on_success(self) -> None:
+        client = _make_client()
+        fake = MagicMock(token=b"\x00\x01\x02\x03", hubs=[])
+        with (
+            patch(
+                "custom_components.aegis_ajax.api.hts.client.asyncio.open_connection",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch.object(client, "_authenticate", AsyncMock(return_value=fake)),
+        ):
+            result = await client.connect()
+        assert result is fake

--- a/tests/unit/test_switch.py
+++ b/tests/unit/test_switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -330,3 +330,107 @@ class TestBypassSwitchSetup:
         # No option set → default (auto); user lacks DEVICE_EDIT → no switches.
         ids = await self._run(mode=None, perms={"ARM"})
         assert ids == set()
+
+
+def _reg_entry(entity_id: str, unique_id: str, domain: str = "switch") -> MagicMock:
+    e = MagicMock()
+    e.entity_id = entity_id
+    e.unique_id = unique_id
+    e.domain = domain
+    return e
+
+
+class TestBypassOrphanEviction:
+    """`async_setup_entry` removes bypass-switch entities the current
+    `bypass_switches` option no longer provides — HA doesn't self-heal orphans
+    (#bypass)."""
+
+    async def _run(
+        self, *, mode: str | None, perms: set | None, registry_entries: list
+    ) -> list[str]:
+        from custom_components.aegis_ajax.switch import async_setup_entry
+
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        hub = MagicMock(device_type="hub_two_plus", hub_id="hub-1")
+        sensor = MagicMock(device_type="door_protect", hub_id="hub-1")
+        coordinator.devices = {"hub-1": hub, "d1": sensor}
+        space = MagicMock(id="s1", hub_id="hub-1")
+        coordinator.spaces = {"s1": space}
+        coordinator.spaces_api.get_member_space_permissions = AsyncMock(return_value=perms)
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.runtime_data = coordinator
+        entry.data = {"user_hex_id": "ABCD1234"}
+        entry.options = {} if mode is None else {"bypass_switches": mode}
+
+        removed: list[str] = []
+        entity_reg = MagicMock()
+        entity_reg.async_remove.side_effect = removed.append
+
+        def _add(entities: list, *a: object, **k: object) -> None:
+            pass
+
+        with (
+            patch(
+                "custom_components.aegis_ajax.switch.er.async_get",
+                return_value=entity_reg,
+            ),
+            patch(
+                "custom_components.aegis_ajax.switch.er.async_entries_for_config_entry",
+                return_value=registry_entries,
+            ),
+        ):
+            await async_setup_entry(MagicMock(), entry, _add)
+        return removed
+
+    @pytest.mark.asyncio
+    async def test_never_evicts_existing_bypass(self) -> None:
+        removed = await self._run(
+            mode="never",
+            perms={"DEVICE_EDIT"},
+            registry_entries=[_reg_entry("switch.d1_bypass", "aegis_ajax_d1_bypass")],
+        )
+        assert removed == ["switch.d1_bypass"]
+
+    @pytest.mark.asyncio
+    async def test_always_keeps_provided_bypass(self) -> None:
+        removed = await self._run(
+            mode="always",
+            perms=None,
+            registry_entries=[_reg_entry("switch.d1_bypass", "aegis_ajax_d1_bypass")],
+        )
+        assert removed == []
+
+    @pytest.mark.asyncio
+    async def test_auto_evicts_when_permission_lost(self) -> None:
+        removed = await self._run(
+            mode="auto",
+            perms={"ARM"},
+            registry_entries=[_reg_entry("switch.d1_bypass", "aegis_ajax_d1_bypass")],
+        )
+        assert removed == ["switch.d1_bypass"]
+
+    @pytest.mark.asyncio
+    async def test_channel_switches_are_never_evicted(self) -> None:
+        removed = await self._run(
+            mode="never",
+            perms={"DEVICE_EDIT"},
+            registry_entries=[
+                _reg_entry("switch.relay_1", "aegis_ajax_relay1_switch_1"),
+                _reg_entry("switch.d1_bypass", "aegis_ajax_d1_bypass"),
+            ],
+        )
+        assert removed == ["switch.d1_bypass"]
+
+    @pytest.mark.asyncio
+    async def test_non_switch_domain_ignored(self) -> None:
+        removed = await self._run(
+            mode="never",
+            perms={"DEVICE_EDIT"},
+            registry_entries=[
+                _reg_entry("sensor.d1_bypass", "aegis_ajax_d1_bypass", domain="sensor"),
+            ],
+        )
+        assert removed == []


### PR DESCRIPTION
## Summary

Two related hardening changes that together close the orphan-entity caveat gating the stable 1.7.0 rollup.

### 1. Evict orphaned bypass switches (`switch.py`)

When `bypass_switches` flips to `never`, or `auto` loses `DEVICE_EDIT` on a hub, `async_setup_entry` stops creating the corresponding `AjaxBypassSwitch`. HA does **not** evict an entity its platform stopped providing — it lingers in the registry as `unavailable` until the user deletes it by hand (the caveat documented in 1.7.0-beta.3).

This mirrors the video-doorbell device eviction (#173) at the **entity-registry** level: after computing which bypass switches this run provides, any `switch.*_bypass` entity of this config entry that is no longer provided is removed on reload. Channel switches and other domains are never touched.

### 2. Stop hiding `hts/client.py` from coverage + cover the gap

`api/hts/client.py` was omitted from coverage reporting despite being the most complex module (encrypted auth handshake + protocol framing). The reported total hid that the riskiest file sat at **67%**.

- Removed the `omit`.
- Covered the 4-step `_authenticate` handshake (happy path, server seq adoption, every error branch), `_read_frame` buffer extraction across chunks / EOF, and `connect()` success + dial-failure wrapping — all via mockable asyncio primitives, no real socket.

`hts/client.py` **67% → 81%**; honest project total stays at **88%** with the file now counted.

## Tests

- 5 new eviction tests (TDD): never evicts, always keeps, auto evicts on permission loss, channel switches untouched, non-switch domain ignored.
- 13 new HTS client tests.
- Full suite: 1472 passed, coverage 87.79% (gate 80%). ruff + format + mypy + vulture clean.

Related to #205