### PR TITLE
feat(lock): read-only SmartLock id probe to unblock HA-side commands (#206)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -558,6 +558,54 @@ class DevicesApi:
             raise SmartLockError(error_type)
         _LOGGER.debug("SmartLock %s in space %s: action=%s OK", smart_lock_id, space_id, action)
 
+    async def probe_smart_locks(self, space_id: str, lock_device_ids: list[str]) -> None:
+        """One-shot read-only probe (#206 Bug B): list the smart locks in a
+        space via `SmartLockService.findAllBySpace` and log each lock's
+        identifiers next to the hub-device ids the lock entities are built
+        from. `switch_smart_lock` currently sends the hub-device id and the
+        server answers `smart_lock_not_found`; this surfaces the id the
+        command service actually expects so it can be correlated to the
+        hub-device. DEBUG-only, device names are NOT logged, and the whole
+        call is guarded — a failure must never affect setup.
+        """
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        try:
+            from systems.ajax.api.mobile.v2.space.smartlock import (  # noqa: PLC0415
+                find_all_by_space_pb2,
+                smart_lock_service_endpoints_pb2_grpc,
+            )
+
+            channel = self._client._get_channel()
+            metadata = self._client._session.get_call_metadata()
+            stub = smart_lock_service_endpoints_pb2_grpc.SmartLockServiceStub(channel)
+            request = find_all_by_space_pb2.FindAllSmartLocksBySpaceRequest(space_id=space_id)
+            response = await stub.findAllBySpace(request, metadata=metadata, timeout=15)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("SmartLock probe (#206) failed for space %s", space_id, exc_info=True)
+            return
+
+        which = response.WhichOneof("response")
+        if which != "success":
+            _LOGGER.debug("SmartLock probe (#206) space %s returned %s", space_id, which)
+            return
+        _LOGGER.debug(
+            "SmartLock probe (#206) space %s: hub-device lock ids=%s", space_id, lock_device_ids
+        )
+        for sl in response.success.smart_locks:
+            details = sl.details
+            _LOGGER.debug(
+                "SmartLock probe (#206) space %s: in_space_id=%s details_id=%s "
+                "external_id=%s serial=%s type=%s lock_status=%s",
+                space_id,
+                sl.id,
+                details.id,
+                details.external_id,
+                details.serial_number,
+                int(details.type),
+                int(details.status.lock_status),
+            )
+
     async def capture_photo(self, hub_id: str, device_id: str, device_type: str) -> str | None:
         """Capture a photo using v2 PhotoOnDemandService.
 

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -88,6 +88,11 @@ _STATUS_KEY_MAP: dict[str, str] = {
     "lock_control_status": "smart_lock_state",
 }
 
+# Mirror of `lock.LOCK_DEVICE_TYPES` (kept local to avoid a circular import
+# with the lock platform, which imports the coordinator). Used only by the
+# one-shot #206 Bug-B SmartLock id probe.
+_LOCK_DEVICE_TYPES: frozenset[str] = frozenset({"smart_lock", "smart_lock_yale"})
+
 # Statuses whose snapshot parser writes more than the single mapped key.
 # Used by the REMOVE op so stale sub-keys don't linger after the hub drops
 # the parent status from the stream.
@@ -163,6 +168,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # (same shape as `self.devices` keys). Empty dict = no readings
         # snapshotted yet OR no electrical devices in the install.
         self.device_readings: dict[str, DeviceReadings] = {}
+        # One-shot guard for the #206 Bug-B SmartLock id probe (DEBUG-only).
+        self._smart_lock_probe_done = False
         # Per-space monotonic timestamp of when the hub first reported
         # offline (cleared on the first ONLINE poll). Drives the
         # `hub_offline_24h` Repair surfaced after sustained downtime.
@@ -466,6 +473,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     await self._devices_cache.async_save(self.devices)
                 except Exception:  # noqa: BLE001
                     _LOGGER.debug("Failed to persist devices cache", exc_info=True)
+        await self._probe_smart_locks_once()
         await self._start_device_streams()
         await self._start_hts()
         self._last_update_success_time = dt_util.utcnow()
@@ -480,6 +488,25 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             len(self.spaces),
             "scheduled" if self._hts_task is not None else "skipped",
         )
+
+    async def _probe_smart_locks_once(self) -> None:
+        """#206 Bug B: one-shot read-only probe of `SmartLockService` to
+        capture the id the command service expects (the hub-device id we send
+        today yields `smart_lock_not_found`). Runs once, only when a lock
+        device is present; the probe itself is DEBUG-gated and never raises.
+        """
+        if self._smart_lock_probe_done:
+            return
+        self._smart_lock_probe_done = True
+        lock_ids_by_space: dict[str, list[str]] = {}
+        for device in self.devices.values():
+            if device.device_type not in _LOCK_DEVICE_TYPES:
+                continue
+            space_id = next((s.id for s in self.spaces.values() if s.hub_id == device.hub_id), None)
+            if space_id:
+                lock_ids_by_space.setdefault(space_id, []).append(device.id)
+        for space_id, lock_ids in lock_ids_by_space.items():
+            await self._devices_api.probe_smart_locks(space_id, lock_ids)
 
     async def _maybe_fallback_device_snapshot(self) -> None:
         """Refresh devices from snapshot when persistent streams aren't all

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1910,3 +1910,45 @@ class TestManualHubRefresh:
         assert hts.request_full_status.await_count == 2
         hts.request_full_status.assert_any_await("hub-1")
         hts.request_full_status.assert_any_await("hub-2")
+
+
+class TestSmartLockProbeOrchestration:
+    """#206 Bug B: the one-shot probe correlates lock hub-devices to their
+    space and delegates to the read-only `DevicesApi.probe_smart_locks`."""
+
+    @pytest.mark.asyncio
+    async def test_probe_once_correlates_lock_to_space(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.spaces = {"s1": _make_space("s1")}  # hub_id="hub-1"
+        lock = Device(
+            id="31524B92",
+            hub_id="hub-1",
+            name="Yale",
+            device_type="smart_lock_yale",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+        coordinator.devices = {"31524B92": lock, "d1": _make_device("d1")}
+        coordinator._devices_api.probe_smart_locks = AsyncMock()
+
+        await coordinator._probe_smart_locks_once()
+
+        coordinator._devices_api.probe_smart_locks.assert_awaited_once_with("s1", ["31524B92"])
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_when_no_lock_and_runs_once(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.spaces = {"s1": _make_space("s1")}
+        coordinator.devices = {"d1": _make_device("d1")}  # no lock
+        coordinator._devices_api.probe_smart_locks = AsyncMock()
+
+        await coordinator._probe_smart_locks_once()
+        await coordinator._probe_smart_locks_once()
+
+        coordinator._devices_api.probe_smart_locks.assert_not_called()
+        assert coordinator._smart_lock_probe_done is True

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -2630,3 +2630,75 @@ class TestSetPhotoOnDemandMode:
             pytest.raises(DeviceCommandError, match="user.*bad_request"),
         ):
             await api.set_photo_on_demand_mode("hub-1", user_enabled=True)
+
+
+class TestSmartLockProbe:
+    """#206 Bug B: read-only `findAllBySpace` probe that surfaces the
+    smart-lock id the command service expects alongside the hub-device ids."""
+
+    def _make_api(self) -> DevicesApi:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        return DevicesApi(client)
+
+    @pytest.mark.asyncio
+    async def test_probe_logs_smart_lock_ids(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging as _logging  # noqa: PLC0415
+
+        from systems.ajax.api.mobile.v2.space.smartlock import (  # noqa: PLC0415
+            find_all_by_space_pb2,
+        )
+
+        response = find_all_by_space_pb2.FindAllSmartLocksBySpaceResponse()
+        sl = response.success.smart_locks.add()
+        sl.id = "5_0"
+        sl.details.id = "details-abc"
+        sl.details.external_id = "ext-1"
+        sl.details.serial_number = "SN123"
+
+        api = self._make_api()
+        stub = MagicMock()
+        stub.findAllBySpace = AsyncMock(return_value=response)
+
+        with (
+            caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"),
+            patch(
+                "systems.ajax.api.mobile.v2.space.smartlock."
+                "smart_lock_service_endpoints_pb2_grpc.SmartLockServiceStub",
+                return_value=stub,
+            ),
+        ):
+            await api.probe_smart_locks("space-1", ["31524B92"])
+
+        msgs = [r.message for r in caplog.records]
+        assert any("hub-device lock ids=['31524B92']" in m for m in msgs)
+        assert any("in_space_id=5_0" in m and "external_id=ext-1" in m for m in msgs)
+
+    @pytest.mark.asyncio
+    async def test_probe_disabled_without_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging as _logging  # noqa: PLC0415
+
+        api = self._make_api()
+        with caplog.at_level(_logging.INFO, logger="custom_components.aegis_ajax.api.devices"):
+            await api.probe_smart_locks("space-1", ["31524B92"])
+        # No gRPC call attempted, no probe output above DEBUG.
+        api._client._get_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_probe_never_raises_on_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging as _logging  # noqa: PLC0415
+
+        api = self._make_api()
+        stub = MagicMock()
+        stub.findAllBySpace = AsyncMock(side_effect=RuntimeError("boom"))
+        with (
+            caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"),
+            patch(
+                "systems.ajax.api.mobile.v2.space.smartlock."
+                "smart_lock_service_endpoints_pb2_grpc.SmartLockServiceStub",
+                return_value=stub,
+            ),
+        ):
+            await api.probe_smart_locks("space-1", ["31524B92"])  # must not raise
+        assert any("SmartLock probe (#206) failed" in r.message for r in caplog.records)


### PR DESCRIPTION
Follow-up to #210 (state fix). Targets the remaining half of #206: locking/unlocking **from Home Assistant** fails with `smart_lock_not_found`.

## Why
`switch_smart_lock` sends the **hub-device id**, but the v3 `SwitchSmartLockService` expects the **smart-locks own id**. The hub-device carries no smart-lock id reference in-band, and `SmartLockService.findAllBySpace` (which returns the correct id) was never wired — so we cant establish the id↔hub-device correlation without a capture from an affected install.

## What
A one-shot, **read-only**, DEBUG-gated probe that, at setup and only when a lock device is present, calls `findAllBySpace` once and logs each locks `in_space_id` / `details_id` / `external_id` / `serial` / `type` / `lock_status` next to the hub-device lock ids. Device **names are never logged**; the call is fully guarded so a failure cant affect setup.

This surfaces the identifier the command service actually expects, so the lock/unlock command can be wired correctly in a follow-up beta — without guessing the correlation key (consistent with how the state fix was nailed down).

## Tests
- `DevicesApi.probe_smart_locks`: logs ids on success, no-op without DEBUG, never raises on error.
- Coordinator orchestration: correlates a lock hub-device to its space and runs once.

Full suite green (1488 tests, 87.89% coverage).

Related to #206