### PR TITLE
fix(doorbell): attribute motion to doorbell device + emit canonical ring (#173)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -117,6 +117,11 @@ class DevicesApi:
 
     def __init__(self, client: AjaxGrpcClient) -> None:
         self._client = client
+        # `{dropped video-doorbell twin id: surviving video_edge id}`,
+        # accumulated by `_dedupe_and_track_aliases` across snapshots. Lets
+        # `notification` resolve doorbell/motion pushes (which carry the
+        # Jeweller twin id) onto the video_edge device the user sees (#173).
+        self.doorbell_twin_aliases: dict[str, str] = {}
 
     # Parsing delegators. The proto-to-Device logic lives in the pure,
     # client-free `devices_parser` module; these thin forwarders preserve the
@@ -153,7 +158,14 @@ class DevicesApi:
 
     @staticmethod
     def _dedupe_video_doorbells(devices: list[Device]) -> list[Device]:
-        return devices_parser._dedupe_video_doorbells(devices)
+        return devices_parser._dedupe_video_doorbells(devices)[0]
+
+    def _dedupe_and_track_aliases(self, devices: list[Device]) -> list[Device]:
+        """Dedupe video-doorbell twins and record the twin→sibling alias map
+        (#173) so doorbell/motion pushes carrying the twin id still resolve."""
+        deduped, aliases = devices_parser._dedupe_video_doorbells(devices)
+        self.doorbell_twin_aliases.update(aliases)
+        return deduped
 
     async def get_devices_snapshot(self, space_id: str) -> list[Device]:
         """Get initial snapshot of all devices in a space."""
@@ -183,7 +195,7 @@ class DevicesApi:
                 _LOGGER.error("Device stream failed: %s", msg.failure)
                 break
 
-        return self._dedupe_video_doorbells(devices)
+        return self._dedupe_and_track_aliases(devices)
 
     def _handle_update(
         self,
@@ -362,7 +374,7 @@ class DevicesApi:
                                         continue
                                     if device is not None:
                                         devices.append(device)
-                                on_devices_snapshot(self._dedupe_video_doorbells(devices))
+                                on_devices_snapshot(self._dedupe_and_track_aliases(devices))
                                 # Reset backoff after successful snapshot
                                 backoff = 5.0
                             elif which == "updates":

--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -548,7 +548,7 @@ def parse_device(proto_light_device: Any) -> Device | None:  # noqa: ANN401
     return None
 
 
-def _dedupe_video_doorbells(devices: list[Device]) -> list[Device]:
+def _dedupe_video_doorbells(devices: list[Device]) -> tuple[list[Device], dict[str, str]]:
     """Drop `motion_cam_video_*` hub_device twins that have a
     `video_edge_*` sibling with a matching name in the same snapshot.
 
@@ -557,25 +557,36 @@ def _dedupe_video_doorbells(devices: list[Device]) -> list[Device]:
     discriminator across the two LightDevice cases — the IDs are
     unrelated (Jeweller short id vs MAC-style `aa:bb:cc:dd:ee:ff-0`)
     and we don't have a serial-number bridge between them. See #173.
+
+    Returns the deduped device list plus an alias map `{dropped twin id:
+    surviving video_edge id}`. Doorbell ring / motion pushes carry the
+    Jeweller twin id, which is no longer in the device set after dedup, so
+    the alias lets `notification` still resolve those pushes onto the
+    video_edge device the user sees (the motion-attribution miss in #173).
     """
-    video_edge_names = {
-        d.name.casefold() for d in devices if d.device_type.startswith(_VIDEO_EDGE_PREFIX)
+    video_edge_id_by_name = {
+        d.name.casefold(): d.id for d in devices if d.device_type.startswith(_VIDEO_EDGE_PREFIX)
     }
     result: list[Device] = []
+    aliases: dict[str, str] = {}
     for d in devices:
         if (
             d.device_type.startswith(_MOTION_CAM_VIDEO_HUB_PREFIX)
-            and d.name.casefold() in video_edge_names
+            and d.name.casefold() in video_edge_id_by_name
         ):
+            sibling_id = video_edge_id_by_name[d.name.casefold()]
+            aliases[d.id] = sibling_id
             _LOGGER.debug(
                 "Dropping duplicate hub_device twin %s (%s) — same name "
-                "as a video_edge sibling in this snapshot (#173)",
+                "as a video_edge sibling in this snapshot (#173); "
+                "aliasing pushes to %s",
                 d.id,
                 d.device_type,
+                sibling_id,
             )
             continue
         result.append(d)
-    return result
+    return result, aliases
 
 
 def _parse_hub_device(hub_dev: Any) -> Device | None:  # noqa: ANN401

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -483,8 +483,14 @@ DOORBELL_DEVICE_TYPES: frozenset[str] = frozenset(
     }
 )
 
-# HA event_type fired by the per-device doorbell event entity (#173).
+# Internal routing key for doorbell pushes (used by the parser, the coordinator
+# dispatch, and the hub-level security event entity). Not the type the
+# doorbell-device-class entity emits — see DOORBELL_RING_EVENT_TYPE.
 DOORBELL_EVENT_TYPE = "doorbell_pressed"
+# Event type the per-device doorbell entity emits. HA requires an entity with
+# `device_class=doorbell` to support the canonical "ring" type (it warns and,
+# from HA 2027.4, rejects anything else). See #173.
+DOORBELL_RING_EVENT_TYPE = "ring"
 # HA event_type for motion pushes; used to flip a device's motion sensor (#173).
 MOTION_EVENT_TYPE = "motion"
 

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
+from custom_components.aegis_ajax.api import devices_parser
 from custom_components.aegis_ajax.api.devices import DevicesApi
 from custom_components.aegis_ajax.api.hts.client import HtsClient
 from custom_components.aegis_ajax.api.hub_object import (
@@ -199,6 +200,15 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     @property
     def spaces_api(self) -> SpacesApi:
         return self._spaces_api
+
+    @property
+    def doorbell_twin_aliases(self) -> dict[str, str]:
+        """`{dropped video-doorbell twin id: surviving video_edge id}` (#173).
+
+        Pushes carry the Jeweller twin id, which is gone after dedup; this lets
+        `notification` resolve doorbell/motion pushes onto the real device.
+        """
+        return self._devices_api.doorbell_twin_aliases
 
     @property
     def devices_api(self) -> DevicesApi:
@@ -867,7 +877,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         active integration still provides).
         """
         current = list(self.devices.values())
-        deduped = DevicesApi._dedupe_video_doorbells(current)
+        deduped, aliases = devices_parser._dedupe_video_doorbells(current)
+        self._devices_api.doorbell_twin_aliases.update(aliases)
         if len(deduped) == len(current):
             return
         kept_ids = {d.id for d in deduped}

--- a/custom_components/aegis_ajax/event.py
+++ b/custom_components/aegis_ajax/event.py
@@ -14,6 +14,7 @@ from custom_components.aegis_ajax.const import (
     DOMAIN,
     DOORBELL_DEVICE_TYPES,
     DOORBELL_EVENT_TYPE,
+    DOORBELL_RING_EVENT_TYPE,
     MANUFACTURER,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
@@ -104,7 +105,9 @@ class AjaxDoorbellEvent(CoordinatorEntity[AjaxCobrandedCoordinator], EventEntity
     _attr_has_entity_name = True
     _attr_translation_key = "doorbell"
     _attr_device_class = EventDeviceClass.DOORBELL
-    _attr_event_types = [DOORBELL_EVENT_TYPE]
+    # HA requires a `doorbell` device-class event entity to advertise the
+    # canonical "ring" type (warns now, rejects from HA 2027.4) — #173.
+    _attr_event_types = [DOORBELL_RING_EVENT_TYPE]
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
         super().__init__(coordinator)
@@ -138,5 +141,6 @@ class AjaxDoorbellEvent(CoordinatorEntity[AjaxCobrandedCoordinator], EventEntity
         """
         if event_type != DOORBELL_EVENT_TYPE:
             return
-        self._trigger_event(event_type, data)
+        # Emit HA's canonical "ring" type, not the internal routing key.
+        self._trigger_event(DOORBELL_RING_EVENT_TYPE, data)
         self.async_write_ha_state()

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -644,6 +644,16 @@ class AjaxNotificationListener:
         device_id = event_data.get("device_id")
         resolved = device_id if device_id in devices else None
 
+        # The push carries the Jeweller twin id, but after the #173 dedup the
+        # device set holds the `video_edge` sibling instead. Resolve via the
+        # twin→sibling alias so BOTH doorbell rings and motion attribute to the
+        # real device — without this, motion (which has no single-doorbell
+        # fallback below) always lands on the hub.
+        if resolved is None and device_id is not None:
+            alias = self._coordinator.doorbell_twin_aliases.get(device_id)
+            if alias in devices:
+                resolved = alias
+
         if resolved is None and event_type == DOORBELL_EVENT_TYPE:
             doorbells = [
                 dev_id

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -300,7 +300,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Doorbell pressed"
+                            "ring": "Doorbell pressed"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Timbre premut"
+                            "ring": "Timbre premut"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Stisknutí zvonku"
+                            "ring": "Stisknutí zvonku"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Klingel gedrückt"
+                            "ring": "Klingel gedrückt"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -283,7 +283,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Doorbell pressed"
+                            "ring": "Doorbell pressed"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -283,7 +283,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Timbre pulsado"
+                            "ring": "Timbre pulsado"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Sonnette appuyée"
+                            "ring": "Sonnette appuyée"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Campanello premuto"
+                            "ring": "Campanello premuto"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Bel ingedrukt"
+                            "ring": "Bel ingedrukt"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Naciśnięto dzwonek"
+                            "ring": "Naciśnięto dzwonek"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Campainha tocada"
+                            "ring": "Campainha tocada"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Campainha tocada"
+                            "ring": "Campainha tocada"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Sonerie apăsată"
+                            "ring": "Sonerie apăsată"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Zile basıldı"
+                            "ring": "Zile basıldı"
                         }
                     }
                 }

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -267,7 +267,7 @@
                 "state_attributes": {
                     "event_type": {
                         "state": {
-                            "doorbell_pressed": "Натиснуто дзвінок"
+                            "ring": "Натиснуто дзвінок"
                         }
                     }
                 }

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1169,6 +1169,27 @@ class TestDeduplicateVideoDoorbells:
         deduped = DevicesApi._dedupe_video_doorbells([video_indoor, hub_indoor])
         assert [d.id for d in deduped] == ["9c-ind-0"]
 
+    def test_dedup_records_twin_to_sibling_alias(self) -> None:
+        """The dropped Jeweller twin id is aliased to the surviving video_edge
+        id so doorbell/motion pushes (which carry the twin id) still resolve
+        to the real device — the motion-attribution miss in #173."""
+        video_edge = self._make("9c756e2bca39-0", "Deurbel", "video_edge_doorbell")
+        hub_twin = self._make("310A8DF4", "Deurbel", "motion_cam_video_doorbell", malfunctions=1)
+        api = DevicesApi(MagicMock())
+
+        deduped = api._dedupe_and_track_aliases([video_edge, hub_twin])
+
+        assert [d.id for d in deduped] == ["9c756e2bca39-0"]
+        assert api.doorbell_twin_aliases == {"310A8DF4": "9c756e2bca39-0"}
+
+    def test_dedup_no_twin_records_no_alias(self) -> None:
+        only_video_edge = self._make("9c756e2bca39-0", "Deurbel", "video_edge_doorbell")
+        api = DevicesApi(MagicMock())
+
+        api._dedupe_and_track_aliases([only_video_edge])
+
+        assert api.doorbell_twin_aliases == {}
+
 
 class TestDevicesApiInit:
     def test_init(self) -> None:

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -116,9 +116,11 @@ class TestAjaxDoorbellEvent:
         entity = self._make_doorbell_entity()
         assert entity._attr_device_class == EventDeviceClass.DOORBELL
 
-    def test_event_types_contains_doorbell_pressed(self) -> None:
+    def test_event_types_is_ring(self) -> None:
+        # HA requires a `doorbell` device-class event entity to advertise the
+        # canonical "ring" type (warns now, rejects from HA 2027.4) — #173.
         entity = self._make_doorbell_entity()
-        assert "doorbell_pressed" in entity.event_types
+        assert entity.event_types == ["ring"]
 
     def test_handle_event_triggers_and_writes(self) -> None:
         entity = self._make_doorbell_entity()
@@ -126,11 +128,10 @@ class TestAjaxDoorbellEvent:
         entity.async_write_ha_state = MagicMock()
         entity.hass = MagicMock()
 
+        # Routing key in, canonical "ring" type out.
         entity.handle_event("doorbell_pressed", {"raw_tag": "ring_button_pressed"})
 
-        entity._trigger_event.assert_called_once_with(
-            "doorbell_pressed", {"raw_tag": "ring_button_pressed"}
-        )
+        entity._trigger_event.assert_called_once_with("ring", {"raw_tag": "ring_button_pressed"})
         entity.async_write_ha_state.assert_called_once()
 
     def test_handle_event_does_not_fire_bus_event(self) -> None:

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1776,6 +1776,35 @@ class TestParseAndFireEventDeviceRouting:
         for call in listener._hass.loop.call_soon_threadsafe.call_args_list:
             assert call[0][0] is not coordinator.apply_push_device_motion
 
+    def test_motion_resolves_via_twin_alias(self) -> None:
+        # The push carries the Jeweller twin id (310A8DF4), which is gone after
+        # the #173 dedup; the surviving video_edge sibling is 9c756e2bca39-0.
+        # The twin→sibling alias must let motion attribute to the real device
+        # (the exact miss in Bruno's #173 capture: resolved=None → hub only).
+        listener, coordinator = self._make_listener(
+            {"9c756e2bca39-0": self._doorbell_device("9c756e2bca39-0")}
+        )
+        coordinator.doorbell_twin_aliases = {"310A8DF4": "9c756e2bca39-0"}
+
+        self._fire(listener, "motion", {"device_id": "310A8DF4", "device_name": "Deurbel"})
+
+        listener._hass.loop.call_soon_threadsafe.assert_any_call(
+            coordinator.apply_push_device_motion, "9c756e2bca39-0"
+        )
+
+    def test_doorbell_resolves_via_twin_alias(self) -> None:
+        listener, coordinator = self._make_listener(
+            {"9c756e2bca39-0": self._doorbell_device("9c756e2bca39-0")}
+        )
+        coordinator.doorbell_twin_aliases = {"310A8DF4": "9c756e2bca39-0"}
+
+        self._fire(
+            listener, "doorbell_pressed", {"device_id": "310A8DF4", "device_name": "Deurbel"}
+        )
+
+        coordinator.fire_push_device_event.assert_called_once()
+        assert coordinator.fire_push_device_event.call_args[0][0] == "9c756e2bca39-0"
+
 
 class TestParseAndFireEventThreadSafety:
     """The FCM callback runs on the firebase_messaging worker thread, so every


### PR DESCRIPTION
From @brunovdw68's `1.7.0-beta.6` capture — two issues:

## 1. Motion not attributed to the doorbell
The doorbell ring now lands on the doorbell card, but **motion** still only hit the hub event (`resolved=None` in the log). The push carries the Jeweller **twin id** (`310A8DF4`), but the #173 dedup drops that twin in favour of the `video_edge` sibling (`9c756e2bca39-0`), so the id isn't in the device set. Doorbell survived only via the single-doorbell fallback; motion has no such fallback (it's shared with PIR sensors), so it resolved to nothing.

**Fix:** the dedup now records a `{twin id → surviving video_edge id}` alias map, and push attribution resolves through it. Motion (and doorbell) now attribute to the real device by id — robust even for multi-doorbell installs, and motion from a genuine PIR still resolves to the PIR (no blanket fallback).

## 2. Doorbell entity missing the canonical `ring` event type
HA logs: *`event.deurbel_doorbell` is a doorbell event entity but does not support the `ring` event type. This will stop working in Home Assistant 2027.4.* Our entity had `device_class=doorbell` but advertised `doorbell_pressed`. It now advertises and emits **`ring`** (internal routing key unchanged); state translations rekeyed across all 14 locales.

## Tests
- Alias map recorded on dedup; motion + doorbell resolve via the alias.
- `ring` event type advertised and emitted.
- Full suite green (1492 tests, 87.91%).

Related to #173