### PR TITLE
docs: HA account needs notification access to receive push (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ Click the button above, or manually:
 > Instead of your primary admin login, create a separate Ajax account, invite it to
 > your space (Ajax app → space → Users → Invite) and grant it only what the
 > integration needs. A non-admin **User** role is enough to read device state and
-> arm / disarm. You can also revoke its **photo / video** access if you don't use
+> arm / disarm — but to also receive **push events**, the account must be allowed to
+> receive event notifications (a very restricted role can register for push yet never
+> get events; see the FCM troubleshooting note below). You can also revoke its
+> **photo / video** access if you don't use
 > Photo on Demand, so Home Assistant never has access to camera images. This keeps
 > your main credentials out of HA and limits what a compromised HA host could reach
 > in your Ajax installation.
@@ -418,12 +421,17 @@ The integration can run with or without Firebase Cloud Messaging (FCM) push, but
 
 If you cannot configure FCM, the integration still works as a polled view of your Ajax installation, but automations that rely on alarm-panel events will not fire. You can dismiss the related Repair card; the integration will not break.
 
-> **FCM shows connected but app → HA updates still don't arrive?** Make sure Home
-> Assistant uses a **different Ajax account than your phone app**. Ajax doesn't
-> reliably deliver one account's push to two sessions at once, so an actively-used
-> phone app can leave HA's push channel starved even though FCM reports connected —
-> you'd still get changes on the next poll, just not instantly. A dedicated account
-> for HA (see [Configuration](#configuration)) avoids this.
+> **FCM shows connected but app → HA updates still don't arrive?** Two common causes:
+>
+> - **Same account in the app and in HA.** Ajax doesn't reliably deliver one account's
+>   push to two sessions at once, so an actively-used phone app can leave HA's push
+>   channel starved even though FCM reports connected. Give HA its own account (see
+>   [Configuration](#configuration)).
+> - **The HA account can't receive event notifications.** A very limited invited role
+>   may register for push yet never get events — one user found a full-access role was
+>   needed. Make sure the account is allowed to receive notifications for the space.
+>
+> Either way you'd still get changes on the next poll, just not instantly.
 
 > **Alternative to FCM: Ajax's SIA stream.** If you'd rather not extract Firebase
 > credentials at all, many Ajax hubs can stream events to Home Assistant's built-in


### PR DESCRIPTION
Corrects an inaccuracy in the dedicated-account guidance (from the earlier #234 docs PR).

Reporters in #234 showed that a separate account isn't sufficient on its own: a too-limited invited role can register for FCM push yet **never receive events** (@rikman122 needed a full-access role). The README claimed a non-admin User role is "enough".

- Adds a caveat to the account recommendation: User role covers state + arm/disarm, but push events also require the account to be allowed to receive notifications.
- Expands the FCM troubleshooting note to list **two** causes — same-account contention *and* insufficient notification access on the HA account.

Docs-only.

Refs #234