### PR TITLE
docs: recommend a separate Ajax account for reliable real-time push (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,20 @@ Click the button above, or manually:
 4. Select which spaces (hubs) to add
 5. Done
 
-> **Recommended: use a dedicated, limited Ajax account.** Instead of your primary
-> admin login, create a separate Ajax account, invite it to your space (Ajax app →
-> space → Users → Invite) and grant it only what the integration needs. A non-admin
-> **User** role is enough to read device state and arm / disarm. You can also revoke
-> its **photo / video** access if you don't use Photo on Demand, so Home Assistant
-> never has access to camera images. This keeps your main credentials out of HA and
-> limits what a compromised HA host could reach in your Ajax installation.
+> **Recommended: use a dedicated Ajax account, separate from the one on your phone.**
+> Instead of your primary admin login, create a separate Ajax account, invite it to
+> your space (Ajax app → space → Users → Invite) and grant it only what the
+> integration needs. A non-admin **User** role is enough to read device state and
+> arm / disarm. You can also revoke its **photo / video** access if you don't use
+> Photo on Demand, so Home Assistant never has access to camera images. This keeps
+> your main credentials out of HA and limits what a compromised HA host could reach
+> in your Ajax installation.
+>
+> **This also matters for real-time updates.** Running the *same* Ajax account in
+> both your phone app and Home Assistant can prevent instant push notifications from
+> reaching HA — changes you make from the app (arm / disarm, sensor events) would
+> then only appear on the next poll instead of immediately. Giving HA its own account
+> avoids this contention.
 >
 > Trade-offs to know: without photo / video permission the MotionCam Photo-on-Demand
 > button won't work, and per-device bypass switches need the account to hold the

--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ The integration can run with or without Firebase Cloud Messaging (FCM) push, but
 
 If you cannot configure FCM, the integration still works as a polled view of your Ajax installation, but automations that rely on alarm-panel events will not fire. You can dismiss the related Repair card; the integration will not break.
 
+> **FCM shows connected but app → HA updates still don't arrive?** Make sure Home
+> Assistant uses a **different Ajax account than your phone app**. Ajax doesn't
+> reliably deliver one account's push to two sessions at once, so an actively-used
+> phone app can leave HA's push channel starved even though FCM reports connected —
+> you'd still get changes on the next poll, just not instantly. A dedicated account
+> for HA (see [Configuration](#configuration)) avoids this.
+
 > **Alternative to FCM: Ajax's SIA stream.** If you'd rather not extract Firebase
 > credentials at all, many Ajax hubs can stream events to Home Assistant's built-in
 > [SIA integration](https://www.home-assistant.io/integrations/sia/) (set up a


### PR DESCRIPTION
Strengthens the existing "dedicated, limited Ajax account" recommendation in the README.

Today the note sells a separate account purely on **security / least-privilege** grounds. This adds the **real-time updates** angle: running the *same* Ajax account in both the phone app and Home Assistant can prevent push notifications from reaching HA — app-side changes (arm/disarm, sensor events) then only surface on the next poll instead of instantly. A dedicated account for HA avoids that contention.

Motivated by #234 (FCM connected, but app→HA updates only arrive via polling). Wording is intentionally hedged ("can prevent") since the precise Ajax-side mechanism isn't fully confirmed yet — but two sessions of one account interfering is already the rationale behind the recommended setup.

Docs-only, no code change.

Refs #234