### PR TITLE
fix(doorbell): run motion auto-off on the loop, not the executor (#173)

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -9,6 +9,7 @@ import time
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -1010,10 +1011,14 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         cancel = self._motion_off_cancels.pop(device_id, None)
         if cancel is not None:
             cancel()
+        # The action MUST be a HA `@callback`: async_call_later classifies a
+        # plain sync function as an executor job and runs it in a worker thread,
+        # where `_clear_device_motion`'s `async_set_updated_data` would write
+        # entity state off-loop (the RuntimeError storm in #173 on beta.8).
         self._motion_off_cancels[device_id] = async_call_later(
             self.hass,
             MOTION_PUSH_AUTO_OFF_SECONDS,
-            lambda _now: self._clear_device_motion(device_id),
+            callback(lambda _now: self._clear_device_motion(device_id)),
         )
 
     def _clear_device_motion(self, device_id: str) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1411,6 +1411,25 @@ class TestApplyPushDeviceMotion:
 
         call_later.assert_called_once()
 
+    def test_auto_off_is_scheduled_as_loop_callback(self) -> None:
+        """Regression (#173): the auto-off action must be a HA `@callback` so
+        `async_call_later` runs it on the event loop. A plain lambda is
+        classified as a sync job and run in the executor (SyncWorker) thread,
+        where its `async_set_updated_data` raises the off-loop
+        `async_write_ha_state` RuntimeError storm Bruno hit on beta.8."""
+        from homeassistant.core import is_callback
+
+        coordinator = self._make_coordinator_with_device()
+
+        with patch("homeassistant.helpers.event.async_call_later") as call_later:
+            coordinator.apply_push_device_motion("doorbell-1")
+
+        action = call_later.call_args.args[2]
+        assert is_callback(action), (
+            "auto-off action is not a HA callback; async_call_later would run it "
+            "in the executor thread and async_set_updated_data would be off-loop"
+        )
+
 
 class TestApplyPushGroupSecurityState:
     """Per-group arm/disarm push updates (#148): only the matching Group is


### PR DESCRIPTION
## Problem

@brunovdw68 confirmed on `1.7.0-beta.8` that video-doorbell **motion and ring now both land on the doorbell card** — the #173 attribution fix works. But his log also showed a storm of ~240 `RuntimeError: ... calls async_write_ha_state from a thread other than the event loop` errors (one per entity), firing ~30 s after each motion push.

## Root cause

The motion-**on** path is correctly marshalled onto the loop (`_dispatch_to_loop` → `call_soon_threadsafe`), and it runs on `MainThread` in the log. The **auto-off** is scheduled by passing a plain lambda to `async_call_later`:

```python
async_call_later(self.hass, SECS, lambda _now: self._clear_device_motion(device_id))
```

HomeAssistant wraps the action in a `HassJob` and classifies a non-`@callback` sync function as an **executor** job — so when the timer fires it runs `_clear_device_motion` in a worker thread (`SyncWorker_2` in the log), and its `async_set_updated_data` writes entity state **off-loop**. That's exactly the corruption HA's thread-safety check raises on, and it fans out to one error per listening entity.

## Fix

Wrap the scheduled action in `homeassistant.core.callback` so the `HassJob` is typed as a callback and `async_call_later` runs it **inline on the loop**.

Audited the only other delayed scheduler (`__init__`'s `async_track_time_interval(_photo_cleanup)`) — its target is a coroutine function, which HA already runs on the loop, so no change needed.

## Test

New regression test asserts the action passed to `async_call_later` satisfies `is_callback()` (fails on the old plain lambda, passes with the wrapper). `make check` green without volume mount: 1495 passed, 88% cov.

This is the last blocker before the stable 1.7.0 rollup. Refs #173