### PR TITLE
fix(binary_sensor): drop phantom CO sensor on generic FireProtect 2 (#231)

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.const import EntityCategory
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
@@ -180,11 +181,18 @@ _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
     "fire_protect": ["smoke_detected", "high_temperature", "tamper"],
     "fire_protect_plus": ["smoke_detected", "co_detected", "high_temperature", "tamper"],
     # FireProtect 2 family. Ajax's hub catalog uses both `_2` (legacy) and
-    # `_two*` (current) naming for the same generation of detectors. Map all
-    # variants to the same expressive sensor set; sub-models that don't have
-    # CO/smoke/heat physically just leave the corresponding entity at False.
-    "fire_protect_2": ["smoke_detected", "steam", "co_detected", "high_temperature", "tamper"],
-    "fire_protect_two": ["smoke_detected", "steam", "co_detected", "high_temperature", "tamper"],
+    # `_two*` (current) naming for the same generation of detectors.
+    #
+    # CO is the OPTIONAL cell across this line — only the SKUs whose object_type
+    # name explicitly encodes it (`*_c*`, `*_hc*`, `*_hsc*`) physically have it.
+    # The generic `fire_protect_two` case (which the cloud reports for plain
+    # Heat/Smoke RB units that lack a dedicated enum variant) must therefore
+    # NOT advertise a `co_detected` entity: doing so created a phantom CO sensor
+    # stuck at "Clear" on detectors that have no CO cell at all (#231). Smoke +
+    # heat are always present on a FireProtect 2, so they stay. A real CO alarm
+    # on a CO-equipped unit still arrives via FCM push regardless of this map.
+    "fire_protect_2": ["smoke_detected", "steam", "high_temperature", "tamper"],
+    "fire_protect_two": ["smoke_detected", "steam", "high_temperature", "tamper"],
     "fire_protect_two_base": [
         "smoke_detected",
         "steam",
@@ -343,6 +351,21 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = []
     for device_id, device in coordinator.devices.items():
         sensor_keys = _DEVICE_TYPE_SENSORS.get(device.device_type, ["tamper"])
+        # #231 data probe: CO presence on the FireProtect 2 line is decided by
+        # the object_type variant, but the cloud reports several units under
+        # generic/non-sensor-encoded types (`fire_protect_two`, `_base`,
+        # `_plus`, `_plus_sb`, `_sb`) where we can only guess whether a CO cell
+        # exists. Log the exact type + our CO decision so a diagnostic from a
+        # CO-equipped detector tells us which type it actually reports — the one
+        # piece of data needed to confirm the `_base`/`_plus`/`_sb` mappings
+        # (and whether a CO model can ever land on the generic case).
+        if device.device_type.startswith(("fire_protect_two", "fire_protect_2")):
+            _LOGGER.debug(
+                "FireProtect 2 setup: device_type=%s co_sensor=%s (sensors=%s)",
+                device.device_type,
+                "co_detected" in sensor_keys,
+                sensor_keys,
+            )
         for key in sensor_keys:
             if key in BINARY_SENSOR_TYPES:
                 entities.append(
@@ -360,7 +383,51 @@ async def async_setup_entry(
                 entities.append(AjaxHubEthernetSensor(coordinator, space.hub_id))
                 entities.append(AjaxHubWifiSensor(coordinator, space.hub_id))
                 entities.append(AjaxHubPowerSensor(coordinator, space.hub_id))
+
+    # #231: a previous version attached a CO sensor to the generic FireProtect 2
+    # mapping. HA never evicts an entity its platform stopped providing, so on
+    # upgrade those phantom CO sensors would linger as `unavailable`. Mirror the
+    # bypass-switch eviction (switch.py) and drop CO entities this run no longer
+    # provides. Only runs when devices are loaded so a transient empty snapshot
+    # can't wipe a legitimate CO sensor (it would be recreated next setup anyway).
+    if coordinator.devices:
+        _evict_orphan_co_sensors(
+            hass,
+            entry,
+            provided={
+                e.unique_id
+                for e in entities
+                if isinstance(e, AjaxBinarySensor)
+                and e._status_key == "co_detected"
+                and e.unique_id is not None
+            },
+        )
     async_add_entities(entities)
+
+
+def _evict_orphan_co_sensors(
+    hass: HomeAssistant, entry: ConfigEntry, *, provided: set[str]
+) -> None:
+    """Remove `co_detected` binary sensors this run no longer provides (#231).
+
+    FireProtect 2 detectors without a CO cell used to get a phantom CO sensor
+    from the generic device-type mapping. HA leaves an entity its platform
+    stopped providing in the registry as `unavailable` until the user deletes
+    it by hand, so evict the stale CO entities at the registry level — same
+    approach as the orphan bypass-switch cleanup.
+    """
+    entity_reg = er.async_get(hass)
+    for reg_entry in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
+        if (
+            reg_entry.domain == "binary_sensor"
+            and reg_entry.unique_id.endswith("_co_detected")
+            and reg_entry.unique_id not in provided
+        ):
+            _LOGGER.info(
+                "Removing orphaned CO sensor %s — the device has no CO cell (#231)",
+                reg_entry.entity_id,
+            )
+            entity_reg.async_remove(reg_entry.entity_id)
 
 
 class AjaxBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensorEntity):

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -23,6 +23,7 @@ from custom_components.aegis_ajax.binary_sensor import (
     AjaxHubPowerSensor,
     AjaxHubWifiSensor,
     AjaxProblemSensor,
+    async_setup_entry,
 )
 from custom_components.aegis_ajax.const import ConnectionStatus, DeviceState, SecurityState
 
@@ -594,6 +595,51 @@ class TestDeviceTypeSensors:
     def test_fire_protect_without_smoke_chamber_has_no_steam(self, device_type: str) -> None:
         assert "steam" not in _DEVICE_TYPE_SENSORS[device_type]
 
+    # #231: CO is the optional cell on the FireProtect 2 line. The generic
+    # object_type (which the cloud reports for plain Heat/Smoke RB units that
+    # lack a dedicated enum variant) must NOT advertise a CO sensor — that
+    # created a phantom "Clear" CO entity on detectors with no CO cell.
+    @pytest.mark.parametrize(
+        "device_type",
+        [
+            "fire_protect_2",
+            "fire_protect_two",
+            "fire_protect",
+            "fire_protect_two_hrb",
+            "fire_protect_two_hsb",
+            "fire_protect_two_h_ac",
+            "fire_protect_two_h_rb_ul",
+            "fire_protect_two_hs_ac",
+            "fire_protect_two_hs_ac_ul",
+            "fire_protect_two_hs_rb_ul",
+            "fire_protect_two_hs_sb_ul",
+        ],
+    )
+    def test_fire_protect_without_co_cell_has_no_co(self, device_type: str) -> None:
+        assert "co_detected" not in _DEVICE_TYPE_SENSORS[device_type]
+
+    # Regression guard: every variant whose object_type explicitly encodes a CO
+    # cell (`*_c*`, `*_hc*`, `*_hsc*`) must keep its CO sensor.
+    @pytest.mark.parametrize(
+        "device_type",
+        [
+            "fire_protect_plus",
+            "fire_protect_two_crb",
+            "fire_protect_two_csb",
+            "fire_protect_two_c_ac",
+            "fire_protect_two_c_rb_ul",
+            "fire_protect_two_hcrb",
+            "fire_protect_two_hcsb",
+            "fire_protect_two_hc_ac",
+            "fire_protect_two_hsc_ac",
+            "fire_protect_two_hsc_ac_ul",
+            "fire_protect_two_hsc_rb_ul",
+            "fire_protect_two_hsc_sb_ul",
+        ],
+    )
+    def test_fire_protect_with_co_cell_has_co(self, device_type: str) -> None:
+        assert "co_detected" in _DEVICE_TYPE_SENSORS[device_type]
+
     # Hub family — `hub`, `hub_plus`, `hub_two_4g` were already mapped, but
     # the v3 catalog also names `hub_two`, `hub_two_plus`, `hub_hybrid_*`,
     # `hub_mega`, `hub_lite`, `hub_4g`, `hub_three`, etc. Anyone running a
@@ -1076,3 +1122,96 @@ class TestAjaxHubPowerSensor:
         coordinator.hub_network = {}
         sensor = AjaxHubPowerSensor(coordinator, "hub-1")
         assert sensor.available is False
+
+
+def _reg_entry(entity_id: str, unique_id: str, domain: str = "binary_sensor") -> MagicMock:
+    e = MagicMock()
+    e.entity_id = entity_id
+    e.unique_id = unique_id
+    e.domain = domain
+    return e
+
+
+class TestOrphanCoSensorEviction:
+    """#231: phantom CO sensors on no-CO FireProtect 2 units are evicted."""
+
+    def _make_device(self, device_id: str, device_type: str) -> Device:
+        return Device(
+            id=device_id,
+            hub_id="hub-1",
+            name="FireProtect 2 RB",
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    async def _run(self, *, devices: dict[str, Device], registry_entries: list) -> list[str]:
+        coordinator = MagicMock()
+        coordinator.devices = devices
+        coordinator.spaces = {}
+        coordinator.rooms = {}
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.runtime_data = coordinator
+
+        removed: list[str] = []
+        entity_reg = MagicMock()
+        entity_reg.async_remove.side_effect = removed.append
+
+        def _add(entities: list, *a: object, **k: object) -> None:
+            pass
+
+        with (
+            patch(
+                "custom_components.aegis_ajax.binary_sensor.er.async_get",
+                return_value=entity_reg,
+            ),
+            patch(
+                "custom_components.aegis_ajax.binary_sensor.er.async_entries_for_config_entry",
+                return_value=registry_entries,
+            ),
+        ):
+            await async_setup_entry(MagicMock(), entry, _add)
+        return removed
+
+    @pytest.mark.asyncio
+    async def test_evicts_co_on_generic_no_co_device(self) -> None:
+        removed = await self._run(
+            devices={"d1": self._make_device("d1", "fire_protect_two")},
+            registry_entries=[_reg_entry("binary_sensor.d1_co", "aegis_ajax_d1_co_detected")],
+        )
+        assert removed == ["binary_sensor.d1_co"]
+
+    @pytest.mark.asyncio
+    async def test_keeps_co_on_co_equipped_device(self) -> None:
+        removed = await self._run(
+            devices={"d1": self._make_device("d1", "fire_protect_two_hcrb")},
+            registry_entries=[_reg_entry("binary_sensor.d1_co", "aegis_ajax_d1_co_detected")],
+        )
+        assert removed == []
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_other_binary_sensors(self) -> None:
+        removed = await self._run(
+            devices={"d1": self._make_device("d1", "fire_protect_two")},
+            registry_entries=[
+                _reg_entry("binary_sensor.d1_smoke", "aegis_ajax_d1_smoke_detected"),
+                _reg_entry("binary_sensor.d1_co", "aegis_ajax_d1_co_detected"),
+            ],
+        )
+        assert removed == ["binary_sensor.d1_co"]
+
+    @pytest.mark.asyncio
+    async def test_skips_eviction_when_no_devices_loaded(self) -> None:
+        # A transient empty snapshot must NOT wipe a legitimate CO entity.
+        removed = await self._run(
+            devices={},
+            registry_entries=[_reg_entry("binary_sensor.d1_co", "aegis_ajax_d1_co_detected")],
+        )
+        assert removed == []


### PR DESCRIPTION
## Summary

FireProtect 2 detectors of the **Heat/Smoke** type (no CO cell) were showing a Carbon monoxide binary sensor stuck at "Clear" (reported in #231). The cloud reports these plain Heat/Smoke RB units under the **generic `fire_protect_two`** object_type — they have no dedicated sensor-encoded enum variant — and the generic mapping blanket-attached `co_detected`.

## Root cause

`device_type = object_type.WhichOneof("type")` (`devices_parser.py`). The reporter's diagnostics show his 8 FireProtect 2 RB units all resolve to the generic `fire_protect_two`, and `binary_sensor.py` mapped that to `[smoke, steam, co_detected, high_temperature, tamper]`. CO is the **optional** cell on this line — only SKUs whose object_type name explicitly encodes it (`*_c*`, `*_hc*`, `*_hsc*`) physically have it. The variant-specific mappings were already correct; only the generic catch-all over-promised CO.

The rich `StreamHubDevice` proto doesn't even model FireProtect 2 (only `en54_*`), so CO capability can't be read per-device — the object_type variant is the only signal, and it's generic here.

## Changes

- Drop `co_detected` from `fire_protect_two` / `fire_protect_2` → `[smoke_detected, steam, high_temperature, tamper]`. Smoke + heat are always present; a real CO alarm on a CO-equipped unit still arrives via FCM push.
- **Evict the orphaned CO entities** at the registry level (mirrors the bypass-switch / ghost-doorbell cleanup) so they don't linger as `unavailable` after upgrade. Guarded to no-op on an empty device snapshot so a transient load can't wipe a legitimate CO sensor.
- **DEBUG probe**: log each FireProtect 2's exact `object_type` + our CO decision. `_base`/`_plus`/`_plus_sb`/`_sb` are intentionally **left untouched** (Ajax's "Plus" historically implies +CO); a diagnostic from a CO-equipped detector will confirm which type those models report before we change their mappings.

## Tests

- Generic / Heat-only / Heat-Smoke variants have **no** CO; every C-encoded variant **keeps** CO.
- Orphan eviction removes only unprovided `_co_detected` entities, ignores other binary sensors, and no-ops on an empty snapshot.

1556 passed, 88% coverage. lint/format/typecheck/vulture green (no-mount image build).

Refs #231