### PR TITLE
fix(sensor): drive siren temperature refresh from a dedicated timer (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0-beta.3] - 2026-06-01
+
+### Fixed
+- **Siren temperature sensor now actually appears on push-heavy hubs (#220).** The refresh added in `1.8.0-beta.1` ran only inside the scheduled poll, but on hubs with an active HTS stream every push calls `async_set_updated_data`, which resets Home Assistant's poll timer — so the scheduled poll never fired again after startup and the refresh was starved (the sensor never materialised). It now runs on a dedicated 15-minute timer, independent of the poll, with a non-blocking initial fetch at startup so the sensor shows up within seconds instead of waiting for a poll that never comes.
+
 ## [1.8.0-beta.2] - 2026-05-31
 
 ### Added

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -9,9 +9,10 @@ import time
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.core import callback
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -158,9 +159,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Rooms rarely change — cache and refresh once per hour. None means
         # never fetched yet so the first poll always populates rooms.
         self._rooms_last_fetch: float | None = None
-        # Siren internal temperature (#220) — throttled one-shot refresh.
-        # None means never fetched so the first poll populates it.
-        self._siren_temp_last_fetch: float | None = None
+        # Siren internal temperature (#220) — refreshed on a dedicated timer
+        # (`async_track_time_interval`), NOT the poll cycle. On push-heavy hubs
+        # every HTS update resets HA's poll timer, so the scheduled poll never
+        # fires again after startup; a poll-driven refresh would be starved.
+        self._unsub_siren_temp: CALLBACK_TYPE | None = None
         # HTS client for hub network data (ethernet, wifi, gsm, power)
         self._hts_client: HtsClient | None = None
         self._hts_task: asyncio.Task[None] | None = None
@@ -288,7 +291,6 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self._first_startup_init()
                 return {"spaces": self.spaces, "devices": self.devices}
             await self._maybe_fallback_device_snapshot()
-            await self._maybe_refresh_device_temperatures(now)
             await self._maybe_restart_hts()
             self._last_update_success_time = dt_util.utcnow()
             return {"spaces": self.spaces, "devices": self.devices}
@@ -454,24 +456,42 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.rooms = refreshed_rooms
         self._rooms_last_fetch = now
 
-    async def _maybe_refresh_device_temperatures(self, now: float) -> None:
-        """Throttled one-shot refresh of siren internal temperature (#220).
+    def _schedule_siren_temperature_refresh(self) -> None:
+        """Start the dedicated siren-temperature refresh timer (#220).
+
+        The refresh runs on its own `async_track_time_interval` timer rather
+        than inside `_async_update_data`: on push-heavy hubs every HTS update
+        calls `async_set_updated_data`, which resets HA's poll timer, so the
+        scheduled poll never fires again after startup and a poll-driven
+        refresh is starved (the sensor never materialises). The timer's first
+        fire is one full interval out, so we also kick a non-blocking initial
+        refresh so the sensor appears within seconds of startup.
+        """
+        if self._unsub_siren_temp is not None:
+            return
+        self._unsub_siren_temp = async_track_time_interval(
+            self.hass,
+            self._async_refresh_siren_temperatures,
+            timedelta(seconds=SIREN_TEMP_REFRESH_INTERVAL),
+        )
+        self.hass.async_create_task(self._async_refresh_siren_temperatures())
+
+    async def _async_refresh_siren_temperatures(self, _now: datetime | None = None) -> None:
+        """Fetch + merge siren internal temperature (#220), timer-driven.
 
         Sirens don't carry a `temperature` status in the `StreamLightDevices`
         stream the way motion/door sensors do, so the auto-created temperature
         sensor never appears for them. The value lives in the rich per-device
-        `StreamHubDevice` snapshot instead. We pull it once per
-        `SIREN_TEMP_REFRESH_INTERVAL` for each siren that doesn't already have
-        a temperature, and merge it into `device.statuses["temperature"]` —
-        which is all `sensor.py` needs to materialise the sensor.
+        `StreamHubDevice` snapshot instead. We pull it for each siren that
+        doesn't already have a temperature and merge it into
+        `device.statuses["temperature"]` — all `sensor.py` needs to materialise
+        the sensor. When anything changed, push it to listeners so the entity
+        platform picks it up immediately. The `async_track_time_interval`
+        cadence is the throttle; there is no separate rate-limit.
         """
         from dataclasses import replace as dc_replace  # noqa: PLC0415
 
-        if (
-            self._siren_temp_last_fetch is not None
-            and now - self._siren_temp_last_fetch <= SIREN_TEMP_REFRESH_INTERVAL
-        ):
-            return
+        changed = False
         for device_id, device in list(self.devices.items()):
             if (
                 device.device_type not in SIREN_TEMPERATURE_DEVICE_TYPES
@@ -493,7 +513,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.devices[device_id] = dc_replace(
                 current, statuses={**current.statuses, "temperature": temperature}
             )
-        self._siren_temp_last_fetch = now
+            changed = True
+        if changed:
+            self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     async def _first_startup_init(self) -> None:
         """First-cycle bootstrap: warm devices cache, start persistent
@@ -534,6 +556,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._probe_smart_locks_once()
         await self._start_device_streams()
         await self._start_hts()
+        self._schedule_siren_temperature_refresh()
         self._last_update_success_time = dt_util.utcnow()
         # One-line summary so users debugging "HTS streams: 0/1" or
         # "FCM clients: 0/1" reports (#111) can see at a glance which
@@ -897,10 +920,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         for device in devices:
             # Siren temperature (#220) comes from a separate per-device RPC,
             # not this stream, so a fresh snapshot would wipe the value we
-            # merged in `_maybe_refresh_device_temperatures` and the throttle
-            # would leave the sensor `unknown` until the next refresh. Carry
-            # the previously-merged temperature forward (it's slow-moving;
-            # the periodic refresh still updates it).
+            # merged in `_async_refresh_siren_temperatures` and leave the
+            # sensor `unknown` until the next timer fire. Carry the
+            # previously-merged temperature forward (it's slow-moving; the
+            # periodic refresh still updates it).
             existing = self.devices.get(device.id)
             if (
                 existing is not None
@@ -1131,6 +1154,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._notification_listener.async_start()
 
     async def async_shutdown(self) -> None:
+        # Stop the siren-temperature refresh timer (#220)
+        if self._unsub_siren_temp is not None:
+            self._unsub_siren_temp()
+            self._unsub_siren_temp = None
+
         # Cancel all stream tasks
         for task in self._stream_tasks:
             if not task.done():

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.8.0-beta.2"
+    "version": "1.8.0-beta.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aegis-ajax-hass"
 # Mirror of manifest.json's version (the source of truth HA reads). Kept in
 # sync by tests/unit/test_version_consistency.py — bump both when releasing.
-version = "1.8.0-beta.2"
+version = "1.8.0-beta.3"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -19,7 +19,12 @@ from custom_components.aegis_ajax.api.models import (
     Space,
     SpaceSnapshot,
 )
-from custom_components.aegis_ajax.const import ConnectionStatus, DeviceState, SecurityState
+from custom_components.aegis_ajax.const import (
+    SIREN_TEMP_REFRESH_INTERVAL,
+    ConnectionStatus,
+    DeviceState,
+    SecurityState,
+)
 
 
 def _make_space(space_id: str = "s1") -> Space:
@@ -1989,65 +1994,64 @@ def _make_siren(device_id: str, *, statuses: dict | None = None) -> Device:
     )
 
 
-class TestMaybeRefreshDeviceTemperatures:
+class TestSirenTemperatureRefresh:
     @pytest.mark.asyncio
     async def test_merges_temperature_into_siren_statuses(self) -> None:
         coordinator = _make_coordinator(["s1"])
         coordinator.devices = {"s1d": _make_siren("s1d")}
+        coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
 
-        await coordinator._maybe_refresh_device_temperatures(100.0)
+        await coordinator._async_refresh_siren_temperatures()
 
         assert coordinator.devices["s1d"].statuses["temperature"] == 21.0
         coordinator._devices_api.get_hub_device_temperature.assert_awaited_once_with("hub-1", "s1d")
+        # The merge must be pushed to listeners or the sensor never materialises.
+        coordinator.async_set_updated_data.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_skips_non_siren_devices(self) -> None:
         coordinator = _make_coordinator(["s1"])
         coordinator.devices = {"d1": _make_device("d1")}  # door_protect
+        coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
 
-        await coordinator._maybe_refresh_device_temperatures(100.0)
+        await coordinator._async_refresh_siren_temperatures()
 
         coordinator._devices_api.get_hub_device_temperature.assert_not_called()
         assert "temperature" not in coordinator.devices["d1"].statuses
+        coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_skips_siren_that_already_has_temperature(self) -> None:
         coordinator = _make_coordinator(["s1"])
         coordinator.devices = {"s1d": _make_siren("s1d", statuses={"temperature": 18.0})}
+        coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=99.0)
 
-        await coordinator._maybe_refresh_device_temperatures(100.0)
+        await coordinator._async_refresh_siren_temperatures()
 
         coordinator._devices_api.get_hub_device_temperature.assert_not_called()
         assert coordinator.devices["s1d"].statuses["temperature"] == 18.0
-
-    @pytest.mark.asyncio
-    async def test_throttles_subsequent_calls(self) -> None:
-        coordinator = _make_coordinator(["s1"])
-        coordinator.devices = {"s1d": _make_siren("s1d")}
-        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
-
-        await coordinator._maybe_refresh_device_temperatures(100.0)
-        await coordinator._maybe_refresh_device_temperatures(200.0)  # within interval
-
-        coordinator._devices_api.get_hub_device_temperature.assert_awaited_once()
+        coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_none_result_leaves_statuses_untouched(self) -> None:
         coordinator = _make_coordinator(["s1"])
         coordinator.devices = {"s1d": _make_siren("s1d")}
+        coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=None)
 
-        await coordinator._maybe_refresh_device_temperatures(100.0)
+        await coordinator._async_refresh_siren_temperatures()
 
         assert "temperature" not in coordinator.devices["s1d"].statuses
+        coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_one_device_error_does_not_abort_others(self) -> None:
         coordinator = _make_coordinator(["s1"])
         coordinator.devices = {"bad": _make_siren("bad"), "good": _make_siren("good")}
+        coordinator.async_set_updated_data = MagicMock()
 
         async def _temp(hub_id: str, device_id: str) -> float:
             if device_id == "bad":
@@ -2056,23 +2060,26 @@ class TestMaybeRefreshDeviceTemperatures:
 
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(side_effect=_temp)
 
-        await coordinator._maybe_refresh_device_temperatures(100.0)
+        await coordinator._async_refresh_siren_temperatures()
 
         assert coordinator.devices["good"].statuses["temperature"] == 20.0
         assert "temperature" not in coordinator.devices["bad"].statuses
 
     @pytest.mark.asyncio
-    async def test_wired_into_async_update_data(self) -> None:
+    async def test_not_driven_by_poll_cycle(self) -> None:
+        # Regression for #220: the temperature refresh must NOT depend on the
+        # scheduled poll. On push-heavy hubs every HTS update calls
+        # `async_set_updated_data`, which resets HA's poll timer, so the
+        # scheduled poll never fires again after startup — a poll-driven
+        # refresh is starved and the siren sensor never appears. The poll path
+        # must therefore not touch siren temperatures at all.
         coordinator = _make_coordinator()
         coordinator._client.session.is_authenticated = True
         coordinator._streams_started = True
         coordinator.devices = {"s1d": _make_siren("s1d")}
-        # Healthy streams + live HTS so the unrelated post-startup sub-steps
-        # (fallback snapshot / HTS restart) stay no-ops.
         coordinator._stream_tasks = [MagicMock(done=MagicMock(return_value=False))]
         coordinator._hts_client = MagicMock()
         coordinator._hts_task = MagicMock(done=MagicMock(return_value=False))
-
         coordinator._spaces_api = MagicMock()
         coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
         coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
@@ -2081,7 +2088,50 @@ class TestMaybeRefreshDeviceTemperatures:
 
         await coordinator._async_update_data()
 
-        assert coordinator.devices["s1d"].statuses["temperature"] == 22.0
+        coordinator._devices_api.get_hub_device_temperature.assert_not_called()
+
+    def test_schedule_registers_independent_timer_and_initial_kick(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        # Replace with a MagicMock so the initial-kick call returns a non-coro.
+        coordinator._async_refresh_siren_temperatures = MagicMock()
+        with patch(
+            "custom_components.aegis_ajax.coordinator.async_track_time_interval",
+            return_value=MagicMock(),
+        ) as mock_track:
+            coordinator._schedule_siren_temperature_refresh()
+
+        mock_track.assert_called_once()
+        assert mock_track.call_args.args[2] == timedelta(seconds=SIREN_TEMP_REFRESH_INTERVAL)
+        assert coordinator._unsub_siren_temp is mock_track.return_value
+        # Timer's first fire is one full interval out, so an initial
+        # non-blocking kick must run for the sensor to appear within seconds.
+        coordinator.hass.async_create_task.assert_called_once()
+
+    def test_schedule_is_idempotent(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator._unsub_siren_temp = MagicMock()
+        with patch(
+            "custom_components.aegis_ajax.coordinator.async_track_time_interval",
+        ) as mock_track:
+            coordinator._schedule_siren_temperature_refresh()
+
+        mock_track.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_timer(self) -> None:
+        coordinator = _make_coordinator()
+        unsub = MagicMock()
+        coordinator._unsub_siren_temp = unsub
+        coordinator._stream_tasks = []
+        coordinator._hts_task = None
+        coordinator._hts_client = None
+        coordinator._notification_listener = None
+        coordinator._client.close = AsyncMock()
+
+        await coordinator.async_shutdown()
+
+        unsub.assert_called_once()
+        assert coordinator._unsub_siren_temp is None
 
     def test_snapshot_preserves_merged_siren_temperature(self) -> None:
         coordinator = _make_coordinator()


### PR DESCRIPTION
## Problem

The HomeSiren/StreetSiren temperature sensor shipped in `1.8.0-beta.1` never appears on real hubs. The reporter (#220) updated, waited 30 min, and got no sensor.

Root cause: `_maybe_refresh_device_temperatures()` ran **only** inside the scheduled poll (`_async_update_data`), and after the `_first_startup_init` early-return. On any hub with an active HTS stream, every push calls `async_set_updated_data()` → HA resets the 300s poll timer. With pushes arriving ~every 60s the scheduled poll **never fires again after startup**, so the temperature is never fetched and the sensor is never materialised.

Reporter's log evidence after startup: `Finished fetching` (scheduled poll) = 1, `Manually updated` (HTS push) = 15.

## Fix

- Move the refresh onto a dedicated `async_track_time_interval` timer (`SIREN_TEMP_REFRESH_INTERVAL`, 15 min), decoupled from the poll and immune to poll-timer starvation.
- Kick a **non-blocking** initial fetch at startup so the sensor appears within seconds instead of waiting a full interval.
- The timer cadence is the throttle, so the old monotonic-time rate-limit (`_siren_temp_last_fetch`) is dropped.
- Push the merged statuses via `async_set_updated_data` only when something changed, so the entity platform materialises the sensor.
- Cancel the timer in `async_shutdown`.

The timer callback runs on the event loop (unlike `_on_hts_update`, which can run off-loop), so no worker-thread marshalling is needed.

## Tests

`TestSirenTemperatureRefresh` rewritten: merge+notify, skip non-siren, skip already-set (no notify), `None` result, per-device error isolation, plus new regression coverage — `test_not_driven_by_poll_cycle` (poll must not touch siren temps), timer registration + initial kick, idempotent scheduling, and shutdown cancellation.

Full suite green in Docker: 1519 passed, 88% coverage, ruff/format/mypy/vulture clean.

Related to #220