### PR TITLE
feat(sensor): siren internal temperature sensor (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0-beta.1] - 2026-05-31
+
+### Added
+- **HomeSiren / StreetSiren internal temperature sensor (#220).** Sirens report their temperature in the Ajax app but not in the device stream we run continuously, so no sensor appeared. The value is now pulled from the per-device `StreamHubDevice` snapshot on a throttled cycle (every 15 min — temperature is slow-moving) and surfaced as the standard temperature sensor. Covers `street_siren`, `street_siren_plus_g3`, `home_siren`, `home_siren_g3`, `home_siren_s` and `home_siren_fibra`. The value is preserved across stream snapshots so the sensor doesn't flicker to `unknown`. Buzzer/sounding state is not included (it needs a different signal path).
+
 ## [1.7.0] - 2026-05-30
 
 Doorbell, lock and bypass improvements, plus thread-safety and reliability fixes. Consolidates the 1.6.2-beta and 1.7.0-beta series.

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -229,6 +229,44 @@ class DevicesApi:
 
         return self._dedupe_and_track_aliases(devices)
 
+    async def get_hub_device_temperature(self, hub_id: str, hub_device_id: str) -> float | None:
+        """Read one device's internal temperature via `StreamHubDevice` (#220).
+
+        A per-device stream (`hub_id` + `hub_device_id`) whose first
+        `success.snapshot` carries the rich `HubDevice` proto. Sirens expose
+        their temperature here but not in the lighter `StreamLightDevices`
+        stream. We read the first snapshot and stop — temperature is slow and
+        the `Success` oneof has no delta case anyway. Returns `None` on a
+        `failure` response (e.g. a hub-attached device not addressable on this
+        backend, cf. #206) or an empty stream; gRPC errors propagate to the
+        caller, which guards each device individually.
+        """
+        from v3.mobilegwsvc.service.stream_hub_device import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.StreamHubDeviceServiceStub(channel)
+        request = request_pb2.StreamHubDeviceRequest(hub_id=hub_id, hub_device_id=hub_device_id)
+        stream = stub.execute(request, metadata=metadata, timeout=10)
+
+        async for msg in stream:
+            if msg.HasField("success"):
+                if msg.success.WhichOneof("success") == "snapshot":
+                    return devices_parser.parse_hub_device_temperature(
+                        msg.success.snapshot.hub_device
+                    )
+            elif msg.HasField("failure"):
+                _LOGGER.debug(
+                    "StreamHubDevice failed for device %s: %s",
+                    hub_device_id,
+                    msg.failure,
+                )
+                break
+        return None
+
     def _handle_update(
         self,
         update: Any,  # noqa: ANN401

--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -548,6 +548,32 @@ def parse_device(proto_light_device: Any) -> Device | None:  # noqa: ANN401
     return None
 
 
+def parse_hub_device_temperature(hub_device: Any) -> float | None:  # noqa: ANN401
+    """Pull the internal temperature out of a rich `HubDevice` proto (#220).
+
+    The per-device `StreamHubDevice` RPC returns a `HubDevice` whose
+    `device` oneof selects a per-type message (`street_siren`,
+    `home_siren`, …). Siren-family messages carry a `device_temperature`
+    (`DeviceTemperature { value, is_extreme }`) that the lighter
+    `StreamLightDevices` stream omits for sirens — so this is the only
+    path to a siren's temperature. Returns the value as a float, or
+    `None` when the oneof is unset, the sub-message has no
+    `device_temperature`, or anything about the shape is unexpected.
+    """
+    which = hub_device.WhichOneof("device") if hasattr(hub_device, "WhichOneof") else None
+    if which is None:
+        return None
+    sub = getattr(hub_device, which, None)
+    if sub is None or not hasattr(sub, "HasField"):
+        return None
+    try:
+        if not sub.HasField("device_temperature"):
+            return None
+        return float(sub.device_temperature.value)
+    except (ValueError, TypeError):
+        return None
+
+
 def _dedupe_video_doorbells(devices: list[Device]) -> tuple[list[Device], dict[str, str]]:
     """Drop `motion_cam_video_*` hub_device twins that have a
     `video_edge_*` sibling with a matching name in the same snapshot.

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -147,6 +147,24 @@ MAX_RETRIES = 3
 RATE_LIMIT_REQUESTS = 60
 RATE_LIMIT_WINDOW = 60  # seconds
 
+# Siren internal temperature (#220). Sirens report their temperature only in
+# the rich per-device `StreamHubDevice` snapshot, not in the lighter
+# `StreamLightDevices` stream we run continuously. We pull it with a throttled
+# one-shot snapshot per siren — temperature is slow-moving and a persistent
+# per-device stream would contradict how the Ajax app uses that endpoint.
+SIREN_TEMP_REFRESH_INTERVAL = 900  # seconds (15 min)
+# Device types whose `HubDevice` oneof case carries a `device_temperature`.
+SIREN_TEMPERATURE_DEVICE_TYPES = frozenset(
+    {
+        "street_siren",
+        "street_siren_plus_g3",
+        "home_siren",
+        "home_siren_g3",
+        "home_siren_s",
+        "home_siren_fibra",
+    }
+)
+
 
 class SecurityState(IntEnum):
     """Maps DisplayedSpaceSecurityState proto enum."""

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -34,6 +34,8 @@ from custom_components.aegis_ajax.const import (
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
     MOTION_PUSH_AUTO_OFF_SECONDS,
+    SIREN_TEMP_REFRESH_INTERVAL,
+    SIREN_TEMPERATURE_DEVICE_TYPES,
     ConnectionStatus,
 )
 from custom_components.aegis_ajax.device_cache import DevicesCache
@@ -156,6 +158,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Rooms rarely change — cache and refresh once per hour. None means
         # never fetched yet so the first poll always populates rooms.
         self._rooms_last_fetch: float | None = None
+        # Siren internal temperature (#220) — throttled one-shot refresh.
+        # None means never fetched so the first poll populates it.
+        self._siren_temp_last_fetch: float | None = None
         # HTS client for hub network data (ethernet, wifi, gsm, power)
         self._hts_client: HtsClient | None = None
         self._hts_task: asyncio.Task[None] | None = None
@@ -283,6 +288,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self._first_startup_init()
                 return {"spaces": self.spaces, "devices": self.devices}
             await self._maybe_fallback_device_snapshot()
+            await self._maybe_refresh_device_temperatures(now)
             await self._maybe_restart_hts()
             self._last_update_success_time = dt_util.utcnow()
             return {"spaces": self.spaces, "devices": self.devices}
@@ -447,6 +453,47 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
         self.rooms = refreshed_rooms
         self._rooms_last_fetch = now
+
+    async def _maybe_refresh_device_temperatures(self, now: float) -> None:
+        """Throttled one-shot refresh of siren internal temperature (#220).
+
+        Sirens don't carry a `temperature` status in the `StreamLightDevices`
+        stream the way motion/door sensors do, so the auto-created temperature
+        sensor never appears for them. The value lives in the rich per-device
+        `StreamHubDevice` snapshot instead. We pull it once per
+        `SIREN_TEMP_REFRESH_INTERVAL` for each siren that doesn't already have
+        a temperature, and merge it into `device.statuses["temperature"]` —
+        which is all `sensor.py` needs to materialise the sensor.
+        """
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        if (
+            self._siren_temp_last_fetch is not None
+            and now - self._siren_temp_last_fetch <= SIREN_TEMP_REFRESH_INTERVAL
+        ):
+            return
+        for device_id, device in list(self.devices.items()):
+            if (
+                device.device_type not in SIREN_TEMPERATURE_DEVICE_TYPES
+                or "temperature" in device.statuses
+            ):
+                continue
+            try:
+                temperature = await self._devices_api.get_hub_device_temperature(
+                    device.hub_id, device_id
+                )
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Failed to fetch temperature for siren %s", device_id, exc_info=True)
+                continue
+            if temperature is None:
+                continue
+            current = self.devices.get(device_id)
+            if current is None:
+                continue
+            self.devices[device_id] = dc_replace(
+                current, statuses={**current.statuses, "temperature": temperature}
+            )
+        self._siren_temp_last_fetch = now
 
     async def _first_startup_init(self) -> None:
         """First-cycle bootstrap: warm devices cache, start persistent
@@ -848,6 +895,28 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _handle_devices_snapshot(self, devices: list[Device]) -> None:
         """Handle initial snapshot or full device snapshot update from stream."""
         for device in devices:
+            # Siren temperature (#220) comes from a separate per-device RPC,
+            # not this stream, so a fresh snapshot would wipe the value we
+            # merged in `_maybe_refresh_device_temperatures` and the throttle
+            # would leave the sensor `unknown` until the next refresh. Carry
+            # the previously-merged temperature forward (it's slow-moving;
+            # the periodic refresh still updates it).
+            existing = self.devices.get(device.id)
+            if (
+                existing is not None
+                and device.device_type in SIREN_TEMPERATURE_DEVICE_TYPES
+                and "temperature" not in device.statuses
+                and "temperature" in existing.statuses
+            ):
+                from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+                device = dc_replace(
+                    device,
+                    statuses={
+                        **device.statuses,
+                        "temperature": existing.statuses["temperature"],
+                    },
+                )
             self.devices[device.id] = device
         # `DevicesApi` dedups video-doorbell twins per snapshot, but the merge
         # above only ever *adds* keys — a `motion_cam_video_*` ghost that was

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.7.0"
+    "version": "1.8.0-beta.1"
 }

--- a/docs/superpowers/specs/2026-05-30-siren-temperature-design.md
+++ b/docs/superpowers/specs/2026-05-30-siren-temperature-design.md
@@ -1,0 +1,95 @@
+# Siren internal temperature sensor (#220)
+
+## Problem
+
+HomeSiren / StreetSiren devices report their internal temperature in the Ajax
+app, but the integration does not expose it. Motion/door devices already get a
+temperature sensor because the `StreamLightDevices` stream we consume carries a
+`temperature` entry in `LightDeviceProfile.statuses` for them. For sirens the
+server omits that status entry, so no sensor is created.
+
+Buzzer / sounding state is **out of scope** here — `CommonSirenPart` only carries
+settings/capabilities, and the live "is sounding" signal is almost certainly an
+alarm event (FCM), not a polled status. Tracked separately.
+
+## Where the value lives
+
+The siren temperature is carried by a different RPC, `StreamHubDevice`
+(`v3/mobilegwsvc/service/stream_hub_device`):
+
+- `StreamHubDeviceResponse.Success.Snapshot.hub_device` → `HubDevice`
+- `HubDevice` has a per-type `device` oneof; each siren case
+  (`street_siren`, `street_siren_plus_g3`, `home_siren`, `home_siren_g3`,
+  `home_siren_s`, `home_siren_fibra`) carries
+  `device_temperature` (`DeviceTemperature { value: int32 (field 1),
+  is_extreme: bool (field 2) }`).
+
+All required protos are already compiled. The Ajax app renders this via
+`DeviceInfoController.buildTemperatureSensorParts`, so it is a consumed value,
+not a dead field.
+
+## Approach: throttled one-shot snapshot (not a persistent stream)
+
+`StreamHubDeviceRequest` takes `hub_id` + `hub_device_id` — it is a **per-device**
+stream, and `Success` only has a `snapshot` case (no deltas). A persistent
+stream would mean one held-open connection *per siren* for a value that barely
+changes, contradicting how the app uses the endpoint (transient, on device-detail
+open). A throttled one-shot (open → read first snapshot → close) mirrors the
+app's usage and minimises Ajax backend load. It also avoids a second persistent
+asyncio task / reconnect loop in HA, hanging off the existing poll cycle instead.
+
+## Components
+
+1. **`devices_parser.parse_hub_device_temperature(hub_device_proto) -> float | None`**
+   - `which = hub_device.WhichOneof("device")`; `getattr(hub_device, which)`.
+   - If the sub-message `HasField("device_temperature")`, return
+     `device_temperature.value` as float; else `None`. Defensive: any
+     missing-field / unknown-type path returns `None`.
+
+2. **`DevicesApi.get_hub_device_temperature(hub_id, hub_device_id) -> float | None`**
+   - Mirrors `get_devices_snapshot`: open `StreamHubDeviceService` stub, send
+     `StreamHubDeviceRequest(hub_id, hub_device_id)`, `timeout≈10s`, read first
+     `success.snapshot`, parse, `break`. `failure` → log debug, return `None`.
+     gRPC errors caught by caller.
+
+3. **`coordinator._maybe_refresh_device_temperatures(now)`** — throttled sub-step
+   in `_async_update_data`, same shape as `_maybe_refresh_rooms`.
+   - Interval `SIREN_TEMP_REFRESH_INTERVAL = 900` (15 min); guarded by a
+     `_siren_temp_last_fetch` timestamp.
+   - For each device whose `device_type` ∈ `SIREN_TEMPERATURE_DEVICE_TYPES`
+     **and** that does not already have `"temperature"` in `statuses`:
+     call `get_hub_device_temperature`; on a non-None result, merge into
+     `device.statuses["temperature"]` via `dataclasses.replace`.
+   - Per-device try/except: one failure must not break the refresh.
+
+4. **`const.py`** — add `SIREN_TEMPERATURE_DEVICE_TYPES` (the 6 oneof types
+   above) and `SIREN_TEMP_REFRESH_INTERVAL = 900`.
+
+5. **`sensor.py`** — **no change**. It already creates a temperature sensor for
+   any device with `"temperature" in statuses`; the merge makes the sensor
+   appear automatically.
+
+## Error handling
+
+- Stream `failure` (`device_not_found` / `bad_request`) → debug log, skip device.
+  Some hub-attached sirens on third-party backends may not be addressable (cf.
+  the #206 Yale locks); the refresh must degrade gracefully, never raise.
+- Bounded per-device `timeout` so a hung device cannot stall `_async_update_data`.
+- `CancelledError` discrimination already handled at the `_async_update_data`
+  level (#148); we do not add new swallowing there.
+
+## Testing (TDD)
+
+- `parse_hub_device_temperature`: real `HubDevice` proto per siren type →
+  correct value; type without `device_temperature` / unknown oneof → `None`.
+- `get_hub_device_temperature`: mocked stub yielding a snapshot → value;
+  yielding `failure` → `None`.
+- `_maybe_refresh_device_temperatures`: merges temperature into the matching
+  device's `statuses`; respects the throttle; skips devices that already have
+  `temperature`; one device error doesn't abort the others.
+
+## Out of scope
+
+- Buzzer / sounding binary_sensor (needs an FCM alarm-event capture).
+- `is_extreme` flag (could later become a sensor attribute / problem binary_sensor).
+- Extending the rich `StreamHubDevice` model to non-siren device types.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aegis-ajax-hass"
 # Mirror of manifest.json's version (the source of truth HA reads). Kept in
 # sync by tests/unit/test_version_consistency.py — bump both when releasing.
-version = "1.7.0"
+version = "1.8.0-beta.1"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1971,3 +1971,138 @@ class TestSmartLockProbeOrchestration:
 
         coordinator._devices_api.probe_smart_locks.assert_not_called()
         assert coordinator._smart_lock_probe_done is True
+
+
+def _make_siren(device_id: str, *, statuses: dict | None = None) -> Device:
+    return Device(
+        id=device_id,
+        hub_id="hub-1",
+        name="Siren",
+        device_type="street_siren",
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses=statuses if statuses is not None else {},
+        battery=None,
+    )
+
+
+class TestMaybeRefreshDeviceTemperatures:
+    @pytest.mark.asyncio
+    async def test_merges_temperature_into_siren_statuses(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {"s1d": _make_siren("s1d")}
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
+
+        await coordinator._maybe_refresh_device_temperatures(100.0)
+
+        assert coordinator.devices["s1d"].statuses["temperature"] == 21.0
+        coordinator._devices_api.get_hub_device_temperature.assert_awaited_once_with("hub-1", "s1d")
+
+    @pytest.mark.asyncio
+    async def test_skips_non_siren_devices(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {"d1": _make_device("d1")}  # door_protect
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
+
+        await coordinator._maybe_refresh_device_temperatures(100.0)
+
+        coordinator._devices_api.get_hub_device_temperature.assert_not_called()
+        assert "temperature" not in coordinator.devices["d1"].statuses
+
+    @pytest.mark.asyncio
+    async def test_skips_siren_that_already_has_temperature(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {"s1d": _make_siren("s1d", statuses={"temperature": 18.0})}
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=99.0)
+
+        await coordinator._maybe_refresh_device_temperatures(100.0)
+
+        coordinator._devices_api.get_hub_device_temperature.assert_not_called()
+        assert coordinator.devices["s1d"].statuses["temperature"] == 18.0
+
+    @pytest.mark.asyncio
+    async def test_throttles_subsequent_calls(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {"s1d": _make_siren("s1d")}
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
+
+        await coordinator._maybe_refresh_device_temperatures(100.0)
+        await coordinator._maybe_refresh_device_temperatures(200.0)  # within interval
+
+        coordinator._devices_api.get_hub_device_temperature.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_none_result_leaves_statuses_untouched(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {"s1d": _make_siren("s1d")}
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=None)
+
+        await coordinator._maybe_refresh_device_temperatures(100.0)
+
+        assert "temperature" not in coordinator.devices["s1d"].statuses
+
+    @pytest.mark.asyncio
+    async def test_one_device_error_does_not_abort_others(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {"bad": _make_siren("bad"), "good": _make_siren("good")}
+
+        async def _temp(hub_id: str, device_id: str) -> float:
+            if device_id == "bad":
+                raise RuntimeError("boom")
+            return 20.0
+
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(side_effect=_temp)
+
+        await coordinator._maybe_refresh_device_temperatures(100.0)
+
+        assert coordinator.devices["good"].statuses["temperature"] == 20.0
+        assert "temperature" not in coordinator.devices["bad"].statuses
+
+    @pytest.mark.asyncio
+    async def test_wired_into_async_update_data(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator.devices = {"s1d": _make_siren("s1d")}
+        # Healthy streams + live HTS so the unrelated post-startup sub-steps
+        # (fallback snapshot / HTS restart) stay no-ops.
+        coordinator._stream_tasks = [MagicMock(done=MagicMock(return_value=False))]
+        coordinator._hts_client = MagicMock()
+        coordinator._hts_task = MagicMock(done=MagicMock(return_value=False))
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=22.0)
+
+        await coordinator._async_update_data()
+
+        assert coordinator.devices["s1d"].statuses["temperature"] == 22.0
+
+    def test_snapshot_preserves_merged_siren_temperature(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._devices_cache = None
+        coordinator.async_set_updated_data = MagicMock()
+        # A siren already carrying a temperature merged from StreamHubDevice.
+        coordinator.devices = {"s1d": _make_siren("s1d", statuses={"temperature": 22.0})}
+
+        # A fresh stream snapshot for the same siren WITHOUT temperature
+        # (the light stream never carries siren temperature).
+        coordinator._handle_devices_snapshot([_make_siren("s1d")])
+
+        assert coordinator.devices["s1d"].statuses["temperature"] == 22.0
+
+    def test_snapshot_does_not_invent_temperature_for_non_siren(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._devices_cache = None
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.devices = {"d1": replace(_make_device("d1"), statuses={"temperature": 18.0})}
+
+        # A door_protect is not in the siren set; carry-forward must not apply.
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert "temperature" not in coordinator.devices["d1"].statuses

--- a/tests/unit/test_siren_temperature.py
+++ b/tests/unit/test_siren_temperature.py
@@ -1,0 +1,135 @@
+"""Tests for siren internal temperature via the per-device StreamHubDevice RPC (#220)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Wire up the proto search path before any `systems.*` import.
+from custom_components.aegis_ajax.api import _proto_path as _proto_path  # noqa: E402, F401
+from custom_components.aegis_ajax.api.devices import DevicesApi  # noqa: E402
+from custom_components.aegis_ajax.api.devices_parser import (  # noqa: E402
+    parse_hub_device_temperature,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from contextlib import AbstractContextManager
+
+    from google.protobuf.message import Message
+
+
+def _hub_device_with_siren_temperature(value: int, *, is_extreme: bool = False) -> Message:
+    from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import (
+        hub_device_pb2,
+        street_siren_pb2,
+    )
+    from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device.common import (
+        device_temperature_pb2,
+    )
+
+    return hub_device_pb2.HubDevice(
+        street_siren=street_siren_pb2.StreetSiren(
+            device_temperature=device_temperature_pb2.DeviceTemperature(
+                value=value, is_extreme=is_extreme
+            )
+        )
+    )
+
+
+class TestParseHubDeviceTemperature:
+    def test_returns_value_for_street_siren(self) -> None:
+        hub_device = _hub_device_with_siren_temperature(23)
+        assert parse_hub_device_temperature(hub_device) == 23.0
+
+    def test_returns_value_for_home_siren(self) -> None:
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import (
+            home_siren_pb2,
+            hub_device_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device.common import (
+            device_temperature_pb2,
+        )
+
+        hub_device = hub_device_pb2.HubDevice(
+            home_siren=home_siren_pb2.HomeSiren(
+                device_temperature=device_temperature_pb2.DeviceTemperature(value=19)
+            )
+        )
+        assert parse_hub_device_temperature(hub_device) == 19.0
+
+    def test_returns_none_when_device_temperature_absent(self) -> None:
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import (
+            hub_device_pb2,
+            street_siren_pb2,
+        )
+
+        hub_device = hub_device_pb2.HubDevice(street_siren=street_siren_pb2.StreetSiren())
+        assert parse_hub_device_temperature(hub_device) is None
+
+    def test_returns_none_when_no_device_oneof_set(self) -> None:
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import hub_device_pb2
+
+        assert parse_hub_device_temperature(hub_device_pb2.HubDevice()) is None
+
+
+def _patch_stream_hub_device(stub_class: MagicMock) -> AbstractContextManager[None]:
+    mock_request_pb2 = MagicMock()
+    mock_grpc_module = MagicMock(StreamHubDeviceServiceStub=stub_class)
+    return patch.dict(
+        "sys.modules",
+        {
+            "v3.mobilegwsvc.service.stream_hub_device.endpoint_pb2_grpc": mock_grpc_module,
+            "v3.mobilegwsvc.service.stream_hub_device.request_pb2": mock_request_pb2,
+            "v3.mobilegwsvc.service.stream_hub_device": MagicMock(
+                endpoint_pb2_grpc=mock_grpc_module,
+                request_pb2=mock_request_pb2,
+            ),
+        },
+    )
+
+
+def _stub_yielding(msg: MagicMock) -> MagicMock:
+    async def _aiter(*args: object, **kwargs: object) -> AsyncGenerator[MagicMock, None]:
+        yield msg
+
+    stub_instance = MagicMock()
+    stub_instance.execute.return_value = _aiter()
+    return MagicMock(return_value=stub_instance)
+
+
+class TestGetHubDeviceTemperature:
+    @pytest.mark.asyncio
+    async def test_returns_temperature_from_snapshot(self) -> None:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        api = DevicesApi(client)
+
+        hub_device = _hub_device_with_siren_temperature(21)
+        msg = MagicMock()
+        msg.HasField.side_effect = lambda field: field == "success"
+        msg.success.WhichOneof.return_value = "snapshot"
+        msg.success.snapshot.hub_device = hub_device
+
+        with _patch_stream_hub_device(_stub_yielding(msg)):
+            result = await api.get_hub_device_temperature("hub-1", "dev-1")
+
+        assert result == 21.0
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_failure_message(self) -> None:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        api = DevicesApi(client)
+
+        msg = MagicMock()
+        msg.HasField.side_effect = lambda field: field == "failure"
+
+        with _patch_stream_hub_device(_stub_yielding(msg)):
+            result = await api.get_hub_device_temperature("hub-1", "dev-1")
+
+        assert result is None


### PR DESCRIPTION
Adds a temperature sensor for HomeSiren / StreetSiren devices (#220).

## Why
Sirens report their internal temperature in the Ajax app, but it doesn't arrive in the `StreamLightDevices` stream the integration runs continuously (motion/door sensors do carry a `temperature` status there, sirens don't). So the auto-created temperature sensor never appeared for sirens.

## Where the value lives
The temperature is carried by the per-device `StreamHubDevice` RPC: `Success.Snapshot.hub_device` → `HubDevice` whose per-type `device` oneof (`street_siren`, `home_siren`, …) exposes `device_temperature` (`DeviceTemperature { value, is_extreme }`). The Ajax app renders this same field, so it's a consumed value, not a dead one.

## Approach
A **throttled one-shot snapshot** (open → read first snapshot → close) per siren, every `SIREN_TEMP_REFRESH_INTERVAL` (15 min). `StreamHubDevice` is a per-device stream with no delta case, so a persistent stream would mean one held-open connection per siren — heavy on the Ajax backend and against how the app uses the endpoint — for a slow-moving value. Hangs off the existing poll cycle (mirrors `_maybe_refresh_rooms`), no second persistent task.

The merged temperature is merged into `device.statuses["temperature"]` (so `sensor.py` materialises the standard temperature sensor with no platform change) and carried forward across stream snapshots so it doesn't flicker to `unknown`.

## Out of scope
- Buzzer / sounding state (needs a different signal path; likely an FCM alarm event).
- `is_extreme` flag.

## Testing
- `parse_hub_device_temperature`: real `HubDevice` protos per siren type; absent/unknown → `None`.
- `get_hub_device_temperature`: mocked stub (snapshot → value; failure → `None`).
- coordinator: merge, throttle, skip non-siren, skip already-has-temperature, per-device error isolation, wiring through `_async_update_data`, and snapshot carry-forward.
- Full suite: 1511 passed, 88% coverage; ruff/format/mypy/vulture clean (no-volume-mount image).

Refs #220