### PR TITLE
feat(sensor): temperature for outdoor curtain PIRs via StreamHubDevice (#229)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -230,12 +230,13 @@ class DevicesApi:
         return self._dedupe_and_track_aliases(devices)
 
     async def get_hub_device_temperature(self, hub_id: str, hub_device_id: str) -> float | None:
-        """Read one device's internal temperature via `StreamHubDevice` (#220).
+        """Read one device's internal temperature via `StreamHubDevice` (#220, #229).
 
         A per-device stream (`hub_id` + `hub_device_id`) whose first
-        `success.snapshot` carries the rich `HubDevice` proto. Sirens expose
-        their temperature here but not in the lighter `StreamLightDevices`
-        stream. We read the first snapshot and stop — temperature is slow and
+        `success.snapshot` carries the rich `HubDevice` proto. Sirens (#220) and
+        outdoor curtain PIRs (#229) expose their temperature here but not in the
+        lighter `StreamLightDevices` stream. We read the first snapshot and stop
+        — temperature is slow and
         the `Success` oneof has no delta case anyway. Returns `None` on a
         `failure` response (e.g. a hub-attached device not addressable on this
         backend, cf. #206) or an empty stream; gRPC errors propagate to the
@@ -255,9 +256,26 @@ class DevicesApi:
         async for msg in stream:
             if msg.HasField("success"):
                 if msg.success.WhichOneof("success") == "snapshot":
-                    return devices_parser.parse_hub_device_temperature(
-                        msg.success.snapshot.hub_device
-                    )
+                    hub_device = msg.success.snapshot.hub_device
+                    temperature = devices_parser.parse_hub_device_temperature(hub_device)
+                    if temperature is None:
+                        # #229 proto-drift probe: our HubDevice proto models only
+                        # the `_mini` curtain-outdoor variant. If a Base/Plus unit
+                        # populates a oneof case we don't know (or one without a
+                        # `device_temperature`), the value silently vanishes. Log
+                        # the actual case so we can extend the proto from a real
+                        # device's response (cf. #206).
+                        case = (
+                            hub_device.WhichOneof("device")
+                            if hasattr(hub_device, "WhichOneof")
+                            else None
+                        )
+                        _LOGGER.debug(
+                            "StreamHubDevice for %s: no temperature; HubDevice oneof case=%r",
+                            hub_device_id,
+                            case,
+                        )
+                    return temperature
             elif msg.HasField("failure"):
                 _LOGGER.debug(
                     "StreamHubDevice failed for device %s: %s",

--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -553,10 +553,12 @@ def parse_hub_device_temperature(hub_device: Any) -> float | None:  # noqa: ANN4
 
     The per-device `StreamHubDevice` RPC returns a `HubDevice` whose
     `device` oneof selects a per-type message (`street_siren`,
-    `home_siren`, …). Siren-family messages carry a `device_temperature`
-    (`DeviceTemperature { value, is_extreme }`) that the lighter
-    `StreamLightDevices` stream omits for sirens — so this is the only
-    path to a siren's temperature. Returns the value as a float, or
+    `home_siren`, `motion_protect_curtain_outdoor`, …). Those messages
+    carry a `device_temperature` (`DeviceTemperature { value, is_extreme }`)
+    that the lighter `StreamLightDevices` stream omits (#220 sirens, #229
+    outdoor curtain PIRs) — so this is the only path to their temperature.
+    The lookup is oneof-case-agnostic, so any device whose sub-message has
+    a `device_temperature` works. Returns the value as a float, or
     `None` when the oneof is unset, the sub-message has no
     `device_temperature`, or anything about the shape is unexpected.
     """

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -147,14 +147,17 @@ MAX_RETRIES = 3
 RATE_LIMIT_REQUESTS = 60
 RATE_LIMIT_WINDOW = 60  # seconds
 
-# Siren internal temperature (#220). Sirens report their temperature only in
-# the rich per-device `StreamHubDevice` snapshot, not in the lighter
-# `StreamLightDevices` stream we run continuously. We pull it with a throttled
-# one-shot snapshot per siren — temperature is slow-moving and a persistent
+# Per-device internal temperature (#220, #229). Some devices report their
+# temperature only in the rich per-device `StreamHubDevice` snapshot, not in
+# the lighter `StreamLightDevices` stream we run continuously: sirens (#220)
+# and outdoor curtain motion detectors (#229). We pull it with a throttled
+# one-shot snapshot per device — temperature is slow-moving and a persistent
 # per-device stream would contradict how the Ajax app uses that endpoint.
-SIREN_TEMP_REFRESH_INTERVAL = 900  # seconds (15 min)
-# Device types whose `HubDevice` oneof case carries a `device_temperature`.
-SIREN_TEMPERATURE_DEVICE_TYPES = frozenset(
+HUB_DEVICE_TEMP_REFRESH_INTERVAL = 900  # seconds (15 min)
+# Device types whose `HubDevice` oneof case carries a `device_temperature`
+# that the `StreamLightDevices` stream omits. Indoor motion/door sensors are
+# NOT here — they already carry `temperature` in the light stream.
+HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
     {
         "street_siren",
         "street_siren_plus_g3",
@@ -162,6 +165,12 @@ SIREN_TEMPERATURE_DEVICE_TYPES = frozenset(
         "home_siren_g3",
         "home_siren_s",
         "home_siren_fibra",
+        # Outdoor curtain PIRs (#229) — all map to the rich `HubDevice`
+        # oneof case `motion_protect_curtain_outdoor`, which carries
+        # `device_temperature`.
+        "motion_protect_curtain_outdoor_base",
+        "motion_protect_curtain_outdoor_mini",
+        "motion_protect_curtain_outdoor_plus",
     }
 )
 

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -32,11 +32,11 @@ from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import (
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
+    HUB_DEVICE_TEMP_REFRESH_INTERVAL,
+    HUB_DEVICE_TEMPERATURE_DEVICE_TYPES,
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
     MOTION_PUSH_AUTO_OFF_SECONDS,
-    SIREN_TEMP_REFRESH_INTERVAL,
-    SIREN_TEMPERATURE_DEVICE_TYPES,
     ConnectionStatus,
 )
 from custom_components.aegis_ajax.device_cache import DevicesCache
@@ -159,11 +159,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Rooms rarely change — cache and refresh once per hour. None means
         # never fetched yet so the first poll always populates rooms.
         self._rooms_last_fetch: float | None = None
-        # Siren internal temperature (#220) — refreshed on a dedicated timer
-        # (`async_track_time_interval`), NOT the poll cycle. On push-heavy hubs
-        # every HTS update resets HA's poll timer, so the scheduled poll never
-        # fires again after startup; a poll-driven refresh would be starved.
-        self._unsub_siren_temp: CALLBACK_TYPE | None = None
+        # Per-device internal temperature (#220 sirens, #229 outdoor curtain
+        # PIRs) — refreshed on a dedicated timer (`async_track_time_interval`),
+        # NOT the poll cycle. On push-heavy hubs every HTS update resets HA's
+        # poll timer, so the scheduled poll never fires again after startup; a
+        # poll-driven refresh would be starved.
+        self._unsub_hub_device_temp: CALLBACK_TYPE | None = None
         # HTS client for hub network data (ethernet, wifi, gsm, power)
         self._hts_client: HtsClient | None = None
         self._hts_task: asyncio.Task[None] | None = None
@@ -456,8 +457,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.rooms = refreshed_rooms
         self._rooms_last_fetch = now
 
-    def _schedule_siren_temperature_refresh(self) -> None:
-        """Start the dedicated siren-temperature refresh timer (#220).
+    def _schedule_hub_device_temperature_refresh(self) -> None:
+        """Start the dedicated per-device-temperature refresh timer (#220, #229).
 
         The refresh runs on its own `async_track_time_interval` timer rather
         than inside `_async_update_data`: on push-heavy hubs every HTS update
@@ -467,22 +468,23 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         fire is one full interval out, so we also kick a non-blocking initial
         refresh so the sensor appears within seconds of startup.
         """
-        if self._unsub_siren_temp is not None:
+        if self._unsub_hub_device_temp is not None:
             return
-        self._unsub_siren_temp = async_track_time_interval(
+        self._unsub_hub_device_temp = async_track_time_interval(
             self.hass,
-            self._async_refresh_siren_temperatures,
-            timedelta(seconds=SIREN_TEMP_REFRESH_INTERVAL),
+            self._async_refresh_hub_device_temperatures,
+            timedelta(seconds=HUB_DEVICE_TEMP_REFRESH_INTERVAL),
         )
-        self.hass.async_create_task(self._async_refresh_siren_temperatures())
+        self.hass.async_create_task(self._async_refresh_hub_device_temperatures())
 
-    async def _async_refresh_siren_temperatures(self, _now: datetime | None = None) -> None:
-        """Fetch + merge siren internal temperature (#220), timer-driven.
+    async def _async_refresh_hub_device_temperatures(self, _now: datetime | None = None) -> None:
+        """Fetch + merge per-device internal temperature (#220, #229), timer-driven.
 
-        Sirens don't carry a `temperature` status in the `StreamLightDevices`
-        stream the way motion/door sensors do, so the auto-created temperature
-        sensor never appears for them. The value lives in the rich per-device
-        `StreamHubDevice` snapshot instead. We pull it for each siren that
+        Sirens (#220) and outdoor curtain PIRs (#229) don't carry a
+        `temperature` status in the `StreamLightDevices` stream the way indoor
+        motion/door sensors do, so the auto-created temperature sensor never
+        appears for them. The value lives in the rich per-device
+        `StreamHubDevice` snapshot instead. We pull it for each such device that
         doesn't already have a temperature and merge it into
         `device.statuses["temperature"]` — all `sensor.py` needs to materialise
         the sensor. When anything changed, push it to listeners so the entity
@@ -494,7 +496,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         changed = False
         for device_id, device in list(self.devices.items()):
             if (
-                device.device_type not in SIREN_TEMPERATURE_DEVICE_TYPES
+                device.device_type not in HUB_DEVICE_TEMPERATURE_DEVICE_TYPES
                 or "temperature" in device.statuses
             ):
                 continue
@@ -503,7 +505,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     device.hub_id, device_id
                 )
             except Exception:  # noqa: BLE001
-                _LOGGER.debug("Failed to fetch temperature for siren %s", device_id, exc_info=True)
+                _LOGGER.debug("Failed to fetch temperature for device %s", device_id, exc_info=True)
                 continue
             if temperature is None:
                 continue
@@ -556,7 +558,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._probe_smart_locks_once()
         await self._start_device_streams()
         await self._start_hts()
-        self._schedule_siren_temperature_refresh()
+        self._schedule_hub_device_temperature_refresh()
         self._last_update_success_time = dt_util.utcnow()
         # One-line summary so users debugging "HTS streams: 0/1" or
         # "FCM clients: 0/1" reports (#111) can see at a glance which
@@ -918,16 +920,16 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _handle_devices_snapshot(self, devices: list[Device]) -> None:
         """Handle initial snapshot or full device snapshot update from stream."""
         for device in devices:
-            # Siren temperature (#220) comes from a separate per-device RPC,
-            # not this stream, so a fresh snapshot would wipe the value we
-            # merged in `_async_refresh_siren_temperatures` and leave the
-            # sensor `unknown` until the next timer fire. Carry the
+            # Per-device temperature (#220, #229) comes from a separate
+            # per-device RPC, not this stream, so a fresh snapshot would wipe
+            # the value we merged in `_async_refresh_hub_device_temperatures`
+            # and leave the sensor `unknown` until the next timer fire. Carry the
             # previously-merged temperature forward (it's slow-moving; the
             # periodic refresh still updates it).
             existing = self.devices.get(device.id)
             if (
                 existing is not None
-                and device.device_type in SIREN_TEMPERATURE_DEVICE_TYPES
+                and device.device_type in HUB_DEVICE_TEMPERATURE_DEVICE_TYPES
                 and "temperature" not in device.statuses
                 and "temperature" in existing.statuses
             ):
@@ -1155,9 +1157,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_shutdown(self) -> None:
         # Stop the siren-temperature refresh timer (#220)
-        if self._unsub_siren_temp is not None:
-            self._unsub_siren_temp()
-            self._unsub_siren_temp = None
+        if self._unsub_hub_device_temp is not None:
+            self._unsub_hub_device_temp()
+            self._unsub_hub_device_temp = None
 
         # Cancel all stream tasks
         for task in self._stream_tasks:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -20,7 +20,7 @@ from custom_components.aegis_ajax.api.models import (
     SpaceSnapshot,
 )
 from custom_components.aegis_ajax.const import (
-    SIREN_TEMP_REFRESH_INTERVAL,
+    HUB_DEVICE_TEMP_REFRESH_INTERVAL,
     ConnectionStatus,
     DeviceState,
     SecurityState,
@@ -1978,12 +1978,14 @@ class TestSmartLockProbeOrchestration:
         assert coordinator._smart_lock_probe_done is True
 
 
-def _make_siren(device_id: str, *, statuses: dict | None = None) -> Device:
+def _make_siren(
+    device_id: str, *, statuses: dict | None = None, device_type: str = "street_siren"
+) -> Device:
     return Device(
         id=device_id,
         hub_id="hub-1",
         name="Siren",
-        device_type="street_siren",
+        device_type=device_type,
         room_id=None,
         group_id=None,
         state=DeviceState.ONLINE,
@@ -1994,7 +1996,7 @@ def _make_siren(device_id: str, *, statuses: dict | None = None) -> Device:
     )
 
 
-class TestSirenTemperatureRefresh:
+class TestHubDeviceTemperatureRefresh:
     @pytest.mark.asyncio
     async def test_merges_temperature_into_siren_statuses(self) -> None:
         coordinator = _make_coordinator(["s1"])
@@ -2002,11 +2004,29 @@ class TestSirenTemperatureRefresh:
         coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
 
-        await coordinator._async_refresh_siren_temperatures()
+        await coordinator._async_refresh_hub_device_temperatures()
 
         assert coordinator.devices["s1d"].statuses["temperature"] == 21.0
         coordinator._devices_api.get_hub_device_temperature.assert_awaited_once_with("hub-1", "s1d")
         # The merge must be pushed to listeners or the sensor never materialises.
+        coordinator.async_set_updated_data.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_merges_temperature_into_curtain_outdoor_statuses(self) -> None:
+        # #229: outdoor curtain PIRs are gated for the StreamHubDevice
+        # temperature fetch just like sirens — the light stream omits their
+        # temperature, so the sensor only materialises via this path.
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {
+            "c1d": _make_siren("c1d", device_type="motion_protect_curtain_outdoor_plus")
+        }
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=17.0)
+
+        await coordinator._async_refresh_hub_device_temperatures()
+
+        assert coordinator.devices["c1d"].statuses["temperature"] == 17.0
+        coordinator._devices_api.get_hub_device_temperature.assert_awaited_once_with("hub-1", "c1d")
         coordinator.async_set_updated_data.assert_called_once()
 
     @pytest.mark.asyncio
@@ -2016,7 +2036,7 @@ class TestSirenTemperatureRefresh:
         coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
 
-        await coordinator._async_refresh_siren_temperatures()
+        await coordinator._async_refresh_hub_device_temperatures()
 
         coordinator._devices_api.get_hub_device_temperature.assert_not_called()
         assert "temperature" not in coordinator.devices["d1"].statuses
@@ -2029,7 +2049,7 @@ class TestSirenTemperatureRefresh:
         coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=99.0)
 
-        await coordinator._async_refresh_siren_temperatures()
+        await coordinator._async_refresh_hub_device_temperatures()
 
         coordinator._devices_api.get_hub_device_temperature.assert_not_called()
         assert coordinator.devices["s1d"].statuses["temperature"] == 18.0
@@ -2042,7 +2062,7 @@ class TestSirenTemperatureRefresh:
         coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=None)
 
-        await coordinator._async_refresh_siren_temperatures()
+        await coordinator._async_refresh_hub_device_temperatures()
 
         assert "temperature" not in coordinator.devices["s1d"].statuses
         coordinator.async_set_updated_data.assert_not_called()
@@ -2060,7 +2080,7 @@ class TestSirenTemperatureRefresh:
 
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(side_effect=_temp)
 
-        await coordinator._async_refresh_siren_temperatures()
+        await coordinator._async_refresh_hub_device_temperatures()
 
         assert coordinator.devices["good"].statuses["temperature"] == 20.0
         assert "temperature" not in coordinator.devices["bad"].statuses
@@ -2093,27 +2113,27 @@ class TestSirenTemperatureRefresh:
     def test_schedule_registers_independent_timer_and_initial_kick(self) -> None:
         coordinator = _make_coordinator(["s1"])
         # Replace with a MagicMock so the initial-kick call returns a non-coro.
-        coordinator._async_refresh_siren_temperatures = MagicMock()
+        coordinator._async_refresh_hub_device_temperatures = MagicMock()
         with patch(
             "custom_components.aegis_ajax.coordinator.async_track_time_interval",
             return_value=MagicMock(),
         ) as mock_track:
-            coordinator._schedule_siren_temperature_refresh()
+            coordinator._schedule_hub_device_temperature_refresh()
 
         mock_track.assert_called_once()
-        assert mock_track.call_args.args[2] == timedelta(seconds=SIREN_TEMP_REFRESH_INTERVAL)
-        assert coordinator._unsub_siren_temp is mock_track.return_value
+        assert mock_track.call_args.args[2] == timedelta(seconds=HUB_DEVICE_TEMP_REFRESH_INTERVAL)
+        assert coordinator._unsub_hub_device_temp is mock_track.return_value
         # Timer's first fire is one full interval out, so an initial
         # non-blocking kick must run for the sensor to appear within seconds.
         coordinator.hass.async_create_task.assert_called_once()
 
     def test_schedule_is_idempotent(self) -> None:
         coordinator = _make_coordinator(["s1"])
-        coordinator._unsub_siren_temp = MagicMock()
+        coordinator._unsub_hub_device_temp = MagicMock()
         with patch(
             "custom_components.aegis_ajax.coordinator.async_track_time_interval",
         ) as mock_track:
-            coordinator._schedule_siren_temperature_refresh()
+            coordinator._schedule_hub_device_temperature_refresh()
 
         mock_track.assert_not_called()
 
@@ -2121,7 +2141,7 @@ class TestSirenTemperatureRefresh:
     async def test_shutdown_cancels_timer(self) -> None:
         coordinator = _make_coordinator()
         unsub = MagicMock()
-        coordinator._unsub_siren_temp = unsub
+        coordinator._unsub_hub_device_temp = unsub
         coordinator._stream_tasks = []
         coordinator._hts_task = None
         coordinator._hts_client = None
@@ -2131,7 +2151,7 @@ class TestSirenTemperatureRefresh:
         await coordinator.async_shutdown()
 
         unsub.assert_called_once()
-        assert coordinator._unsub_siren_temp is None
+        assert coordinator._unsub_hub_device_temp is None
 
     def test_snapshot_preserves_merged_siren_temperature(self) -> None:
         coordinator = _make_coordinator()

--- a/tests/unit/test_hub_device_temperature.py
+++ b/tests/unit/test_hub_device_temperature.py
@@ -1,4 +1,9 @@
-"""Tests for siren internal temperature via the per-device StreamHubDevice RPC (#220)."""
+"""Tests for per-device internal temperature via the per-device StreamHubDevice RPC.
+
+Covers sirens (#220) and outdoor curtain PIRs (#229) — device families whose
+temperature lives only in the rich `StreamHubDevice` snapshot, not the lighter
+`StreamLightDevices` stream.
+"""
 
 from __future__ import annotations
 
@@ -59,6 +64,28 @@ class TestParseHubDeviceTemperature:
             )
         )
         assert parse_hub_device_temperature(hub_device) == 19.0
+
+    def test_returns_value_for_motion_protect_curtain_outdoor_mini(self) -> None:
+        # #229: outdoor curtain PIRs carry their temperature in the same
+        # `device_temperature` field on the rich HubDevice oneof, just like
+        # sirens. The parser is oneof-case-agnostic, so it must work unchanged.
+        # NOTE: our HubDevice proto only models the `_mini` curtain variant
+        # (field 21); the Base/Plus variants are not yet in the proto — see the
+        # #229 probe log in `DevicesApi.get_hub_device_temperature`.
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import (
+            hub_device_pb2,
+            motion_protect_curtain_outdoor_pb2,
+        )
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device.common import (
+            device_temperature_pb2,
+        )
+
+        hub_device = hub_device_pb2.HubDevice(
+            motion_protect_curtain_outdoor_mini=motion_protect_curtain_outdoor_pb2.MotionProtectCurtainOutdoorMini(
+                device_temperature=device_temperature_pb2.DeviceTemperature(value=17)
+            )
+        )
+        assert parse_hub_device_temperature(hub_device) == 17.0
 
     def test_returns_none_when_device_temperature_absent(self) -> None:
         from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import (


### PR DESCRIPTION
## Summary

Outdoor curtain motion detectors (*MotionProtect Curtain Outdoor*) expose their internal temperature in the Ajax app but not in HA (reported in #229). Their temperature lives only in the rich per-device `StreamHubDevice` snapshot, not the lighter `StreamLightDevices` stream we run continuously — the exact same shape as sirens (#220). So the auto-created temperature sensor never materialised for them.

This generalises the #220 siren-temperature path into a device-agnostic per-device temperature refresh.

## Changes

- Rename `SIREN_TEMPERATURE_DEVICE_TYPES` → `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES` (plus the timer, methods, interval const and `test_siren_temperature.py` → `test_hub_device_temperature.py`); keeping a `siren`-only name while it now gates curtains would be misleading.
- Add `motion_protect_curtain_outdoor_{base,mini,plus}` to the gate set.
- `parse_hub_device_temperature` already walks the `HubDevice` oneof generically, so any sub-message carrying `device_temperature` works with no parser change.

## Proto-drift caveat (important)

Our `HubDevice` proto only models the **`_mini`** curtain variant — oneof field 21, `MotionProtectCurtainOutdoorMini`, which carries `device_temperature`. The **Base/Plus** variants' oneof cases are **not in our proto snapshot**. The reporter's device is a **Plus**.

To resolve this empirically (cf. the #206 probe approach) without a blind proto regen, `DevicesApi.get_hub_device_temperature` now logs the actual `HubDevice.WhichOneof("device")` case at debug level whenever no temperature is found. A Base/Plus beta log will tell us exactly which message to add.

This means:
- **Mini** curtain → confirmed working in-proto.
- **Base/Plus** → fetch runs and degrades gracefully (returns `None`, no regression); the probe log captures the real oneof case for a follow-up proto addition if needed.

## Tests

- Parser: `device_temperature` extracted from the `motion_protect_curtain_outdoor_mini` oneof case.
- Coordinator: refresh merges temperature for a gated curtain device.

1529 passed, 88% coverage. lint/format/typecheck/vulture green (no-mount image build).

Refs #229