### PR TITLE
fix(config_flow): refresh entry title & unique_id when reconfiguring account (#241)

### DIFF
--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -457,7 +457,15 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._client and self._client.session.session_token:
             new_data["session_token"] = self._client.session.session_token
             new_data["user_hex_id"] = self._client.session.user_hex_id
-        return self.async_update_reload_and_abort(entry, data=new_data)
+        # Refresh the visible title and unique_id too, not just the data —
+        # otherwise switching accounts leaves the old email on the entry's
+        # front page until a second reconfigure (#241).
+        return self.async_update_reload_and_abort(
+            entry,
+            unique_id=self._email,
+            title=f"Ajax Security ({self._email})",
+            data=new_data,
+        )
 
     @staticmethod
     @callback

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -633,6 +633,44 @@ class TestAsyncStepReauth:
         assert kwargs["data"]["session_token"] == "tok-2fa"
 
 
+class TestAsyncFinishReconfigure:
+    """Reconfiguring to a different account must refresh the entry's visible
+    title and unique_id, not just its data (#241)."""
+
+    @staticmethod
+    def _make_flow() -> tuple[AjaxCobrandedConfigFlow, MagicMock]:
+        flow = AjaxCobrandedConfigFlow()
+        entry = MagicMock()
+        entry.data = {"email": "old@example.com", "app_label": "Ajax"}
+        entry.unique_id = "old@example.com"
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+        flow.async_update_reload_and_abort = MagicMock(return_value={"type": "abort"})
+        return flow, entry
+
+    @pytest.mark.asyncio
+    async def test_finish_reconfigure_updates_title_and_unique_id(self) -> None:
+        flow, entry = self._make_flow()
+        flow._email = "new@example.com"
+        flow._app_label = "Ajax"
+        flow._password_hash = hashlib.sha256(b"pw").hexdigest()
+        mock_client = MagicMock()
+        mock_client.session.session_token = "tok"
+        mock_client.session.user_hex_id = "hex"
+        flow._client = mock_client
+
+        await flow._async_finish_reconfigure()
+
+        flow.async_update_reload_and_abort.assert_called_once()
+        kwargs = flow.async_update_reload_and_abort.call_args.kwargs
+        # The new email must drive both the stored data AND the visible title /
+        # unique_id, so the integration's front page reflects it immediately.
+        assert kwargs["data"]["email"] == "new@example.com"
+        assert kwargs["title"] == "Ajax Security (new@example.com)"
+        assert kwargs["unique_id"] == "new@example.com"
+
+
 class TestOptionsFlow:
     @staticmethod
     def _make_flow(


### PR DESCRIPTION
## Problem (#241)

Reconfiguring the integration to switch to a different Ajax account left the **old email on the integration's front page** (the config entry title). A second reconfigure showed the correct one.

## Cause

`_async_finish_reconfigure` called `async_update_reload_and_abort(entry, data=new_data)` — updating only the entry **data**. The title (set at creation to `Ajax Security (<email>)`) and the `unique_id` were never refreshed, so they kept the previous account's email.

## Fix

Pass `title=` and `unique_id=` derived from the new email, so the visible title and unique_id update on the **first** reconfigure:

```python
return self.async_update_reload_and_abort(
    entry,
    unique_id=self._email,
    title=f"Ajax Security ({self._email})",
    data=new_data,
)
```

## Tests

New `TestAsyncFinishReconfigure` asserts the reconfigure finish passes the new email through to `data`, `title`, and `unique_id`. Full suite: 1565 passed; lint/format/type clean.

Surfaced by @GurliGebis after following the dedicated-account guidance from #234.

Refs #241