### PR TITLE
feat(lock): log the SmartLock failure sub-case in the #206 probe

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -48,6 +48,19 @@ def _override_client_version(
     return [(k, version if k == "client-version-major" else v) for k, v in metadata]
 
 
+def _failure_error_case(response: Any, which: str) -> str | None:  # noqa: ANN401
+    """For a SmartLock response whose top-level oneof is `failure`, return the
+    inner error oneof case (e.g. `space_armed`, `external_service_access_denied`)
+    so the #206 probe records *why* a call failed, not just that it did."""
+    if which != "failure":
+        return None
+    try:
+        error = response.failure.WhichOneof("error")
+    except Exception:  # noqa: BLE001
+        return None
+    return error if isinstance(error, str) else None
+
+
 class SmartLockError(Exception):
     """Raised when a SwitchSmartLockService call fails."""
 
@@ -657,7 +670,10 @@ class DevicesApi:
         which = response.WhichOneof("response")
         if which != "success":
             _LOGGER.debug(
-                "SmartLock probe (#206) findAllBySpace (cv=%s) returned %s", version, which
+                "SmartLock probe (#206) findAllBySpace (cv=%s) returned %s (error=%s)",
+                version,
+                which,
+                _failure_error_case(response, which),
             )
             return
         locks = response.success.smart_locks
@@ -702,9 +718,10 @@ class DevicesApi:
         which = response.WhichOneof("response")
         if which != "success":
             _LOGGER.debug(
-                "SmartLock probe (#206) findAllAvailableToAdd (type=%s) returned %s",
+                "SmartLock probe (#206) findAllAvailableToAdd (type=%s) returned %s (error=%s)",
                 lock_type,
                 which,
+                _failure_error_case(response, which),
             )
             return
         locks = response.success.smart_locks

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -2779,6 +2779,42 @@ class TestSmartLockProbe:
         )
 
     @pytest.mark.asyncio
+    async def test_probe_logs_failure_error_case(self, caplog: pytest.LogCaptureFixture) -> None:
+        """#206 beta.12: a `failure` response must log the inner error oneof
+        (e.g. `space_armed`), not just `failure` — that sub-case decides whether
+        HA-side lock control is fixable or a backend limitation."""
+        import logging as _logging  # noqa: PLC0415
+
+        from systems.ajax.api.mobile.v2.space.smartlock import (  # noqa: PLC0415
+            find_all_available_to_add_pb2,
+            find_all_by_space_pb2,
+        )
+
+        failed = find_all_available_to_add_pb2.FindAllSmartLocksAvailableToAddResponse()
+        failed.failure.external_service_access_denied.SetInParent()
+
+        api = self._make_api()
+        stub = MagicMock()
+        stub.findAllBySpace = AsyncMock(
+            return_value=find_all_by_space_pb2.FindAllSmartLocksBySpaceResponse()
+        )
+        stub.findAllAvailableToAdd = AsyncMock(return_value=failed)
+
+        with (
+            caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"),
+            self._patch_stub(stub),
+        ):
+            await api.probe_smart_locks("space-1", ["31524B92"])
+
+        msgs = [r.message for r in caplog.records]
+        assert any(
+            "findAllAvailableToAdd" in m
+            and "returned failure" in m
+            and "error=external_service_access_denied" in m
+            for m in msgs
+        )
+
+    @pytest.mark.asyncio
     async def test_probe_disabled_without_debug(self, caplog: pytest.LogCaptureFixture) -> None:
         import logging as _logging  # noqa: PLC0415
 


### PR DESCRIPTION
## Context

beta.9's probe log from @SebastianKristo answered two of three questions:

- `findAllBySpace` returns **0 locks at both `cv=3.30` and `cv=3.60`** → not a client-version gate.
- `findAllAvailableToAdd` (type 1 and 2) returns a **failure**.

But the probe logged only the top-level `failure` oneof, not the **inner error case**. That sub-case — `external_service_access_denied` / `permission_denied` / `bad_request` / `space_not_found` / `space_armed` — is exactly what decides whether HA-side lock control is fixable (e.g. `space_armed` is transient) or a backend limitation (e.g. `external_service_access_denied` = the Yale/Assa Abloy locks are managed by an external service this account can't reach, consistent with the Svenska third-party backend).

## Change

Adds `_failure_error_case()` and logs it on both `findAllBySpace` and `findAllAvailableToAdd` non-success responses (`returned failure (error=...)`). Read-only, DEBUG-gated, no behaviour change.

`make check` green without volume mount (1496 passed, 88% cov). Refs #206