### PR TITLE
fix(binary_sensor): map leak sensor to leak_protect, not leaks_protect (#211)

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -269,7 +269,10 @@ _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
         "high_temperature",
         "tamper",
     ],
-    "leaks_protect": ["leak_detected", "tamper"],
+    # `leak_protect` is the device_type `parse_device` emits (the ObjectType
+    # oneof field name, object_type.proto field 22). The old `leaks_protect`
+    # key never matched, so no LeakProtect ever got its leak sensor (#211).
+    "leak_protect": ["leak_detected", "tamper"],
     "home_siren": ["tamper"],
     "home_siren_s": ["tamper"],
     "home_siren_fibra": ["tamper"],

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -405,8 +405,12 @@ class TestDeviceTypeSensors:
     def test_fire_protect_plus_has_co(self) -> None:
         assert "co_detected" in _DEVICE_TYPE_SENSORS["fire_protect_plus"]
 
-    def test_leaks_protect_has_leak(self) -> None:
-        assert "leak_detected" in _DEVICE_TYPE_SENSORS["leaks_protect"]
+    def test_leak_protect_has_leak(self) -> None:
+        # #211: key must be `leak_protect` — the device_type `parse_device`
+        # emits (ObjectType oneof field name). The old plural `leaks_protect`
+        # never matched, so LeakProtect units showed no leak sensor.
+        assert "leak_detected" in _DEVICE_TYPE_SENSORS["leak_protect"]
+        assert "leaks_protect" not in _DEVICE_TYPE_SENSORS
 
     def test_door_protect_s_in_device_types(self) -> None:
         assert "door_protect_s" in _DEVICE_TYPE_SENSORS


### PR DESCRIPTION
## Problem

@lexius reported that his LeakProtect units show no leak/water status sensor — only the generic tamper/temperature/battery entities. His diagnostics confirm all four units arrive as `type: leak_protect`.

## Root cause

The per-device sensor map keyed the leak (moisture) binary_sensor on `leaks_protect` (plural), but `parse_device` emits `leak_protect` — the `ObjectType` oneof field name (`object_type.proto` field 22). The key **never matched**, so no LeakProtect unit has ever gotten its leak binary_sensor; only the status-driven generic entities appeared.

## Fix

Rename the map key `leaks_protect` → `leak_protect` (one line). The pre-existing test asserted the buggy plural key — so it passed while the feature was broken; updated to assert the real device_type and that the plural key is gone.

Note: the entity is created from the device_type regardless of current state, so a dry sensor will correctly show "Dry"; it turns wet when the `leak_detected` status arrives.

`make check` green without volume mount (1495 passed, 88% cov). Refs #211