### PR TITLE
fix(lock): actuate hub-attached SmartLocks via generic on/off + channel 1 (#219)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -583,9 +583,10 @@ class DevicesApi:
         metadata = self._client._session.get_call_metadata()
         stub = endpoint_pb2_grpc.DeviceCommandDeviceOnServiceStub(channel)
         # Send channels exactly as given. Channelled devices (relay, socket,
-        # wall/light switch) pass an explicit `[channel]`; a SmartLock (#219)
-        # passes none — the Ajax app omits channels for the lock on/off command,
-        # so an empty list leaves the repeated field unset, matching the wire.
+        # wall/light switch) pass an explicit `[channel]`; a hub-attached
+        # SmartLock (#219) passes `[1]` (CHANNEL_1) — the Ajax app always sends
+        # the lock on/off command on channel 1 (decompiled), and an on/off with
+        # no channel is accepted-but-inert.
         request = request_pb2.DeviceCommandDeviceOnRequest(
             hub_id=command.hub_id,
             device_id=command.device_id,
@@ -608,7 +609,7 @@ class DevicesApi:
         metadata = self._client._session.get_call_metadata()
         stub = endpoint_pb2_grpc.DeviceCommandDeviceOffServiceStub(channel)
         # See `_device_on`: channels are sent as given (explicit per channel for
-        # relays/switches, empty for a SmartLock #219).
+        # relays/switches, `[1]` for a hub-attached SmartLock #219).
         request = request_pb2.DeviceCommandDeviceOffRequest(
             hub_id=command.hub_id,
             device_id=command.device_id,

--- a/custom_components/aegis_ajax/lock.py
+++ b/custom_components/aegis_ajax/lock.py
@@ -111,8 +111,14 @@ class AjaxLock(CoordinatorEntity[AjaxCobrandedCoordinator], LockEntity):
         on a third-party backend) are not in the SmartLock cloud registry, so
         `SwitchSmartLockService` answers `smart_lock_not_found`. The Ajax app
         drives them with `DeviceCommandDeviceOn/Off` keyed by device id —
-        lock = On, unlock = Off — exactly as for a relay (verified against the
-        app). No channel is sent for a lock.
+        lock = On, unlock = Off.
+
+        Two details, decompiled from the app's hub-lock command path, are
+        load-bearing (an earlier attempt without them was accepted-but-inert):
+        the app routes EVERY hub-attached lock (generic and Yale alike) through
+        a single processor that emits the GENERIC `smart_lock` ObjectType, and
+        it always sends the command on CHANNEL_1. So we override the stream's
+        `smart_lock_yale` type to `smart_lock` and send `channels=[1]`.
         """
         device = self._device
         if device is None:
@@ -121,7 +127,8 @@ class AjaxLock(CoordinatorEntity[AjaxCobrandedCoordinator], LockEntity):
         command = factory(
             hub_id=device.hub_id,
             device_id=self._device_id,
-            device_type=device.device_type,
+            device_type="smart_lock",
+            channels=[1],
         )
         try:
             await self.coordinator.devices_api.send_command(command)

--- a/tests/unit/test_lock.py
+++ b/tests/unit/test_lock.py
@@ -127,7 +127,11 @@ class TestAjaxLockCommands:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("device_type", ["smart_lock", "smart_lock_yale"])
     async def test_async_lock_sends_device_on(self, device_type: str) -> None:
-        # #219: lock = DeviceCommandDeviceOn keyed by device id, no channels.
+        # #219: lock = DeviceCommandDeviceOn keyed by device id. The Ajax app
+        # routes every hub-attached lock (generic AND Yale) through one command
+        # path that normalises to the generic `smart_lock` ObjectType on
+        # CHANNEL_1, so we always send device_type="smart_lock" + channels=[1]
+        # regardless of the stream's `smart_lock_yale` type.
         device = _make_device(device_type, "unlocked")
         coordinator = _make_coordinator(device)
         lock = AjaxLock(coordinator=coordinator, device_id=device.id)
@@ -139,8 +143,8 @@ class TestAjaxLockCommands:
         assert cmd.action == "on"
         assert cmd.hub_id == "hub-1"
         assert cmd.device_id == "lock-1"
-        assert cmd.device_type == device_type
-        assert cmd.channels == []
+        assert cmd.device_type == "smart_lock"
+        assert cmd.channels == [1]
         coordinator.devices_api.switch_smart_lock.assert_not_called()
         coordinator.async_request_refresh.assert_awaited_once()
 
@@ -155,7 +159,8 @@ class TestAjaxLockCommands:
         cmd: DeviceCommand = coordinator.devices_api.send_command.await_args.args[0]
         assert cmd.action == "off"
         assert cmd.device_id == "lock-1"
-        assert cmd.channels == []
+        assert cmd.device_type == "smart_lock"
+        assert cmd.channels == [1]
         coordinator.async_request_refresh.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Hub-attached Jeweller locks — including installer-added Yale modules on a third-party monitoring backend (#219) — are not present in the SmartLock cloud registry, so `SwitchSmartLockService` answers `smart_lock_not_found`. Lock/unlock is therefore issued through the generic `DeviceCommandDeviceOn/Off` path.

The previous attempt (1.8.1-beta.4) routed that command with the device's own `smart_lock_yale` ObjectType and no channel. The hub accepted it (returned `OK`) but the command was inert: the bolt never moved and the state in the Ajax app and in Home Assistant stayed unchanged.

The on/off command for every hub-attached lock uses the **generic `smart_lock` ObjectType on channel 1**, regardless of the lock brand. This PR routes `lock = On` / `unlock = Off` with `device_type="smart_lock"` and `channels=[1]`.

## Changes
- `lock.py::_async_switch` — send the generic `smart_lock` ObjectType and `channels=[1]` for all lock entities.
- `api/devices.py` — corrected the (now inaccurate) comments stating the lock on/off command omits the channel.
- `tests/unit/test_lock.py` — assert the lock/unlock command carries `device_type="smart_lock"` and `channels=[1]`.

No proto changes. Unlatch (OPEN) via `SwitchSmartLockService` is unchanged.

## Verification
- lint, format-check and typecheck pass.
- Full unit suite: 1567 passed.
- Physical actuation on a real lock still needs in-the-field confirmation before this is promoted to a stable release.

Refs #219.