### PR TITLE
fix(notification): stop re-attempting FCM registration for rejected creds (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0-beta.4] - 2026-06-01
+
+### Changed
+- **Don't re-attempt FCM registration for credentials Google already rejected (#227).** When the entered FCM api-key is well-formed but wrong (e.g. a non-FCM `AIza…` key extracted from the app), registration credentials are never persisted, so the integration used to re-attempt the registration against the cobranded Firebase project on every Home Assistant restart. It now remembers a terminally-rejected credential set by a one-way hash (the secret is never stored) and skips the network attempt until the values change, keeping the Repair card raised. Transient / host-unreachable failures stay retryable, and a successful registration or a changed credential set clears the marker.
+
 ## [1.8.0-beta.3] - 2026-06-01
 
 ### Fixed

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.8.0-beta.3"
+    "version": "1.8.0-beta.4"
 }

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -40,6 +40,10 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 STORAGE_KEY = f"{DOMAIN}_fcm_credentials"
+# Records the SHA-256 fingerprint of the most recent credential set that
+# Google terminally rejected, so we don't re-hit the Firebase project on every
+# restart with a key we already know is wrong (#227).
+REJECTED_STORAGE_KEY = f"{DOMAIN}_fcm_rejected"
 STORAGE_VERSION = 1
 
 # Ajax dispatches two FCM messages per security transition (one user-facing
@@ -101,6 +105,8 @@ from custom_components.aegis_ajax.notification_fcm_creds import (  # noqa: E402,
     _FCM_API_KEY_RE,
     _FCM_APP_ID_RE,
     _classify_fcm_failure,
+    _fcm_creds_hash,
+    _is_terminal_fcm_failure,
     _validate_fcm_shape,
 )
 
@@ -130,6 +136,9 @@ class AjaxNotificationListener:
         self._app_label = app_label
         self._push_client: Any = None
         self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._rejected_store: Store[dict[str, Any]] = Store(
+            hass, STORAGE_VERSION, REJECTED_STORAGE_KEY
+        )
         self._credentials: dict[str, Any] | None = None
         self._photo_callbacks: dict[str, asyncio.Future[str | None]] = {}
         self._notification_id_callbacks: dict[str, asyncio.Future[str | None]] = {}
@@ -230,6 +239,30 @@ class AjaxNotificationListener:
         )
 
         if not self._credentials:
+            # Short-circuit if this exact credential set was already rejected
+            # by Google (#227). Without working credentials, `async_start` runs
+            # the registration again on every restart / reload; for a
+            # well-formed-but-wrong api-key that means an unbounded series of
+            # failed requests against the Firebase project. We remember the
+            # rejected set by hash (never the secret) and skip the network
+            # attempt until the user changes the values.
+            creds_hash = _fcm_creds_hash(
+                fcm_project_id=self._fcm_project_id,
+                fcm_app_id=self._fcm_app_id,
+                fcm_api_key=self._fcm_api_key,
+                fcm_sender_id=self._fcm_sender_id,
+            )
+            rejected = await self._rejected_store.async_load()
+            if rejected and rejected.get("hash") == creds_hash:
+                _LOGGER.warning(
+                    "FCM credentials were already rejected by Google and haven't "
+                    "changed — skipping re-registration to avoid repeated failed "
+                    "requests against the Firebase project. Re-enter the four values "
+                    "via the Repair card under Settings → Repairs to try again."
+                )
+                if self._entry_id:
+                    async_register_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)
+                return
             _LOGGER.debug("Registering with FCM...")
             # Inject `X-Android-Package` on Firebase Installations calls when
             # we know the user's co-branded Android package. The Ajax co-brand
@@ -269,8 +302,16 @@ class AjaxNotificationListener:
                     raw_result = await self._hass.async_add_executor_job(registerer.register)
                 self._credentials = dict(raw_result)
                 await self._store.async_save(self._credentials)
+                if rejected:
+                    # These values worked — drop any stale rejection marker.
+                    await self._rejected_store.async_remove()
                 _LOGGER.info("FCM registration successful")
             except Exception as exc:
+                # Remember a terminal credential rejection so we don't re-hit
+                # the Firebase project on every restart (#227). Transient /
+                # host-unreachable errors stay retryable.
+                if _is_terminal_fcm_failure(exc):
+                    await self._rejected_store.async_save({"hash": creds_hash})
                 _LOGGER.warning(_classify_fcm_failure(exc), exc_info=True)
                 if self._entry_id:
                     async_register_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)

--- a/custom_components/aegis_ajax/notification_fcm_creds.py
+++ b/custom_components/aegis_ajax/notification_fcm_creds.py
@@ -8,6 +8,7 @@ notification.py re-exports the public surface.
 
 from __future__ import annotations
 
+import hashlib
 import re
 
 # Permissive Firebase-Installations shape match for `fcm_app_id`. We do NOT
@@ -71,6 +72,40 @@ def _validate_fcm_shape(
         )
 
     return None
+
+
+def _fcm_creds_hash(
+    *,
+    fcm_project_id: str,
+    fcm_app_id: str,
+    fcm_api_key: str,
+    fcm_sender_id: str,
+) -> str:
+    """Stable one-way fingerprint of a four-value FCM credential set.
+
+    Used to remember that a specific set was terminally rejected by Google so
+    we don't re-attempt registration against the Firebase project on every
+    restart (#227). It is a SHA-256 digest, never the secret itself.
+    """
+    joined = "|".join((fcm_project_id, fcm_app_id, fcm_api_key, fcm_sender_id))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def _is_terminal_fcm_failure(exc: BaseException) -> bool:
+    """True when an FCM registration error is a Google credential rejection
+    (won't change on retry), False for transient / host-unreachable errors.
+
+    Mirrors the `_classify_fcm_failure` taxonomy: the two credential-rejection
+    strings are terminal; "unable to register and check in to gcm" is the
+    FCM-hosts-unreachable case (DNS / firewall / proxy) and must stay
+    retryable. Unknown errors default to NOT terminal, so a transient blip is
+    never mistaken for a permanently-bad credential set (which would suppress
+    a legitimate retry until the user re-enters the values).
+    """
+    lower = (str(exc) if exc else "").lower()
+    if "subscription" in lower and "google cloud messaging" in lower:
+        return True
+    return "unable to register with fcm" in lower
 
 
 def _classify_fcm_failure(exc: BaseException) -> str:

--- a/custom_components/aegis_ajax/notification_fcm_creds.py
+++ b/custom_components/aegis_ajax/notification_fcm_creds.py
@@ -86,9 +86,15 @@ def _fcm_creds_hash(
     Used to remember that a specific set was terminally rejected by Google so
     we don't re-attempt registration against the Firebase project on every
     restart (#227). It is a SHA-256 digest, never the secret itself.
+
+    This is a change-detection fingerprint, NOT password storage: it's only
+    compared against itself to answer "are these the same four values I already
+    tried?", never used to authenticate anything, so a fast hash is correct and
+    a slow KDF (bcrypt/argon2) would be pointless here. `usedforsecurity=False`
+    documents that intent (and keeps it FIPS-safe).
     """
     joined = "|".join((fcm_project_id, fcm_app_id, fcm_api_key, fcm_sender_id))
-    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+    return hashlib.sha256(joined.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def _is_terminal_fcm_failure(exc: BaseException) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aegis-ajax-hass"
 # Mirror of manifest.json's version (the source of truth HA reads). Kept in
 # sync by tests/unit/test_version_consistency.py — bump both when releasing.
-version = "1.8.0-beta.3"
+version = "1.8.0-beta.4"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -467,6 +467,7 @@ class TestAsyncStartFcmRepairs:
             hass=hass, coordinator=coordinator, **_FCM_KWARGS, entry_id="entry-x"
         )
         listener._store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_load = AsyncMock(return_value=None)
 
         register_cls = MagicMock()
         instance = MagicMock()
@@ -485,6 +486,198 @@ class TestAsyncStartFcmRepairs:
             await listener.async_start()
 
         reg.assert_called_once_with(hass, entry_id="entry-x")
+
+
+class TestFcmRejectedCredsShortCircuit:
+    """#227 — don't re-hit the Firebase project on every restart with a
+    credential set Google already rejected. The rejection is remembered by a
+    one-way hash; a terminal failure persists it, a matching hash short-circuits
+    the next attempt, and a successful registration / changed values clear it.
+    """
+
+    @staticmethod
+    def _listener(hass: MagicMock) -> AjaxNotificationListener:
+        listener = AjaxNotificationListener(
+            hass=hass, coordinator=MagicMock(), **_FCM_KWARGS, entry_id="entry-x"
+        )
+        listener._store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_save = AsyncMock()
+        listener._rejected_store.async_remove = AsyncMock()
+        return listener
+
+    @staticmethod
+    def _expected_hash() -> str:
+        from custom_components.aegis_ajax.notification import _fcm_creds_hash
+
+        return _fcm_creds_hash(
+            fcm_project_id=_FCM_KWARGS["fcm_project_id"],
+            fcm_app_id=_FCM_KWARGS["fcm_app_id"],
+            fcm_api_key=_FCM_KWARGS["fcm_api_key"],
+            fcm_sender_id=_FCM_KWARGS["fcm_sender_id"],
+        )
+
+    @staticmethod
+    def _repair_patches() -> tuple:
+        return (
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_invalid"
+            ),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_credentials_invalid"),
+            patch("custom_components.aegis_ajax.notification.async_register_fcm_not_configured"),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_not_configured"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_terminal_failure_persists_rejected_hash(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=RuntimeError(
+                "Unable to establish subscription with Google Cloud Messaging."
+            )
+        )
+        listener = self._listener(hass)
+        register_cls = MagicMock(return_value=MagicMock(register=MagicMock()))
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+        ):
+            await listener.async_start()
+
+        listener._rejected_store.async_save.assert_awaited_once_with(
+            {"hash": self._expected_hash()}
+        )
+
+    @pytest.mark.asyncio
+    async def test_transient_failure_does_not_persist(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=RuntimeError("Unable to register and check in to gcm")
+        )
+        listener = self._listener(hass)
+        register_cls = MagicMock(return_value=MagicMock(register=MagicMock()))
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+        ):
+            await listener.async_start()
+
+        listener._rejected_store.async_save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_short_circuits_when_hash_matches(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock()
+        listener = self._listener(hass)
+        listener._rejected_store.async_load = AsyncMock(
+            return_value={"hash": self._expected_hash()}
+        )
+        register_cls = MagicMock()
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv as reg,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+        ):
+            await listener.async_start()
+
+        # No network registration attempt, but the Repair is kept visible.
+        register_cls.assert_not_called()
+        hass.async_add_executor_job.assert_not_called()
+        reg.assert_called_once_with(hass, entry_id="entry-x")
+
+    @pytest.mark.asyncio
+    async def test_no_short_circuit_when_hash_differs(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=RuntimeError("boom"))
+        listener = self._listener(hass)
+        listener._rejected_store.async_load = AsyncMock(return_value={"hash": "some-other-hash"})
+        register_cls = MagicMock(return_value=MagicMock(register=MagicMock()))
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+        ):
+            await listener.async_start()
+
+        # Different values → must still attempt registration.
+        register_cls.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_success_clears_rejected_marker(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            return_value={"fcm": {"registration": {"token": "T"}}}
+        )
+        listener = self._listener(hass)
+        listener._store.async_save = AsyncMock()
+        listener._rejected_store.async_load = AsyncMock(return_value={"hash": "stale-hash"})
+        listener._register_push_token = AsyncMock()
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch(
+                "firebase_messaging.fcmregister.FcmRegister",
+                MagicMock(return_value=MagicMock(register=MagicMock())),
+            ),
+            patch("firebase_messaging.FcmPushClient", MagicMock()),
+        ):
+            await listener.async_start()
+
+        listener._rejected_store.async_remove.assert_awaited_once()
+
+
+class TestIsTerminalFcmFailure:
+    def test_credential_rejection_strings_are_terminal(self) -> None:
+        from custom_components.aegis_ajax.notification import _is_terminal_fcm_failure
+
+        assert _is_terminal_fcm_failure(
+            RuntimeError("Unable to establish subscription with Google Cloud Messaging.")
+        )
+        assert _is_terminal_fcm_failure(RuntimeError("Unable to register with fcm"))
+
+    def test_network_and_unknown_are_not_terminal(self) -> None:
+        from custom_components.aegis_ajax.notification import _is_terminal_fcm_failure
+
+        assert not _is_terminal_fcm_failure(RuntimeError("Unable to register and check in to gcm"))
+        assert not _is_terminal_fcm_failure(TimeoutError())
+        assert not _is_terminal_fcm_failure(RuntimeError("something unexpected"))
+
+
+class TestFcmCredsHash:
+    def test_stable_and_sensitive(self) -> None:
+        from custom_components.aegis_ajax.notification import _fcm_creds_hash
+
+        a = _fcm_creds_hash(**{k: v for k, v in _FCM_KWARGS.items()})
+        b = _fcm_creds_hash(**{k: v for k, v in _FCM_KWARGS.items()})
+        assert a == b and len(a) == 64
+        changed = dict(_FCM_KWARGS)
+        changed["fcm_api_key"] = "AIza" + "y" * 35
+        assert _fcm_creds_hash(**changed) != a
+        # The hash must not leak the secret itself.
+        assert _FCM_KWARGS["fcm_api_key"] not in a
 
 
 class TestValidateFcmShape:
@@ -629,6 +822,7 @@ class TestAsyncStartFcmAndroidPackageHeader:
             app_label="Ajax",
         )
         listener._store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_load = AsyncMock(return_value=None)
         listener._register_push_token = AsyncMock()
 
         register_cls = MagicMock()
@@ -690,6 +884,7 @@ class TestAsyncStartFcmAndroidPackageHeader:
             app_label="some_brand_we_dont_map_yet",
         )
         listener._store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_load = AsyncMock(return_value=None)
         listener._register_push_token = AsyncMock()
 
         register_cls = MagicMock()
@@ -746,6 +941,7 @@ class TestAsyncStartFcmShapePreflight:
             entry_id="entry-x",
         )
         listener._store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_load = AsyncMock(return_value=None)
 
         register_cls = MagicMock()
 
@@ -797,6 +993,7 @@ class TestAsyncStartFcmShapePreflight:
             hass=hass, coordinator=coordinator, **_VALID_FCM_SHAPES, entry_id="entry-x"
         )
         listener._store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_load = AsyncMock(return_value=None)
 
         register_cls = MagicMock()
         instance = MagicMock()


### PR DESCRIPTION
## Problem

A point raised by @GurliGebis in #209. When the entered FCM api-key is **well-formed but wrong** (the common mistake — picking a non-FCM `AIza…` key from the app), Google rejects registration (`API_KEY_*_BLOCKED`). Registration credentials are only persisted on success, so `async_start` re-attempts the registration against the cobranded Firebase project on **every HA restart / reload** — an unbounded series of failed requests against a third party's project for a permanently-misconfigured key.

(The offline `_validate_fcm_shape` pre-flight already blocks malformed/typo values with zero network traffic, and registration is already single-attempt with no retry loop — this is specifically the well-formed-but-wrong case repeating across restarts.)

## Fix

- Remember a **terminally-rejected** credential set by a one-way `sha256(project_id|app_id|api_key|sender_id)` hash (the secret is never stored) in a dedicated `Store`.
- On `async_start`, after the shape check and before calling Firebase: if the current four-value hash matches the stored rejected hash and there are no working credentials, **skip the network attempt** and just keep the `fcm_credentials_invalid` Repair raised.
- Terminal vs transient is decided by the existing `_classify_fcm_failure` taxonomy — the two credential-rejection strings are terminal; the GCM check-in / hosts-unreachable string stays **retryable**; unknown errors default to non-terminal (so a transient blip is never mistaken for a permanently-bad set).
- A successful registration, or a changed credential set (different hash), clears/bypasses the marker and tries again.

Net effect: from "one failed request per restart, indefinitely" to "one per distinct wrong credential set", plus instant setup feedback instead of a round-trip we already know will fail.

## Tests

`TestFcmRejectedCredsShortCircuit` (terminal persists hash / transient doesn't / matching hash short-circuits with no network call / differing hash still attempts / success clears the marker), `TestIsTerminalFcmFailure`, `TestFcmCredsHash` (stable, sensitive, doesn't leak the secret). Existing FCM listener tests updated to mock the new store.

Full suite green in Docker: 1527 passed, 88% coverage, ruff/format/mypy/vulture clean.

Bumps to `1.8.0-beta.4`.

Related to #227