### PR TITLE
feat(alarm): Alexa / HA Cloud support — ARM_HOME + code_format (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0-beta.2] - 2026-05-31
+
+### Added
+- **Alexa / Home Assistant Cloud support for the alarm panel (#221).** The alarm panel now advertises `ARM_HOME` and reports `code_format: number` when a PIN is configured, which makes the Nabu Casa / Alexa skill discover the panel (it wouldn't discover a panel exposing Night without Home) and lets the Home Assistant Lovelace alarm card render a numeric keypad. Ajax has a single partial-arm mode ("Night mode"), so **Arm Home** maps to it just like **Arm Night** — both settle to `armed_night`; it is kept under both names to cover the HA/Alexa convention (Home) and Ajax's own term (Night). For per-group panels, Arm Home maps to the single group-arm command. Alexa caveats (documented in the README): the panel must not require a code to arm to be discovered, and Alexa's voice PIN disarm only supports 4-digit codes.
+
 ## [1.8.0-beta.1] - 2026-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ Photos are automatically cleaned up based on your retention settings (configurab
 
 Both `force_arm` services accept an optional `entity_id` target (alarm control panel entity). If no target is specified, all panels across all configured accounts are armed.
 
+### Arm modes & voice assistants (Alexa via Home Assistant Cloud)
+
+Ajax has a single partial-arm mode (the app calls it **Night mode**) plus full arm. The panel exposes **Arm Away** (full arm) and both **Arm Home** and **Arm Night** for that one partial mode — so "Arm Home" and "Arm Night" do the same thing and both settle the panel to `armed_night`. "Arm Home" is advertised mainly so the **Nabu Casa / Alexa** skill discovers the panel (it won't discover a panel that exposes Night without Home).
+
+Notes for Alexa:
+
+- The skill only exposes a panel that does **not** require a code to arm. If you enable the PIN option (`use_pin_code`), the panel won't be discovered by Alexa.
+- Alexa requests a PIN only on **disarm**, and only supports a **4-digit** numeric code — Ajax PINs longer than 4 digits won't work for voice disarm.
+- When a PIN is configured, the panel reports `code_format: number`, which also makes the Home Assistant Lovelace alarm card render a numeric keypad.
+
 ### Panic button (SOS)
 
 The integration exposes the same panic button that the official Ajax mobile app does. It calls the underlying `SpaceService/pressPanicButton` endpoint.

--- a/custom_components/aegis_ajax/alarm_control_panel.py
+++ b/custom_components/aegis_ajax/alarm_control_panel.py
@@ -11,6 +11,7 @@ from homeassistant.components.alarm_control_panel import (  # type: ignore[attr-
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
+    CodeFormat,
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -282,6 +283,18 @@ class _AjaxAlarmPanelBase(CoordinatorEntity[AjaxCobrandedCoordinator], AlarmCont
         return bool(self._get_options().get("use_pin_code", False))
 
     @property
+    def code_format(self) -> CodeFormat | None:
+        """Numeric keypad when a PIN is configured, otherwise no code entry.
+
+        Returning `CodeFormat.NUMBER` makes the Lovelace alarm card render a
+        numeric keypad and lets the Nabu Casa / Alexa skill prompt for a PIN on
+        disarm. `None` (no PIN configured) keeps the card keypad-free and is
+        also what lets Alexa discover the panel — its skill only exposes panels
+        that don't require a code to arm.
+        """
+        return CodeFormat.NUMBER if self.code_arm_required else None
+
+    @property
     def _force_arm(self) -> bool:
         return bool(self._get_options().get(CONF_FORCE_ARM, False))
 
@@ -337,8 +350,14 @@ class _AjaxAlarmPanelBase(CoordinatorEntity[AjaxCobrandedCoordinator], AlarmCont
 
 class AjaxAlarmControlPanel(_AjaxAlarmPanelBase):
     _attr_name = None
+    # ARM_HOME is advertised mainly for the Nabu Casa / Alexa skill, which
+    # otherwise won't discover a panel exposing ARM_AWAY|ARM_NIGHT (#221).
+    # Ajax has a single partial mode ("Night mode"), so ARM_HOME and ARM_NIGHT
+    # both drive it — both settle to `armed_night`. See README.
     _attr_supported_features = (
-        AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_NIGHT
+        AlarmControlPanelEntityFeature.ARM_AWAY
+        | AlarmControlPanelEntityFeature.ARM_NIGHT
+        | AlarmControlPanelEntityFeature.ARM_HOME
     )
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, space_id: str) -> None:
@@ -392,6 +411,13 @@ class AjaxAlarmControlPanel(_AjaxAlarmPanelBase):
         self._optimistic_state_update(SecurityState.NIGHT_MODE)
         await self.coordinator.async_request_refresh()
 
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Arm home — Ajax has no native home/stay mode, so this maps to its
+        single partial mode (night). Same effect as `arm_night`; the state
+        settles to `armed_night`. Exposed mainly so the Alexa skill discovers
+        the panel and can arm/disarm by voice (#221)."""
+        await self.async_alarm_arm_night(code)
+
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         self._validate_code(code)
         from custom_components.aegis_ajax.api.security import SecurityError  # noqa: PLC0415
@@ -436,7 +462,12 @@ class AjaxGroupAlarmControlPanel(_AjaxAlarmPanelBase):
     surfacing it per group would mislead users about scope.
     """
 
-    _attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
+    # Groups have a single arm mode (full group arm); ARM_HOME is advertised
+    # so the Alexa skill discovers the per-group panel too, mapping to the same
+    # group-arm command as ARM_AWAY (#221).
+    _attr_supported_features = (
+        AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_HOME
+    )
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, space_id: str, group_id: str) -> None:
         super().__init__(coordinator, space_id)
@@ -489,6 +520,11 @@ class AjaxGroupAlarmControlPanel(_AjaxAlarmPanelBase):
             raise self._arm_error(err) from err
         self._optimistic_state_update(SecurityState.ARMED)
         await self.coordinator.async_request_refresh()
+
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Arm home — groups have a single arm mode, so this maps to the same
+        group-arm command as arm_away (#221)."""
+        await self.async_alarm_arm_away(code)
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         self._validate_code(code)

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.8.0-beta.1"
+    "version": "1.8.0-beta.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aegis-ajax-hass"
 # Mirror of manifest.json's version (the source of truth HA reads). Kept in
 # sync by tests/unit/test_version_consistency.py — bump both when releasing.
-version = "1.8.0-beta.1"
+version = "1.8.0-beta.2"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_alarm_control_panel.py
+++ b/tests/unit/test_alarm_control_panel.py
@@ -309,6 +309,36 @@ class TestAlarmControlPanel:
             await panel.async_alarm_arm_away(code="0000")
         coordinator.security_api.arm.assert_not_called()
 
+    def test_supported_features_includes_arm_home(self) -> None:
+        from homeassistant.components.alarm_control_panel import (
+            AlarmControlPanelEntityFeature,
+        )
+
+        coordinator = self._make_coordinator(use_pin_code=False)
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        assert panel.supported_features & AlarmControlPanelEntityFeature.ARM_HOME
+
+    def test_code_format_number_when_pin_set(self) -> None:
+        from homeassistant.components.alarm_control_panel import CodeFormat
+
+        coordinator = self._make_coordinator(use_pin_code=True, pin_code="1234")
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        assert panel.code_format == CodeFormat.NUMBER
+
+    def test_code_format_none_without_pin(self) -> None:
+        coordinator = self._make_coordinator(use_pin_code=False)
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        assert panel.code_format is None
+
+    @pytest.mark.asyncio
+    async def test_alarm_arm_home_maps_to_night_mode(self) -> None:
+        coordinator = self._make_coordinator(use_pin_code=False)
+        coordinator.security_api.arm_night_mode = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        await panel.async_alarm_arm_home()
+        coordinator.security_api.arm_night_mode.assert_called_once_with("s1", ignore_alarms=False)
+
 
 class TestGroupAlarmControlPanel:
     def _make_space_with_groups(
@@ -418,6 +448,32 @@ class TestGroupAlarmControlPanel:
         panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
         await panel.async_alarm_disarm()
         coordinator.security_api.disarm_group.assert_called_once_with("s1", "g1")
+
+    def test_supported_features_includes_arm_home(self) -> None:
+        from homeassistant.components.alarm_control_panel import (
+            AlarmControlPanelEntityFeature,
+        )
+
+        coordinator = self._make_coordinator()
+        coordinator.spaces = {
+            "s1": self._make_space_with_groups([("g1", "Villa", SecurityState.DISARMED)])
+        }
+        panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
+        assert panel.supported_features & AlarmControlPanelEntityFeature.ARM_HOME
+
+    @pytest.mark.asyncio
+    async def test_arm_home_maps_to_arm_group(self) -> None:
+        coordinator = self._make_coordinator()
+        coordinator.spaces = {
+            "s1": self._make_space_with_groups([("g1", "Villa", SecurityState.DISARMED)])
+        }
+        coordinator.devices = {}
+        coordinator.rooms = {}
+        coordinator.security_api.arm_group = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+        panel = AjaxGroupAlarmControlPanel(coordinator=coordinator, space_id="s1", group_id="g1")
+        await panel.async_alarm_arm_home()
+        coordinator.security_api.arm_group.assert_called_once_with("s1", "g1", ignore_alarms=False)
 
 
 class TestAsyncSetupEntry:


### PR DESCRIPTION
Makes the Ajax alarm panel work with the Nabu Casa / Alexa skill (#221).

## Problem
The panel didn't appear in Alexa: it exposed `ARM_AWAY | ARM_NIGHT` (bitmask 6), which the skill doesn't discover (the reporter found bitmask 6 is not discovered but 7 is), and it had no `code_format`, so no PIN prompt on disarm and no numeric keypad on the Lovelace card.

## Changes
- **`ARM_HOME`** advertised on `AjaxAlarmControlPanel` (hub) and `AjaxGroupAlarmControlPanel` (group) so the skill discovers them.
- **`code_format`** → `CodeFormat.NUMBER` when a PIN is configured (`use_pin_code`), else `None`.
- **`async_alarm_arm_home`**: Ajax has a single partial mode (Night), so on the hub it maps to `arm_night_mode` (same effect as `arm_night` — settles to `armed_night`); on group panels it maps to the single group-arm command.
- README: arm-mode mapping + Alexa caveats.

## Design note (why Home and Night both drive the one partial mode)
Ajax exposes only two arm commands (full + one partial). HA/Alexa want three named modes, so one pair must alias. Verified against HA core: SimpliSafe, iAlarm, Abode, Verisure and Risco (default) all expose a single partial mode as `ARM_HOME`; only Total Connect exposes both Home and Night, and only because it has two real partial commands. We keep **both** `ARM_HOME` and `ARM_NIGHT` for the one Ajax partial mode to cover the HA/Alexa convention (Home) and Ajax's own term (Night). Kept indefinitely — removing `ARM_NIGHT` would break existing automations for no functional gain. Not a breaking change; stays a MINOR feature.

## Testing
- 6 new tests (supported_features includes ARM_HOME on both panels; code_format NUMBER-with-PIN / None-without; arm_home → arm_night_mode on hub, → arm_group on group).
- Full suite: 1517 passed, 88% coverage; ruff/format/mypy/vulture clean (no-volume-mount image).

Refs #221