### PR TITLE
fix: audit remediation — FCM thread-safety + security/robustness hardening

### DIFF
--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -68,6 +68,40 @@ AUTH_TIMEOUT = 20
 # quiet beyond READ_TIMEOUT, so we only close the connection after this many
 # back-to-back read timeouts with no inbound data (#76).
 MAX_CONSECUTIVE_READ_TIMEOUTS = 3
+# Hard cap on the inbound frame buffer. A well-formed HTS frame is a few KB;
+# if STX…ETX never completes while bytes keep arriving (a misbehaving or
+# malicious peer), READ_TIMEOUT never fires because data is flowing, so the
+# buffer would grow without bound. Force a reconnect past this size instead.
+MAX_FRAME_BUFFER_BYTES = 256 * 1024
+
+
+def _redact_payload_hex(data: bytes) -> str:
+    """Hex-encode `data`, masking runs of >=3 printable-ASCII bytes as
+    `<text:Nb>`.
+
+    Mixed-content frame/UPDATES payload dumps can embed device names / user
+    PII as text runs inside otherwise-binary bytes. Unlike `_redact_if_text`
+    (which only redacts a value that is wholly printable), this masks the text
+    runs *within* a binary buffer so a publicly-pasted debug log keeps the
+    byte shape without leaking PII. See [[feedback_pii_in_debug_logs]].
+    """
+    out: list[str] = []
+    run: list[int] = []
+
+    def flush() -> None:
+        if not run:
+            return
+        out.append(f"<text:{len(run)}b>" if len(run) >= 3 else bytes(run).hex())
+        run.clear()
+
+    for byte in data:
+        if 0x20 <= byte <= 0x7E:
+            run.append(byte)
+        else:
+            flush()
+            out.append(f"{byte:02x}")
+    flush()
+    return "".join(out)
 
 
 def _redact_if_text(value: bytes) -> str:
@@ -468,6 +502,14 @@ class HtsClient:
             if not chunk:
                 raise ConnectionError("Connection closed by remote")
             self._read_buf.extend(chunk)
+            if len(self._read_buf) > MAX_FRAME_BUFFER_BYTES:
+                # No complete frame within a sane bound — treat as a broken
+                # stream and force a reconnect rather than grow unboundedly.
+                self._read_buf.clear()
+                raise ConnectionError(
+                    f"HTS frame buffer exceeded {MAX_FRAME_BUFFER_BYTES} bytes "
+                    "without a complete frame"
+                )
 
     # ------------------------------------------------------------------
     # Listen loop
@@ -581,6 +623,17 @@ class HtsClient:
                 except ConnectionError as exc:
                     _LOGGER.warning("HTS connection error in listen: %s", exc)
                     break
+                except ValueError as exc:
+                    # A single corrupt/undecodable frame (bad framing, CRC,
+                    # decrypt, or short header) must not tear down the whole HTS
+                    # connection and blank every hub-network sensor until the
+                    # next poll. The AES layer is per-frame (fixed IV, no
+                    # chaining), so a bad frame doesn't desync later ones —
+                    # skip it and keep listening, mirroring the per-update
+                    # guard in `_handle_update`.
+                    _LOGGER.warning("HTS: skipping undecodable frame: %s", exc)
+                    self._consecutive_read_timeouts = 0
+                    continue
                 self._consecutive_read_timeouts = 0
 
                 if not msg.is_no_ack and msg.msg_type != MsgType.ACK:
@@ -603,7 +656,7 @@ class HtsClient:
                 elif msg.msg_type == MsgType.ACK:
                     pass  # expected
                 else:
-                    _LOGGER.debug("  payload hex: %s", msg.payload[:80].hex())
+                    _LOGGER.debug("  payload hex: %s", _redact_payload_hex(msg.payload[:80]))
         finally:
             await self.close()
 
@@ -624,7 +677,7 @@ class HtsClient:
         except Exception:
             _LOGGER.debug(
                 "Failed to decode UPDATES payload (first 80 bytes: %s) — dropping message",
-                msg.payload[:80].hex(),
+                _redact_payload_hex(msg.payload[:80]),
                 exc_info=True,
             )
             return

--- a/custom_components/aegis_ajax/api/media.py
+++ b/custom_components/aegis_ajax/api/media.py
@@ -95,9 +95,17 @@ class MediaApi:
                         parsed = urlparse(url)
                         hostname = parsed.hostname or ""
                         is_ajax = hostname.endswith(".ajax.systems")
-                        is_s3 = "hubs-uploaded-resources" in hostname
+                        # Anchor the S3 branch to the real bucket host — a bare
+                        # `in` substring would also accept e.g.
+                        # `hubs-uploaded-resources.attacker.com` (SSRF).
+                        is_s3 = "hubs-uploaded-resources" in hostname and hostname.endswith(
+                            ".amazonaws.com"
+                        )
                         if is_ajax or is_s3:
-                            _LOGGER.debug("Photo URL from media stream: %s", url[:80])
+                            # Host + path only — the query string holds the S3 signature.
+                            _LOGGER.debug(
+                                "Photo URL from media stream: %s%s", hostname, parsed.path
+                            )
                             return url
                     _LOGGER.debug(
                         "Media stream: %d bytes, no URL yet, retrying in %.0fs",

--- a/custom_components/aegis_ajax/camera.py
+++ b/custom_components/aegis_ajax/camera.py
@@ -113,14 +113,22 @@ class AjaxCamera(CoordinatorEntity[AjaxCobrandedCoordinator], Camera):
         from urllib.parse import urlparse  # noqa: PLC0415
 
         hostname = urlparse(url).hostname or ""
-        return hostname.endswith(".ajax.systems") or "hubs-uploaded-resources" in hostname
+        # S3 branch anchored to the real bucket host so a substring match can't
+        # accept `hubs-uploaded-resources.attacker.com` (SSRF).
+        is_s3 = "hubs-uploaded-resources" in hostname and hostname.endswith(".amazonaws.com")
+        return hostname.endswith(".ajax.systems") or is_s3
 
     async def _download_image(self, url: str) -> bytes | None:
         """Download image from URL and cache it."""
         import aiohttp  # noqa: PLC0415
 
         if not self._is_valid_photo_url(url):
-            _LOGGER.warning("Rejected photo URL with unexpected domain: %s", url[:80])
+            # Log host only — never the query string (carries the S3 signature).
+            from urllib.parse import urlparse  # noqa: PLC0415
+
+            _LOGGER.warning(
+                "Rejected photo URL with unexpected domain: %s", urlparse(url).hostname or "?"
+            )
             return self._last_image
         self._last_image_url = url
         session = async_get_clientsession(self.hass)

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -31,6 +31,8 @@ from custom_components.aegis_ajax.repairs import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from homeassistant.core import HomeAssistant
 
     from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
@@ -378,11 +380,21 @@ class AjaxNotificationListener:
                     photo_url = raw_url.decode("utf-8", errors="ignore")
                     parsed = urlparse(photo_url)
                     is_ajax = parsed.hostname and parsed.hostname.endswith(".ajax.systems")
-                    is_s3 = parsed.hostname and "hubs-uploaded-resources" in parsed.hostname
+                    # Anchor S3 to the real bucket host (SSRF — a substring would
+                    # also accept `hubs-uploaded-resources.attacker.com`).
+                    is_s3 = (
+                        parsed.hostname
+                        and "hubs-uploaded-resources" in parsed.hostname
+                        and parsed.hostname.endswith(".amazonaws.com")
+                    )
                     if not is_ajax and not is_s3:
                         _LOGGER.debug("Rejected photo URL from unexpected domain")
                         continue
-                    _LOGGER.debug("Extracted photo URL from push: %s", photo_url[:60])
+                    # Log host + path only — the query string carries the S3
+                    # signature (X-Amz-Signature, …) which grants object read.
+                    _LOGGER.debug(
+                        "Extracted photo URL from push: %s%s", parsed.hostname or "?", parsed.path
+                    )
                     # Resolve the photo future for the matching device
                     resolved = False
                     for device_id, future in list(self._photo_callbacks.items()):
@@ -590,12 +602,16 @@ class AjaxNotificationListener:
                 # Try to route to the correct space by matching hub_id from raw bytes
                 target_space = self._find_space_for_event(raw)
                 if target_space:
-                    self._coordinator.fire_push_event(target_space, event_type, event_data)
+                    self._dispatch_to_loop(
+                        self._coordinator.fire_push_event, target_space, event_type, event_data
+                    )
                     self._apply_security_state_from_event(target_space, event_data)
                 else:
                     # Fallback: single-space installations or unknown hub
                     for space_id in self._coordinator._space_ids:
-                        self._coordinator.fire_push_event(space_id, event_type, event_data)
+                        self._dispatch_to_loop(
+                            self._coordinator.fire_push_event, space_id, event_type, event_data
+                        )
                         self._apply_security_state_from_event(space_id, event_data)
                 # Surface doorbell ring / motion on the source device's own
                 # card, in addition to the hub-level event entity (#173).
@@ -661,11 +677,24 @@ class AjaxNotificationListener:
             return
 
         if event_type == DOORBELL_EVENT_TYPE:
-            self._coordinator.fire_push_device_event(resolved, event_type, event_data)
-        elif event_type == MOTION_EVENT_TYPE and self._hass.loop and self._hass.loop.is_running():
-            self._hass.loop.call_soon_threadsafe(
-                self._coordinator.apply_push_device_motion, resolved
+            self._dispatch_to_loop(
+                self._coordinator.fire_push_device_event, resolved, event_type, event_data
             )
+        elif event_type == MOTION_EVENT_TYPE:
+            self._dispatch_to_loop(self._coordinator.apply_push_device_motion, resolved)
+
+    def _dispatch_to_loop(self, func: Callable[..., object], *args: object) -> None:
+        """Marshal a coordinator state-write from the FCM worker thread onto the
+        HA event loop.
+
+        `_on_notification` runs on the firebase_messaging worker thread; the
+        coordinator handlers it calls touch `async_write_ha_state` /
+        `bus.async_fire`, which are loop-only and not thread-safe. Schedule them
+        on the loop instead of calling them inline. No-op if the loop isn't
+        running (shutdown / teardown) — dropping a push beats an off-loop write.
+        """
+        if self._hass.loop and self._hass.loop.is_running():
+            self._hass.loop.call_soon_threadsafe(func, *args)
 
     def _apply_security_state_from_event(self, space_id: str, event_data: dict[str, Any]) -> None:
         """If the push event implies a new security_state, push it now (#68 / #148).

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -557,6 +557,32 @@ class TestHandleUpdate:
         assert client._receive_message.await_count == MAX_CONSECUTIVE_READ_TIMEOUTS
         assert client._consecutive_read_timeouts == MAX_CONSECUTIVE_READ_TIMEOUTS
 
+    @pytest.mark.asyncio
+    async def test_listen_skips_malformed_frame_and_keeps_listening(self) -> None:
+        """A ValueError from frame decode/decrypt/parse must not propagate out
+        of listen() and tear down the connection — skip the bad frame and keep
+        reading (audit fix)."""
+        client = _make_client()
+        client._connected = True
+        ack = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=MsgType.ACK,
+            payload=b"",
+        )
+        client._receive_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[ValueError("bad CRC"), ack, ConnectionError("closed")]
+        )
+
+        # Must NOT raise — the ValueError is swallowed and the loop continues.
+        await client.listen()
+
+        # All three reads happened: bad frame skipped, ack handled, then close.
+        assert client._receive_message.await_count == 3
+
 
 class TestExtractAllDevicesKv:
     """Per-device kv extraction for the #123 probe.
@@ -1318,6 +1344,45 @@ class TestReadFrame:
         client._reader = reader
         with pytest.raises(ConnectionError, match="closed by remote"):
             await client._read_frame()
+
+    @pytest.mark.asyncio
+    async def test_caps_buffer_on_runaway_stream(self) -> None:
+        """Bytes keep arriving but no STX…ETX ever completes — the buffer must
+        be capped and a reconnect forced, not grown without bound (audit fix)."""
+        from custom_components.aegis_ajax.api.hts.client import MAX_FRAME_BUFFER_BYTES
+
+        client = _make_client()
+        reader = MagicMock()
+        reader.read = AsyncMock(return_value=b"\x00" * 4096)  # never STX/ETX
+        client._reader = reader
+        with pytest.raises(ConnectionError, match="exceeded"):
+            await client._read_frame()
+        # Buffer was cleared on the way out, not left to leak.
+        assert len(client._read_buf) == 0
+        assert MAX_FRAME_BUFFER_BYTES > 0
+
+
+class TestRedactPayloadHex:
+    """`_redact_payload_hex` masks printable-ASCII runs inside a binary dump."""
+
+    def test_masks_embedded_text_run(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import _redact_payload_hex
+
+        out = _redact_payload_hex(b"\x00\x01Deurbel\x02")
+        assert "Deurbel" not in out
+        assert "<text:7b>" in out
+        assert out.startswith("0001")
+
+    def test_pure_binary_stays_hex(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import _redact_payload_hex
+
+        assert _redact_payload_hex(b"\x00\x01\x02") == "000102"
+
+    def test_short_printable_run_not_masked(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import _redact_payload_hex
+
+        out = _redact_payload_hex(b"\x00AB\x00")
+        assert "<text:" not in out
 
 
 class TestConnect:

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1440,6 +1440,9 @@ class TestParseAndFireEventLogging:
         hass = MagicMock()
         hass.loop = MagicMock()
         hass.loop.is_running.return_value = True
+        # Event dispatch is now marshaled via call_soon_threadsafe; invoke the
+        # callback inline so these tests observe the downstream fire/state-write.
+        hass.loop.call_soon_threadsafe.side_effect = lambda cb, *a: cb(*a)
         coordinator = MagicMock()
         coordinator._space_ids = []
         return AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
@@ -1692,6 +1695,9 @@ class TestParseAndFireEventDeviceRouting:
         hass = MagicMock()
         hass.loop = MagicMock()
         hass.loop.is_running.return_value = True
+        # Marshaled dispatch: run the scheduled callback inline so the existing
+        # assertions on fire_push_device_event still observe the call.
+        hass.loop.call_soon_threadsafe.side_effect = lambda cb, *a: cb(*a)
         coordinator = MagicMock()
         coordinator._space_ids = []
         coordinator.devices = devices
@@ -1769,6 +1775,87 @@ class TestParseAndFireEventDeviceRouting:
         coordinator.fire_push_device_event.assert_not_called()
         for call in listener._hass.loop.call_soon_threadsafe.call_args_list:
             assert call[0][0] is not coordinator.apply_push_device_motion
+
+
+class TestParseAndFireEventThreadSafety:
+    """The FCM callback runs on the firebase_messaging worker thread, so every
+    event-entity dispatch (which calls async_write_ha_state / bus.async_fire,
+    both loop-only) MUST be marshaled to the loop via call_soon_threadsafe and
+    never invoked directly on the worker thread (audit fix)."""
+
+    def _make_listener(self) -> tuple[AjaxNotificationListener, MagicMock]:
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.is_running.return_value = True
+        coordinator = MagicMock()
+        coordinator._space_ids = []
+        coordinator.fire_push_event = MagicMock()
+        coordinator.fire_push_device_event = MagicMock(return_value=True)
+        coordinator.devices = {}
+        listener = AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
+        return listener, coordinator
+
+    @staticmethod
+    def _scheduled(listener: AjaxNotificationListener) -> list:
+        return [c[0][0] for c in listener._hass.loop.call_soon_threadsafe.call_args_list]
+
+    def test_hub_event_marshaled_to_loop_not_called_directly(self) -> None:
+        listener, coordinator = self._make_listener()
+        encoded = base64.b64encode(b"any-payload").decode()
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=("arm", {"raw_tag": "space_armed"}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value={}),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+        # Never called directly on the worker thread …
+        coordinator.fire_push_event.assert_not_called()
+        # … always scheduled onto the loop instead.
+        assert coordinator.fire_push_event in self._scheduled(listener)
+
+    def test_doorbell_device_event_marshaled_to_loop_not_called_directly(self) -> None:
+        listener, coordinator = self._make_listener()
+        dev = MagicMock()
+        dev.id = "310A8DF4"
+        dev.device_type = "video_edge_doorbell"
+        coordinator.devices = {"310A8DF4": dev}
+        encoded = base64.b64encode(b"any-payload").decode()
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=("doorbell_pressed", {"raw_tag": "ring_button_pressed"}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value={"device_id": "310A8DF4"}),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+        coordinator.fire_push_device_event.assert_not_called()
+        assert coordinator.fire_push_device_event in self._scheduled(listener)
+
+    def test_no_dispatch_when_loop_not_running(self) -> None:
+        listener, coordinator = self._make_listener()
+        listener._hass.loop.is_running.return_value = False
+        encoded = base64.b64encode(b"any-payload").decode()
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=("arm", {"raw_tag": "space_armed"}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value={}),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+        coordinator.fire_push_event.assert_not_called()
+        listener._hass.loop.call_soon_threadsafe.assert_not_called()
 
 
 class TestNotificationDedupe:


### PR DESCRIPTION
Remediation of the full security + performance audit (1.7.0-beta.4). The audit found **no worthwhile pure-performance change** (hot paths already use set/dict lookups, inline crypto/protobuf are <0.1ms/frame); this PR ships the one real correctness bug it surfaced plus the cheap security hardenings. Performance was left untouched by design.

## 🔴 Thread-safety (HIGH — real bug)
The `firebase_messaging` callback runs on a worker thread, but `_parse_and_fire_event` dispatched the hub-level event entity (`fire_push_event`) and the per-device doorbell entity (`fire_push_device_event`) **directly** — both call `async_write_ha_state` / `bus.async_fire`, which are loop-only. The sibling security-state and motion paths already marshalled via `call_soon_threadsafe`; these two were missed. Fires on **every security-event and doorbell push**. Routed through a new `_dispatch_to_loop` helper (motion branch adopts it too).

## 🟡 Security / robustness hardening
- **Photo-URL log hygiene** — log host + path only, never the signed S3 query string (`X-Amz-Signature`), in `notification.py`, `camera.py`, `api/media.py`.
- **SSRF anchor** — the S3 host allowlist used substring `"hubs-uploaded-resources" in hostname`; anchored to `.amazonaws.com` so `hubs-uploaded-resources.attacker.com` no longer passes (all three sites).
- **HTS frame resilience** — a malformed frame (`ValueError` from decode/decrypt/parse) escaped `listen()` and tore down the whole HTS connection; now caught + skipped per-frame (AES is per-frame, no desync).
- **HTS read-buffer cap** — `_read_frame` grew unbounded if ETX never arrived while bytes kept flowing (defeats `READ_TIMEOUT`); capped at 256 KB → forced reconnect.
- **HTS log redaction** — two raw-payload DEBUG dumps now run through `_redact_payload_hex` (masks printable-ASCII runs) so an undecodable frame can't leak device-name/user PII.

## What was NOT changed (and why)
Per the audit's honest cost/benefit: the FCM brute-force parsers, the `bypass_switches: auto` permission probe, the duplicate HTS scan, and dict-literal allocations all run on human-paced or setup-only events — optimizing them saves microseconds and adds complexity. The hardcoded HTS AES key/IV is a vendor protocol constant (non-security-bearing under TLS) and must not be touched.

## Tests
8 new tests (3 thread-safety marshaling, 1 listen frame-skip, 1 read-buffer cap, 3 redaction). Full suite: **1480 passed, 87.83% coverage** (gate 80%). ruff + format + mypy + vulture clean.

Related to #205