### PR TITLE
fix(stream): recreate gRPC channel on reconnect so device updates resume (#236)

### DIFF
--- a/custom_components/aegis_ajax/api/client.py
+++ b/custom_components/aegis_ajax/api/client.py
@@ -77,6 +77,9 @@ class AjaxGrpcClient:
         self._channel: grpc.aio.Channel | None = None
         self._rate_limit_timestamps: list[float] = []
         self._refresh_task: asyncio.Task[None] | None = None
+        # Serializes channel recreation (#236) so a stream reconnect and a
+        # poll failing on the same wedged channel don't churn it twice.
+        self._reconnect_lock = asyncio.Lock()
 
     @property
     def session(self) -> AjaxSession:
@@ -86,11 +89,39 @@ class AjaxGrpcClient:
     def is_connected(self) -> bool:
         return self._channel is not None and self._session.is_authenticated
 
-    async def connect(self) -> None:
+    def _open_channel(self) -> grpc.aio.Channel:
         target = f"{self._host}:{self._port}"
         credentials = grpc.ssl_channel_credentials()
-        self._channel = grpc.aio.secure_channel(target, credentials)
-        _LOGGER.debug("gRPC channel opened to %s", target)
+        return grpc.aio.secure_channel(target, credentials)
+
+    async def connect(self) -> None:
+        self._channel = self._open_channel()
+        _LOGGER.debug("gRPC channel opened to %s:%s", self._host, self._port)
+
+    async def reconnect_channel(self) -> None:
+        """Tear down the current gRPC channel and open a fresh one.
+
+        Used by long-lived consumers (the device stream) when the channel
+        wedges after a transport-level failure (UNAVAILABLE / peer reset)
+        and reconnecting onto it never recovers — the symptom behind #236,
+        where a single stream error left the integration silent for hours
+        until a full HA restart recreated the channel.
+
+        The session token is preserved, so no re-login is needed: callers
+        fetch the channel via `_get_channel()` at call time, so they
+        transparently pick up the new one on their next call. The lock
+        keeps a stream reconnect and a concurrent poll failure from
+        recreating the channel twice.
+        """
+        async with self._reconnect_lock:
+            old = self._channel
+            if old is not None:
+                try:
+                    await old.close()
+                except Exception:  # noqa: BLE001
+                    _LOGGER.debug("Error closing stale gRPC channel", exc_info=True)
+            self._channel = self._open_channel()
+            _LOGGER.debug("gRPC channel recreated after transport failure")
 
     async def close(self) -> None:
         if self._refresh_task and not self._refresh_task.done():
@@ -178,10 +209,13 @@ class AjaxGrpcClient:
         timeout: float = GRPC_TIMEOUT,
     ) -> Any:  # noqa: ANN401
         await self._check_rate_limit()
-        channel = self._get_channel()
         metadata = self._session.get_call_metadata()
 
         async def _do_call() -> Any:  # noqa: ANN401
+            # Re-fetch the channel on every attempt: if a stream reconnect
+            # recreated it (#236) between retries, the retried call must use
+            # the fresh channel rather than the dead one captured up front.
+            channel = self._get_channel()
             method = channel.unary_unary(
                 method_path,
                 request_serializer=request.SerializeToString,

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -499,6 +499,22 @@ class DevicesApi:
                         space_id,
                         backoff,
                     )
+                    # Recreate the shared channel before retrying. The peer
+                    # reset (UNAVAILABLE) can leave the channel half-open, and
+                    # reconnecting onto it never recovers — the integration
+                    # then goes silent until a full HA restart (#236). A fresh
+                    # channel re-opens the stream cleanly; the server resends a
+                    # snapshot, so device state re-syncs on its own.
+                    try:
+                        await self._client.reconnect_channel()
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.debug(
+                            "Channel recreation failed for space %s; will retry",
+                            space_id,
+                            exc_info=True,
+                        )
 
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 60.0)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import grpc
 import pytest
 
 from custom_components.aegis_ajax.api.client import AjaxGrpcClient
@@ -106,6 +108,70 @@ class TestClientConnect:
         await client.close()
 
 
+class TestReconnectChannel:
+    """Channel recreation after a wedged transport (issue #236).
+
+    A long-lived stream that hits UNAVAILABLE must be able to swap the
+    shared channel for a fresh one without re-login, so reconnection
+    doesn't land back on the same half-open channel forever.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reconnect_opens_fresh_channel_and_closes_old(self) -> None:
+        client = AjaxGrpcClient.__new__(AjaxGrpcClient)
+        client._host = GRPC_HOST
+        client._port = GRPC_PORT
+        client._reconnect_lock = asyncio.Lock()
+        old_channel = AsyncMock()
+        client._channel = old_channel
+
+        new_channel = MagicMock()
+        with (
+            patch("grpc.ssl_channel_credentials"),
+            patch("grpc.aio.secure_channel", return_value=new_channel) as mock_secure,
+        ):
+            await client.reconnect_channel()
+
+        old_channel.close.assert_awaited_once()
+        assert client._channel is new_channel
+        mock_secure.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reconnect_with_no_existing_channel(self) -> None:
+        client = AjaxGrpcClient.__new__(AjaxGrpcClient)
+        client._host = GRPC_HOST
+        client._port = GRPC_PORT
+        client._reconnect_lock = asyncio.Lock()
+        client._channel = None
+
+        new_channel = MagicMock()
+        with (
+            patch("grpc.ssl_channel_credentials"),
+            patch("grpc.aio.secure_channel", return_value=new_channel),
+        ):
+            await client.reconnect_channel()
+
+        assert client._channel is new_channel
+
+    @pytest.mark.asyncio
+    async def test_reconnect_preserves_session(self) -> None:
+        client = AjaxGrpcClient.__new__(AjaxGrpcClient)
+        client._host = GRPC_HOST
+        client._port = GRPC_PORT
+        client._reconnect_lock = asyncio.Lock()
+        client._channel = AsyncMock()
+        session = MagicMock()
+        client._session = session
+
+        with (
+            patch("grpc.ssl_channel_credentials"),
+            patch("grpc.aio.secure_channel", return_value=MagicMock()),
+        ):
+            await client.reconnect_channel()
+
+        session.clear_session.assert_not_called()
+
+
 class TestRateLimit:
     @pytest.mark.asyncio
     async def test_rate_limit_passes_under_limit(self) -> None:
@@ -194,6 +260,42 @@ class TestCallUnary:
         result = await client.call_unary("/some/method", mock_request, mock_response_type)
         assert result is mock_response
         mock_channel.unary_unary.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_call_unary_refetches_channel_between_retries(self) -> None:
+        """After the channel is recreated mid-flight (#236), a retried unary
+        call must pick up the new channel instead of reusing the dead one."""
+        client = AjaxGrpcClient.__new__(AjaxGrpcClient)
+        client._rate_limit_timestamps = []
+        mock_session = MagicMock()
+        mock_session.get_call_metadata.return_value = []
+        client._session = mock_session
+
+        channel_a = MagicMock()
+        channel_b = MagicMock()
+        client._channel = channel_a
+
+        transient = grpc.aio.AioRpcError(
+            grpc.StatusCode.UNAVAILABLE,
+            grpc.aio.Metadata(),
+            grpc.aio.Metadata(),
+            details="",
+        )
+
+        async def method_a(*_args: object, **_kwargs: object) -> None:
+            # Simulate the stream task swapping the channel out from under us.
+            client._channel = channel_b
+            raise transient
+
+        channel_a.unary_unary.return_value = AsyncMock(side_effect=method_a)
+        mock_response = MagicMock()
+        channel_b.unary_unary.return_value = AsyncMock(return_value=mock_response)
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            result = await client.call_unary("/m", MagicMock(), MagicMock())
+
+        assert result is mock_response
+        channel_b.unary_unary.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_call_server_stream(self) -> None:

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -2841,3 +2841,54 @@ class TestSmartLockProbe:
         assert any(
             "findAllAvailableToAdd" in r.message and "failed" in r.message for r in caplog.records
         )
+
+
+class TestDeviceStreamReconnect:
+    """The persistent device stream must recreate the shared gRPC channel
+    after a transport-level failure instead of reconnecting onto the same
+    wedged channel forever (issue #236)."""
+
+    @pytest.mark.asyncio
+    async def test_stream_recreates_channel_after_transport_error(self) -> None:
+        import grpc
+
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        client.reconnect_channel = AsyncMock()
+        api = DevicesApi(client)
+
+        transient = grpc.aio.AioRpcError(
+            grpc.StatusCode.UNAVAILABLE,
+            grpc.aio.Metadata(),
+            grpc.aio.Metadata(),
+            details="",
+        )
+
+        class _FailingStream:
+            def __aiter__(self) -> _FailingStream:
+                return self
+
+            async def __anext__(self) -> object:
+                raise transient
+
+        mock_stub = MagicMock()
+        mock_stub.execute.return_value = _FailingStream()
+
+        async def _stop_after_backoff(_delay: float) -> None:
+            # End the otherwise-infinite reconnect loop once it backs off.
+            raise asyncio.CancelledError
+
+        with (
+            patch(
+                "v3.mobilegwsvc.service.stream_light_devices."
+                "endpoint_pb2_grpc.StreamLightDevicesServiceStub",
+                return_value=mock_stub,
+            ),
+            patch("asyncio.sleep", side_effect=_stop_after_backoff),
+        ):
+            task = await api.start_device_stream("space-1", MagicMock(), MagicMock())
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        client.reconnect_channel.assert_awaited_once()


### PR DESCRIPTION
## Problem (#236)

A user's device stream terminated with `StatusCode.UNAVAILABLE` (peer reset) and **nothing synced for ~6 hours** until a full HA restart. The log showed a *single* `Device stream error ... reconnecting in 5s` followed by silence — not a crash-looping reconnect.

## Root cause

The persistent device stream shares one cached `grpc.aio` channel (`AjaxGrpcClient._channel`) with polling and commands. The reconnect loop in `start_device_stream._run_stream` already had exponential backoff (5→60s, `while True`), but on each retry it re-opened the stream on the **same** channel via `_get_channel()`. A peer reset can leave that channel half-open, so the retried `stub.execute(timeout=None)` neither raised nor delivered messages — and because the channel is shared, polling (`list_spaces`) on the same channel stalled too. Only a restart (which recreates the channel) recovered it. This matches the "one error then hours of nothing" signature exactly.

## Fix

The backoff was never the problem — renewing the transport was missing.

- **`client.reconnect_channel()`** (new): closes the old channel and opens a fresh one, **preserving the session token** (no re-login). Guarded by an `asyncio.Lock` so a stream reconnect and a concurrent poll failure can't churn the channel twice. `connect()` refactored to share `_open_channel()`.
- **`_run_stream`**: on a transport failure, `await self._client.reconnect_channel()` before backing off, so the next iteration opens the stream on a fresh channel. The server resends a snapshot on reopen, so device state re-syncs automatically.
- **`call_unary`**: re-fetches the channel on each retry attempt instead of capturing it up front, so an in-flight poll recovers onto the new channel too.

## Tests

- `reconnect_channel`: opens a distinct channel, closes the old one, preserves the session.
- `call_unary` re-fetches the channel between retries.
- The stream loop invokes `reconnect_channel` after an `UNAVAILABLE`.

Full suite: 1564 passed, coverage 88.31%. lint / format / typecheck / dead-code clean (no-mount CI).

Refs #236