### PR TITLE
fix(system_health): treat HTS/FCM activity as reachable, not just polls (#236)

### DIFF
--- a/custom_components/aegis_ajax/system_health.py
+++ b/custom_components/aegis_ajax/system_health.py
@@ -79,18 +79,28 @@ async def _system_health_info(hass: HomeAssistant) -> dict[str, Any]:
             if last_push_age_seconds is None or age < last_push_age_seconds:
                 last_push_age_seconds = age
 
-    # Derive reachability from the actual gRPC poll path we already use,
-    # not from a separate HTTPS HEAD probe. The gRPC host doesn't
-    # respond to plain HTTPS GET / HEAD, so `async_check_can_reach_url`
-    # always returned "unreachable" even when polling worked perfectly
-    # (surfaced once #106 made the rest of the card render). If any
-    # account polled successfully in the last 10 min the cloud *is*
-    # reachable from the integration's perspective, regardless of what
-    # an external HTTP probe would say.
-    if last_update_age_seconds is None:
-        info["can_reach_server"] = "never polled"
-    elif last_update_age_seconds <= _REACHABILITY_STALE_AFTER:
+    # Reachability is "is the integration talking to Ajax at all", derived
+    # from our own data paths rather than a separate HTTPS HEAD probe — the
+    # gRPC host doesn't answer plain HTTPS GET/HEAD, so `async_check_can_reach_url`
+    # always returned "unreachable" even when polling worked (#106).
+    #
+    # Crucially, don't key it off the polled refresh alone: HTS and FCM updates
+    # call `async_set_updated_data`, which resets HA's poll timer, so the polled
+    # `_async_update_data` (the only thing that stamps `last_update_success_time`)
+    # can be starved indefinitely while data keeps flowing — which left the card
+    # reading "unreachable" on a perfectly healthy install (#236). A live HTS
+    # connection or a recent push is equally valid proof of reachability;
+    # `last_poll` below still reports its true age.
+    poll_fresh = (
+        last_update_age_seconds is not None and last_update_age_seconds <= _REACHABILITY_STALE_AFTER
+    )
+    push_fresh = (
+        last_push_age_seconds is not None and last_push_age_seconds <= _REACHABILITY_STALE_AFTER
+    )
+    if poll_fresh or hts_connected > 0 or push_fresh:
         info["can_reach_server"] = "reachable"
+    elif last_update_age_seconds is None:
+        info["can_reach_server"] = "never polled"
     else:
         info["can_reach_server"] = "unreachable"
 

--- a/tests/unit/test_system_health.py
+++ b/tests/unit/test_system_health.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -113,6 +114,42 @@ class TestSystemHealthInfo:
         hass = self._make_hass([MagicMock(runtime_data=coord)])
         info = await _system_health_info(hass)
         assert info["can_reach_server"] == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_reachable_when_poll_stale_but_hts_connected(self) -> None:
+        """A stale poll alone must not read as unreachable: HTS/FCM updates reset
+        HA's poll timer, so the polled refresh can be starved while data still
+        flows (#236). A live HTS connection means the cloud is reachable."""
+        coord = MagicMock()
+        coord.spaces = {"s1": MagicMock()}
+        coord.is_hts_connected = True
+        coord.last_update_success_time = datetime.now(UTC) - timedelta(minutes=30)
+        listener = MagicMock()
+        listener.is_fcm_connected = True
+        listener.pushes_received = 5
+        listener.last_push_at = None
+        coord.notification_listener = listener
+
+        hass = self._make_hass([MagicMock(runtime_data=coord)])
+        info = await _system_health_info(hass)
+        assert info["can_reach_server"] == "reachable"
+
+    @pytest.mark.asyncio
+    async def test_reachable_when_poll_stale_but_recent_push(self) -> None:
+        """A recent FCM push is also proof of reachability even if the poll is stale."""
+        coord = MagicMock()
+        coord.spaces = {"s1": MagicMock()}
+        coord.is_hts_connected = False
+        coord.last_update_success_time = datetime.now(UTC) - timedelta(minutes=30)
+        listener = MagicMock()
+        listener.is_fcm_connected = True
+        listener.pushes_received = 3
+        listener.last_push_at = time.monotonic() - 30  # 30s ago
+        coord.notification_listener = listener
+
+        hass = self._make_hass([MagicMock(runtime_data=coord)])
+        info = await _system_health_info(hass)
+        assert info["can_reach_server"] == "reachable"
 
     @pytest.mark.asyncio
     async def test_can_reach_server_never_polled(self) -> None:


### PR DESCRIPTION
## Problem (#236, follow-up)

After the channel-recreation fix (#238/beta.5) resolved the original gRPC stream outage, a reporter still saw the integration show **"unreachable" in System Information** after a while — yet everything worked, and it snapped back to "reachable" the moment an FCM push arrived.

## Cause

`can_reach_server` was derived **only** from `last_update_success_time`, which is stamped solely by the polled `_async_update_data`. HTS and FCM updates call `async_set_updated_data`, and that **resets HA's poll timer** (the coordinator even documents this). On an active install, HTS pushes (~every 60s) keep deferring the polled refresh indefinitely, so `last_update_success_time` goes stale → after 10 min the card reads "unreachable" — while HTS and FCM are flowing perfectly. An FCM push triggers a real refresh, which is why it "recovered" on push.

Confirmed from the reporter's log: 7 minutes with no `Finished fetching` (poll) line while HTS polled every 60s, then an arriving push immediately produced a successful refresh.

## Fix

Reachability now reflects **any** live data path — a fresh poll, a live HTS connection, or a recent push:

```python
if poll_fresh or hts_connected > 0 or push_fresh:
    info["can_reach_server"] = "reachable"
```

`last_poll` still shows its true age, so a genuinely starved/failed poll remains visible — it just no longer masquerades as a cloud outage. Pure `system_health.py` change; no coordinator/behaviour change.

## Tests

Two new cases: stale poll + live HTS → reachable; stale poll + recent push → reachable. The existing "all paths dead → unreachable" and "never polled" cases still hold. Full suite: 1567 passed.

Refs #236