### PR TITLE
fix(lock): drive lock/unlock via DeviceCommandDeviceOn/Off (#219)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -566,11 +566,15 @@ class DevicesApi:
         channel = self._client._get_channel()
         metadata = self._client._session.get_call_metadata()
         stub = endpoint_pb2_grpc.DeviceCommandDeviceOnServiceStub(channel)
+        # Send channels exactly as given. Channelled devices (relay, socket,
+        # wall/light switch) pass an explicit `[channel]`; a SmartLock (#219)
+        # passes none — the Ajax app omits channels for the lock on/off command,
+        # so an empty list leaves the repeated field unset, matching the wire.
         request = request_pb2.DeviceCommandDeviceOnRequest(
             hub_id=command.hub_id,
             device_id=command.device_id,
             device_type=_build_object_type(command.device_type),
-            channels=command.channels or [1],
+            channels=command.channels,
         )
         response = await stub.execute(request, metadata=metadata, timeout=15)
         if response.HasField("failure"):
@@ -587,11 +591,13 @@ class DevicesApi:
         channel = self._client._get_channel()
         metadata = self._client._session.get_call_metadata()
         stub = endpoint_pb2_grpc.DeviceCommandDeviceOffServiceStub(channel)
+        # See `_device_on`: channels are sent as given (explicit per channel for
+        # relays/switches, empty for a SmartLock #219).
         request = request_pb2.DeviceCommandDeviceOffRequest(
             hub_id=command.hub_id,
             device_id=command.device_id,
             device_type=_build_object_type(command.device_type),
-            channels=command.channels or [1],
+            channels=command.channels,
         )
         response = await stub.execute(request, metadata=metadata, timeout=15)
         if response.HasField("failure"):

--- a/custom_components/aegis_ajax/lock.py
+++ b/custom_components/aegis_ajax/lock.py
@@ -9,11 +9,11 @@ from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.devices import (
-    SMART_LOCK_ACTION_LOCK,
     SMART_LOCK_ACTION_UNLATCH,
-    SMART_LOCK_ACTION_UNLOCK,
+    DeviceCommandError,
     SmartLockError,
 )
+from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 from custom_components.aegis_ajax.entity import build_device_info
 
@@ -28,8 +28,9 @@ _LOGGER = logging.getLogger(__name__)
 
 # Ajax catalog ships two SmartLock device-type buckets — `smart_lock` for
 # generic LockBridge integrations and `smart_lock_yale` for Yale-branded
-# locks. Both expose the same status oneof and are controlled by the same
-# SwitchSmartLockService, so they share a single entity class.
+# locks. Both expose the same status oneof, so they share a single entity
+# class. Lock/unlock is driven through the generic device on/off command
+# (see `_async_switch`), unlatch through SwitchSmartLockService.
 LOCK_DEVICE_TYPES: frozenset[str] = frozenset({"smart_lock", "smart_lock_yale"})
 
 
@@ -45,7 +46,12 @@ async def async_setup_entry(
 
 
 class AjaxLock(CoordinatorEntity[AjaxCobrandedCoordinator], LockEntity):
-    """Lock entity backed by the Ajax SmartLock status + SwitchSmartLockService."""
+    """Lock entity backed by the Ajax SmartLock status stream.
+
+    State comes from the device status stream; lock/unlock is sent via the
+    generic `DeviceCommandDeviceOn/Off` command (#219), unlatch via
+    `SwitchSmartLockService`.
+    """
 
     _attr_has_entity_name = True
     _attr_name = None
@@ -98,7 +104,43 @@ class AjaxLock(CoordinatorEntity[AjaxCobrandedCoordinator], LockEntity):
             return None
         return device.statuses.get("smart_lock_state") == "unlatched"
 
+    async def _async_switch(self, *, lock: bool) -> None:
+        """Lock/unlock via the generic device on/off command (#219).
+
+        Hub-attached Jeweller locks (e.g. Yale modules added by an installer
+        on a third-party backend) are not in the SmartLock cloud registry, so
+        `SwitchSmartLockService` answers `smart_lock_not_found`. The Ajax app
+        drives them with `DeviceCommandDeviceOn/Off` keyed by device id —
+        lock = On, unlock = Off — exactly as for a relay (verified against the
+        app). No channel is sent for a lock.
+        """
+        device = self._device
+        if device is None:
+            return
+        factory = DeviceCommand.on if lock else DeviceCommand.off
+        command = factory(
+            hub_id=device.hub_id,
+            device_id=self._device_id,
+            device_type=device.device_type,
+        )
+        try:
+            await self.coordinator.devices_api.send_command(command)
+        except DeviceCommandError as exc:
+            _LOGGER.error(
+                "SmartLock %s %s failed: %s",
+                self._device_id,
+                "lock" if lock else "unlock",
+                exc,
+            )
+            return
+        await self.coordinator.async_request_refresh()
+
     async def _send_action(self, action: int) -> None:
+        """Unlatch (OPEN) via SwitchSmartLockService — the only unlatch path.
+
+        Lock/unlock no longer use this (see `_async_switch`); it remains for
+        the OPEN feature, which the generic on/off command can't express.
+        """
         space_id = self._resolve_space_id()
         if space_id is None:
             _LOGGER.error(
@@ -116,10 +158,10 @@ class AjaxLock(CoordinatorEntity[AjaxCobrandedCoordinator], LockEntity):
         await self.coordinator.async_request_refresh()
 
     async def async_lock(self, **kwargs: object) -> None:
-        await self._send_action(SMART_LOCK_ACTION_LOCK)
+        await self._async_switch(lock=True)
 
     async def async_unlock(self, **kwargs: object) -> None:
-        await self._send_action(SMART_LOCK_ACTION_UNLOCK)
+        await self._async_switch(lock=False)
 
     async def async_open(self, **kwargs: object) -> None:
         await self._send_action(SMART_LOCK_ACTION_UNLATCH)

--- a/tests/unit/test_lock.py
+++ b/tests/unit/test_lock.py
@@ -7,12 +7,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.aegis_ajax.api.devices import (
-    SMART_LOCK_ACTION_LOCK,
     SMART_LOCK_ACTION_UNLATCH,
-    SMART_LOCK_ACTION_UNLOCK,
-    SmartLockError,
+    DeviceCommandError,
 )
-from custom_components.aegis_ajax.api.models import Device, Space
+from custom_components.aegis_ajax.api.models import Device, DeviceCommand, Space
 from custom_components.aegis_ajax.const import (
     ConnectionStatus,
     DeviceState,
@@ -60,6 +58,7 @@ def _make_coordinator(device: Device) -> MagicMock:
     }
     coordinator.devices_api = MagicMock()
     coordinator.devices_api.switch_smart_lock = AsyncMock()
+    coordinator.devices_api.send_command = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
     return coordinator
 
@@ -126,29 +125,52 @@ class TestAjaxLockState:
 
 class TestAjaxLockCommands:
     @pytest.mark.asyncio
-    async def test_async_lock_invokes_lock_action(self) -> None:
-        device = _make_device("smart_lock", "unlocked")
+    @pytest.mark.parametrize("device_type", ["smart_lock", "smart_lock_yale"])
+    async def test_async_lock_sends_device_on(self, device_type: str) -> None:
+        # #219: lock = DeviceCommandDeviceOn keyed by device id, no channels.
+        device = _make_device(device_type, "unlocked")
         coordinator = _make_coordinator(device)
         lock = AjaxLock(coordinator=coordinator, device_id=device.id)
 
         await lock.async_lock()
 
-        coordinator.devices_api.switch_smart_lock.assert_awaited_once_with(
-            space_id="space-A", smart_lock_id="lock-1", action=SMART_LOCK_ACTION_LOCK
-        )
+        coordinator.devices_api.send_command.assert_awaited_once()
+        cmd: DeviceCommand = coordinator.devices_api.send_command.await_args.args[0]
+        assert cmd.action == "on"
+        assert cmd.hub_id == "hub-1"
+        assert cmd.device_id == "lock-1"
+        assert cmd.device_type == device_type
+        assert cmd.channels == []
+        coordinator.devices_api.switch_smart_lock.assert_not_called()
         coordinator.async_request_refresh.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_async_unlock_invokes_unlock_action(self) -> None:
+    async def test_async_unlock_sends_device_off(self) -> None:
         device = _make_device("smart_lock", "locked")
         coordinator = _make_coordinator(device)
         lock = AjaxLock(coordinator=coordinator, device_id=device.id)
 
         await lock.async_unlock()
 
-        coordinator.devices_api.switch_smart_lock.assert_awaited_once_with(
-            space_id="space-A", smart_lock_id="lock-1", action=SMART_LOCK_ACTION_UNLOCK
-        )
+        cmd: DeviceCommand = coordinator.devices_api.send_command.await_args.args[0]
+        assert cmd.action == "off"
+        assert cmd.device_id == "lock-1"
+        assert cmd.channels == []
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_lock_works_without_a_resolved_space(self) -> None:
+        # The device on/off command is keyed by hub_id, not space_id, so the
+        # lock no longer depends on resolving a space (unlike unlatch).
+        device = _make_device("smart_lock", "unlocked")
+        coordinator = _make_coordinator(device)
+        coordinator.spaces = {}
+        lock = AjaxLock(coordinator=coordinator, device_id=device.id)
+
+        await lock.async_lock()
+
+        coordinator.devices_api.send_command.assert_awaited_once()
+        coordinator.async_request_refresh.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_async_open_invokes_unlatch_action(self) -> None:
@@ -163,13 +185,12 @@ class TestAjaxLockCommands:
         )
 
     @pytest.mark.asyncio
-    async def test_command_swallows_smart_lock_error(self) -> None:
-        # We surface the failure through logs rather than raising — the
-        # entity should not crash HA's service call pipeline. The next poll
-        # corrects the displayed state.
+    async def test_lock_command_swallows_device_command_error(self) -> None:
+        # Surface the failure through logs rather than raising — the entity
+        # must not crash HA's service pipeline. Next poll corrects state.
         device = _make_device("smart_lock", "locked")
         coordinator = _make_coordinator(device)
-        coordinator.devices_api.switch_smart_lock.side_effect = SmartLockError("smart_lock_offline")
+        coordinator.devices_api.send_command.side_effect = DeviceCommandError("smart_lock_offline")
         lock = AjaxLock(coordinator=coordinator, device_id=device.id)
 
         await lock.async_unlock()  # must not raise
@@ -177,13 +198,13 @@ class TestAjaxLockCommands:
         coordinator.async_request_refresh.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_command_no_op_when_space_unresolvable(self) -> None:
+    async def test_open_no_op_when_space_unresolvable(self) -> None:
         device = _make_device("smart_lock", "locked")
         coordinator = _make_coordinator(device)
         coordinator.spaces = {}  # no space matches the hub_id
         lock = AjaxLock(coordinator=coordinator, device_id=device.id)
 
-        await lock.async_lock()
+        await lock.async_open()
 
         coordinator.devices_api.switch_smart_lock.assert_not_called()
         coordinator.async_request_refresh.assert_not_called()


### PR DESCRIPTION
## Summary

Lock/unlock from HA never worked for hub-attached Jeweller locks (e.g. Yale modules an installer adds on a third-party backend, #219 / #206). Their **state** works, but commands failed.

## Root cause (confirmed by decompiling the Ajax app)

These locks aren't in the SmartLock cloud registry — `findAllBySpace` is empty and `findAllAvailableToAdd` returns `external_service_access_denied` — so `SwitchSmartLockService.switchSmartLock(smart_lock_id)`, which the lock entity used, answers `smart_lock_not_found`.

The Ajax app drives them **not through any SmartLock service** but with the **generic `DeviceCommandDeviceOn/Off`** command, keyed by device id. The device-card lock control (`SmartLockSpreadInfoMini` → `switchSmartLockState` → `DeviceCommandDeviceOn/OffService`) builds `setHubId().setDeviceId().setDeviceType(ObjectType)`. Polarity, from the app: `switchOn = (desired != UNLOCKED)` → **lock = On, unlock = Off**.

This is the same path the integration already uses for relays/sockets/WallSwitch via `send_command(action="on"/"off")`.

## Changes

- `lock.async_lock`/`async_unlock` → `send_command` on/off, keyed by `hub_id` + `device_id` + `device_type` (the lock's `ObjectType`, already present: `smart_lock` / `smart_lock_yale`). No channel sent (the app omits it).
- `_device_on`/`_device_off` forward `command.channels` as given instead of defaulting empty→`[1]`. Every other caller passes an explicit channel, so relays/switches/lights are unchanged; a lock passes none.
- `async_open` (unlatch) stays on `SwitchSmartLockService` — the only unlatch path; on/off can't express it.
- No proto change.

## Validation

1559 passed, 88% coverage; lint/format/typecheck/vulture green (no-mount image).

**Polarity is read from the app, but this controls a physical door — keeping it in beta until @SebastianKristo confirms lock locks and unlock unlocks before it rolls into stable.**

Refs #219, #206