### PR TITLE
feat(switch): add hub Chime enable/disable switch (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.8.1] - unreleased
 
 ### Added
+- **Hub Chime enable/disable switch (#239).** A per-hub `Chime` switch toggles the hub-wide Chime (the Ajax app's bottom-left toggle that plays a tone on opening monitored doors while disarmed). State is read from the hub's `chime_status` in the space snapshot (the same field the app shows) and reflects changes made from the app; toggling requires the account's `EDIT_CHIMES` permission, surfacing a clear error otherwise. Only created for hubs that expose the feature. Translated across all 14 locales.
 - **Outdoor curtain PIR internal temperature sensor (#229).** MotionProtect Curtain Outdoor detectors report their internal temperature only in the rich per-device snapshot (same as sirens, #220), so no sensor appeared. The per-device temperature refresh is now device-agnostic and covers them.
 - **`aegis_ajax.disarm_night_mode` service (#233).** Stands down only the night-mode groups via Ajax's native `disarmFromNightMode`, leaving independently away-armed groups armed — previously, exiting night mode required a full disarm that also stood down those groups. Optional alarm-panel target; applies to all panels when omitted.
 

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -992,3 +992,31 @@ class DevicesApi:
                 hub_id,
                 label,
             )
+
+    async def set_chimes_mode(self, hub_id: str, *, enable: bool) -> None:
+        """Enable/disable the hub-wide Chime (#239).
+
+        Hub-level setting (the toggle bottom-left of the Ajax app's security
+        screen), so the request carries only `hub_id` + `chimes_status` — the
+        same call the app's `ChimesModeGrpcApi.setHubChimes` issues. The
+        `groups_statuses` branch (per-group chime) is intentionally not used.
+        Raises `DeviceCommandError` carrying the server's failure-oneof case
+        (`permission_denied` when the account lacks EDIT_CHIMES, `hub_offline`,
+        `hub_busy`, …) so callers can map it to a translated error.
+        """
+        from v3.mobilegwsvc.service.device_command_chimes_mode import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.DeviceCommandChimesModeServiceStub(channel)
+        request_cls = request_pb2.DeviceCommandChimesModeRequest
+        status = request_cls.CHIMES_STATUS_ENABLE if enable else request_cls.CHIMES_STATUS_DISABLE
+        request = request_cls(hub_id=hub_id, chimes_status=status)
+        response = await stub.execute(request, metadata=metadata, timeout=15)
+        if response.HasField("failure"):
+            error = response.failure.WhichOneof("error") or "unknown"
+            raise DeviceCommandError(f"chimes_mode: {error}", reason=error)
+        _LOGGER.debug("Hub %s chimes_mode enable=%s OK", hub_id, enable)

--- a/custom_components/aegis_ajax/api/models.py
+++ b/custom_components/aegis_ajax/api/models.py
@@ -7,6 +7,7 @@ from enum import IntEnum
 from typing import Any
 
 from custom_components.aegis_ajax.const import (
+    ChimeStatus,
     ConnectionStatus,
     DeviceState,
     SecurityState,
@@ -78,6 +79,9 @@ class Space:
     monitoring_companies_loaded: bool = False
     groups: tuple[Group, ...] = field(default_factory=tuple)
     group_mode_enabled: bool = False
+    # Hub-wide Chime on/off setting (#239). UNSPECIFIED = the hub doesn't
+    # expose the feature, so no Chime switch is created for it.
+    chime_status: ChimeStatus = ChimeStatus.UNSPECIFIED
 
     @property
     def is_online(self) -> bool:
@@ -125,6 +129,8 @@ class SpaceSnapshot:
     monitoring_companies_loaded: bool = False
     groups: tuple[Group, ...] = field(default_factory=tuple)
     group_mode_enabled: bool = False
+    # Hub-wide Chime status read off the full snapshot's hub device (#239).
+    chime_status: ChimeStatus = ChimeStatus.UNSPECIFIED
 
 
 @dataclass(frozen=True)

--- a/custom_components/aegis_ajax/api/spaces.py
+++ b/custom_components/aegis_ajax/api/spaces.py
@@ -13,7 +13,7 @@ from custom_components.aegis_ajax.api.models import (
     Space,
     SpaceSnapshot,
 )
-from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
+from custom_components.aegis_ajax.const import ChimeStatus, ConnectionStatus, SecurityState
 
 # GroupSecurity.State proto enum:
 #   GROUP_SECURITY_STATE_NONE = 0
@@ -52,6 +52,29 @@ class SpacesApi:
             connection_status=ConnectionStatus(proto_space.hub_connection_status),
             malfunctions_count=proto_space.malfunctions_count,
         )
+
+    @staticmethod
+    def extract_chime_status(proto_space: Any) -> ChimeStatus:  # noqa: ANN401
+        """Pull the hub-wide Chime status off the full space snapshot (#239).
+
+        Mirrors the official app's `tqs.a(space)`: walk `space.devices`, take
+        the `StandaloneDevice` whose `device` oneof is `hub`, and read its
+        `chime_status`. Only the heavy `get_space_snapshot` carries the full
+        `Space` (with `devices`); the lighter `list_spaces` returns a
+        `LiteSpace` that has no devices, so Chime state rides the same hourly
+        snapshot path as rooms/groups. Defensive on every step — no hub
+        device, an unrecognised enum value, or a snapshot without `devices`
+        all yield `UNSPECIFIED` (no Chime switch), never an error that would
+        blank the whole snapshot.
+        """
+        try:
+            for device in proto_space.devices:
+                which = device.WhichOneof("device") if hasattr(device, "WhichOneof") else None
+                if which == "hub":
+                    return ChimeStatus(int(device.hub.chime_status))
+        except (TypeError, ValueError, AttributeError):
+            pass
+        return ChimeStatus.UNSPECIFIED
 
     @staticmethod
     def parse_groups(proto_security: Any, space_id: str) -> tuple[tuple[Group, ...], bool]:  # noqa: ANN401
@@ -212,6 +235,7 @@ class SpacesApi:
         monitoring_companies: list[MonitoringCompany] = []
         groups: tuple[Group, ...] = ()
         group_mode_enabled: bool = False
+        chime_status = ChimeStatus.UNSPECIFIED
         try:
             async for msg in stream:
                 if msg.HasField("failure"):
@@ -228,6 +252,7 @@ class SpacesApi:
                     monitoring_companies.append(self.parse_monitoring_company(proto_company))
                 if hasattr(snapshot, "security"):
                     groups, group_mode_enabled = self.parse_groups(snapshot.security, space_id)
+                chime_status = self.extract_chime_status(snapshot)
                 break
         finally:
             cancel = getattr(stream, "cancel", None)
@@ -250,6 +275,7 @@ class SpacesApi:
             monitoring_companies_loaded=True,
             groups=groups,
             group_mode_enabled=group_mode_enabled,
+            chime_status=chime_status,
         )
 
     async def _resolve_company_name(

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -197,6 +197,33 @@ class ConnectionStatus(IntEnum):
     OFFLINE = 2
 
 
+class ChimeStatus(IntEnum):
+    """Maps the mobile v2 `DisplayedChimeStatus` proto enum (#239).
+
+    The hub-wide Chime on/off setting the Ajax app exposes (bottom-left of
+    the security screen). Read off `StandaloneDevice.hub.chime_status` inside
+    a space — the same field the official app maps (`tqs.a(space).getChimeStatus()`).
+    `CAN_BE_ENABLED` means Chime is supported and currently off; `UNSPECIFIED`
+    means the hub doesn't expose the feature at all, so no switch is created.
+    """
+
+    UNSPECIFIED = 0
+    ENABLED = 1
+    CAN_BE_ENABLED = 2
+    MALFUNCTION = 3
+    DISABLED = 4
+
+    @property
+    def is_supported(self) -> bool:
+        """True when the hub exposes the Chime feature (any state but UNSPECIFIED)."""
+        return self != ChimeStatus.UNSPECIFIED
+
+    @property
+    def is_on(self) -> bool:
+        """True only when Chime is actively enabled."""
+        return self == ChimeStatus.ENABLED
+
+
 class UserRole(IntEnum):
     """Maps UserRole proto enum."""
 

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -37,6 +37,7 @@ from custom_components.aegis_ajax.const import (
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
     MOTION_PUSH_AUTO_OFF_SECONDS,
+    ChimeStatus,
     ConnectionStatus,
 )
 from custom_components.aegis_ajax.device_cache import DevicesCache
@@ -395,6 +396,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         groups=previous.groups,
                         group_mode_enabled=previous.group_mode_enabled,
                     )
+                # Chime status (#239) also only comes from the hourly snapshot;
+                # `list_spaces` (LiteSpace) doesn't carry it, so preserve the
+                # last known value or the Chime switch flips to UNSPECIFIED
+                # (unavailable) on every plain poll.
+                if previous.chime_status is not ChimeStatus.UNSPECIFIED:
+                    s = dc_replace(s, chime_status=previous.chime_status)
             new_spaces[s.id] = s
         return new_spaces
 
@@ -453,6 +460,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     monitoring_companies_loaded=snapshot.monitoring_companies_loaded,
                     groups=snapshot.groups,
                     group_mode_enabled=snapshot.group_mode_enabled,
+                    chime_status=snapshot.chime_status,
                 )
         self.rooms = refreshed_rooms
         self._rooms_last_fetch = now
@@ -918,6 +926,28 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             dc_replace(g, security_state=new_state) if g.id == group_id else g for g in space.groups
         )
         self.spaces[space_id] = dc_replace(space, groups=new_groups)
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
+    def set_chime_optimistic(self, space_id: str, *, enable: bool) -> None:
+        """Optimistically reflect a hub Chime toggle we just issued (#239).
+
+        The hub-wide Chime status only rides the hourly `get_space_snapshot`
+        path — `list_spaces` (LiteSpace) doesn't carry it — so a plain
+        `async_request_refresh` after the command wouldn't move the switch for
+        up to an hour. Write the expected state in-memory and notify listeners
+        so the toggle is reflected immediately; the next snapshot reconciles
+        with the hub's authoritative value (and catches app-side changes).
+        No-op for an unknown space.
+        """
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        space = self.spaces.get(space_id)
+        if space is None:
+            return
+        new_status = ChimeStatus.ENABLED if enable else ChimeStatus.CAN_BE_ENABLED
+        if space.chime_status == new_status:
+            return
+        self.spaces[space_id] = dc_replace(space, chime_status=new_status)
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     def _handle_devices_snapshot(self, devices: list[Device]) -> None:

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -41,6 +41,7 @@ async def async_get_config_entry_diagnostics(
                 "online": s.is_online,
                 "malfunctions": s.malfunctions_count,
                 "group_mode_enabled": s.group_mode_enabled,
+                "chime_status": s.chime_status.name,
                 "groups": [
                     {
                         "id": g.id,

--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -63,15 +63,43 @@ async def async_send_device_command(
     try:
         await coordinator.devices_api.send_command(command)
     except DeviceCommandError as err:
-        translation_key = COMMAND_ERROR_TRANSLATION_KEYS.get(err.reason or "")
-        if translation_key is not None:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key=translation_key
-            ) from err
-        placeholders: dict[str, Any] = {"reason": err.reason or "unknown"}
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="command_failed",
-            translation_placeholders=placeholders,
-        ) from err
+        _raise_translated_command_error(err)
     await coordinator.async_request_refresh()
+
+
+async def async_set_chimes_mode(
+    coordinator: AjaxCobrandedCoordinator, hub_id: str, *, enable: bool
+) -> None:
+    """Toggle the hub-wide Chime, mapping hub rejections to a clear error (#239).
+
+    Companion to `async_send_device_command` for the hub-level Chime command,
+    which isn't a per-device `DeviceCommand`. Same error-to-translation mapping
+    (`permission_denied` when the account lacks EDIT_CHIMES, `hub_offline`, …)
+    and the coordinator is only refreshed on success.
+    """
+    from custom_components.aegis_ajax.api.devices import DeviceCommandError  # noqa: PLC0415
+
+    try:
+        await coordinator.devices_api.set_chimes_mode(hub_id, enable=enable)
+    except DeviceCommandError as err:
+        _raise_translated_command_error(err)
+    await coordinator.async_request_refresh()
+
+
+def _raise_translated_command_error(err: Any) -> None:  # noqa: ANN401
+    """Re-raise a `DeviceCommandError` as a translated `HomeAssistantError`.
+
+    Maps the server's failure-oneof reason to an `exceptions.*` key when known,
+    otherwise falls back to `command_failed` echoing the raw reason.
+    """
+    translation_key = COMMAND_ERROR_TRANSLATION_KEYS.get(err.reason or "")
+    if translation_key is not None:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN, translation_key=translation_key
+        ) from err
+    placeholders: dict[str, Any] = {"reason": err.reason or "unknown"}
+    raise HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="command_failed",
+        translation_placeholders=placeholders,
+    ) from err

--- a/custom_components/aegis_ajax/icons.json
+++ b/custom_components/aegis_ajax/icons.json
@@ -38,7 +38,8 @@
         },
         "switch": {
             "channel_1": { "default": "mdi:electric-switch", "state": { "on": "mdi:electric-switch-closed", "off": "mdi:electric-switch" } },
-            "channel_2": { "default": "mdi:electric-switch", "state": { "on": "mdi:electric-switch-closed", "off": "mdi:electric-switch" } }
+            "channel_2": { "default": "mdi:electric-switch", "state": { "on": "mdi:electric-switch-closed", "off": "mdi:electric-switch" } },
+            "chime": { "default": "mdi:bell", "state": { "on": "mdi:bell-ring", "off": "mdi:bell-off" } }
         },
         "button": {
             "capture_photo": { "default": "mdi:camera" }

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -430,6 +430,9 @@
             },
             "bypass": {
                 "name": "Bypass"
+            },
+            "chime": {
+                "name": "Chime"
             }
         }
     },

--- a/custom_components/aegis_ajax/switch.py
+++ b/custom_components/aegis_ajax/switch.py
@@ -19,14 +19,18 @@ from custom_components.aegis_ajax.const import (
     DEFAULT_BYPASS_SWITCHES,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
-from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
+from custom_components.aegis_ajax.entity import (
+    async_send_device_command,
+    async_set_chimes_mode,
+    build_device_info,
+)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from custom_components.aegis_ajax.api.models import Device
+    from custom_components.aegis_ajax.api.models import Device, Space
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -117,6 +121,21 @@ async def async_setup_entry(
                     device_type=device.device_type,
                 )
             )
+    # One hub-wide Chime switch per hub that exposes the feature (#239). Hubs
+    # that don't report a Chime status (UNSPECIFIED) get none.
+    for space in coordinator.spaces.values():
+        if (
+            space.hub_id
+            and space.chime_status.is_supported
+            and coordinator.devices.get(space.hub_id)
+        ):
+            entities.append(
+                AjaxChimeSwitch(
+                    coordinator=coordinator,
+                    space_id=space.id,
+                    hub_id=space.hub_id,
+                )
+            )
     _evict_orphan_bypass_switches(
         hass,
         entry,
@@ -124,6 +143,15 @@ async def async_setup_entry(
             e.unique_id
             for e in entities
             if isinstance(e, AjaxBypassSwitch) and e.unique_id is not None
+        },
+    )
+    _evict_orphan_chime_switches(
+        hass,
+        entry,
+        provided={
+            e.unique_id
+            for e in entities
+            if isinstance(e, AjaxChimeSwitch) and e.unique_id is not None
         },
     )
     async_add_entities(entities)
@@ -152,6 +180,32 @@ def _evict_orphan_bypass_switches(
             _LOGGER.info(
                 "Removing orphaned bypass switch %s — the bypass_switches option "
                 "no longer provides it (#bypass)",
+                reg_entry.entity_id,
+            )
+            entity_reg.async_remove(reg_entry.entity_id)
+
+
+def _evict_orphan_chime_switches(
+    hass: HomeAssistant, entry: ConfigEntry, *, provided: set[str]
+) -> None:
+    """Remove Chime-switch entities no longer provided (#239).
+
+    A hub that stops exposing the Chime feature (firmware change, hub removed
+    from the space) drops its `AjaxChimeSwitch`. HA leaves the orphan in the
+    registry as `unavailable` until the user deletes it; evict it here on the
+    reload that drops it, mirroring the bypass-switch eviction.
+    """
+    entity_reg = er.async_get(hass)
+    for reg_entry in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
+        unique_id = reg_entry.unique_id
+        if (
+            reg_entry.domain == "switch"
+            and unique_id.endswith("_chime")
+            and unique_id not in provided
+        ):
+            _LOGGER.info(
+                "Removing orphaned Chime switch %s — the hub no longer exposes "
+                "the Chime feature (#239)",
                 reg_entry.entity_id,
             )
             entity_reg.async_remove(reg_entry.entity_id)
@@ -275,3 +329,56 @@ class AjaxBypassSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity
             enable=enable,
         )
         await async_send_device_command(self.coordinator, cmd)
+
+
+class AjaxChimeSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):
+    """Enable/disable the hub-wide Chime (#239).
+
+    `on` = the hub plays the Chime tone on the configured detectors while
+    disarmed; `off` = silenced. Hub-level setting, so one switch per hub.
+    State is read from `space.chime_status` (the same field the Ajax app
+    shows); toggling requires the account's `EDIT_CHIMES` permission — a
+    limited account surfaces a clear `permission_denied` error on toggle.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "chime"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: AjaxCobrandedCoordinator,
+        space_id: str,
+        hub_id: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._space_id = space_id
+        self._hub_id = hub_id
+        self._attr_unique_id = f"aegis_ajax_{hub_id}_chime"
+        hub_device = coordinator.devices.get(hub_id)
+        if hub_device:
+            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
+
+    @property
+    def _space(self) -> Space | None:
+        return self.coordinator.spaces.get(self._space_id)
+
+    @property
+    def available(self) -> bool:
+        space = self._space
+        return space is not None and space.is_online and space.chime_status.is_supported
+
+    @property
+    def is_on(self) -> bool | None:
+        space = self._space
+        if space is None:
+            return None
+        return space.chime_status.is_on
+
+    async def async_turn_on(self, **kwargs: object) -> None:
+        await async_set_chimes_mode(self.coordinator, self._hub_id, enable=True)
+        self.coordinator.set_chime_optimistic(self._space_id, enable=True)
+
+    async def async_turn_off(self, **kwargs: object) -> None:
+        await async_set_chimes_mode(self.coordinator, self._hub_id, enable=False)
+        self.coordinator.set_chime_optimistic(self._space_id, enable=False)

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Bypass"
+            },
+            "chime": {
+                "name": "Timbre"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Vyřazení"
+            },
+            "chime": {
+                "name": "Gong"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Überbrückung"
+            },
+            "chime": {
+                "name": "Gong"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -435,6 +435,9 @@
             },
             "bypass": {
                 "name": "Bypass"
+            },
+            "chime": {
+                "name": "Chime"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -435,6 +435,9 @@
             },
             "bypass": {
                 "name": "Bypass"
+            },
+            "chime": {
+                "name": "Timbre"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Contournement"
+            },
+            "chime": {
+                "name": "Carillon"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Esclusione"
+            },
+            "chime": {
+                "name": "Campanello"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Overbruggen"
+            },
+            "chime": {
+                "name": "Deurbel"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Pominięcie"
+            },
+            "chime": {
+                "name": "Gong"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Ignorar"
+            },
+            "chime": {
+                "name": "Campainha"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Ignorar"
+            },
+            "chime": {
+                "name": "Campainha"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Excludere"
+            },
+            "chime": {
+                "name": "Sonerie"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Atlama"
+            },
+            "chime": {
+                "name": "Zil sesi"
             }
         },
         "update": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -419,6 +419,9 @@
             },
             "bypass": {
                 "name": "Обхід"
+            },
+            "chime": {
+                "name": "Гонг"
             }
         },
         "update": {

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -21,6 +21,7 @@ from custom_components.aegis_ajax.api.models import (
 )
 from custom_components.aegis_ajax.const import (
     HUB_DEVICE_TEMP_REFRESH_INTERVAL,
+    ChimeStatus,
     ConnectionStatus,
     DeviceState,
     SecurityState,
@@ -2176,3 +2177,59 @@ class TestHubDeviceTemperatureRefresh:
         coordinator._handle_devices_snapshot([_make_device("d1")])
 
         assert "temperature" not in coordinator.devices["d1"].statuses
+
+
+class TestSetChimeOptimistic:
+    """Immediate optimistic Chime state after an HA-initiated toggle (#239)."""
+
+    def _make_coordinator(
+        self, chime_status: ChimeStatus = ChimeStatus.CAN_BE_ENABLED
+    ) -> AjaxCobrandedCoordinator:  # noqa: F821
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        hass = MagicMock()
+        client = MagicMock()
+        with patch(
+            "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+            return_value=None,
+        ):
+            coordinator = AjaxCobrandedCoordinator(
+                hass=hass, client=client, space_ids=["s1"], poll_interval=300
+            )
+        coordinator.hass = hass
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.spaces = {
+            "s1": Space(
+                id="s1",
+                hub_id="hub-1",
+                name="Home",
+                security_state=SecurityState.DISARMED,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+                chime_status=chime_status,
+            )
+        }
+        return coordinator
+
+    def test_enable_sets_enabled(self) -> None:
+        coordinator = self._make_coordinator(ChimeStatus.CAN_BE_ENABLED)
+        coordinator.set_chime_optimistic("s1", enable=True)
+        assert coordinator.spaces["s1"].chime_status == ChimeStatus.ENABLED
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_disable_sets_can_be_enabled(self) -> None:
+        coordinator = self._make_coordinator(ChimeStatus.ENABLED)
+        coordinator.set_chime_optimistic("s1", enable=False)
+        assert coordinator.spaces["s1"].chime_status == ChimeStatus.CAN_BE_ENABLED
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_no_change_skips_update(self) -> None:
+        coordinator = self._make_coordinator(ChimeStatus.ENABLED)
+        coordinator.set_chime_optimistic("s1", enable=True)
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_unknown_space_no_op(self) -> None:
+        coordinator = self._make_coordinator(ChimeStatus.ENABLED)
+        coordinator.set_chime_optimistic("unknown", enable=False)
+        assert coordinator.spaces["s1"].chime_status == ChimeStatus.ENABLED
+        coordinator.async_set_updated_data.assert_not_called()

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -2937,3 +2937,78 @@ class TestKeepaliveRetune:
         now = asyncio.get_running_loop().time()
         api._maybe_retune_keepalive(_PingError("unavailable"), last_msg_at=now - 300.0)
         client.reduce_keepalive.assert_not_called()
+
+
+class TestSetChimesMode:
+    """`device_command_chimes_mode` — hub-wide Chime enable/disable (#239)."""
+
+    def _make_api(self) -> DevicesApi:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        return DevicesApi(client)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("enable", "expected_attr"),
+        [(True, "CHIMES_STATUS_ENABLE"), (False, "CHIMES_STATUS_DISABLE")],
+    )
+    async def test_sends_hub_id_and_chimes_status(self, enable: bool, expected_attr: str) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_chimes_mode import (
+            endpoint_pb2_grpc,
+            request_pb2,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        ok = response_pb2.DeviceCommandChimesModeResponse(success=common_response_pb2.Success())
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                async def _execute(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return ok
+
+                self.execute = AsyncMock(side_effect=_execute)
+
+        with patch.object(endpoint_pb2_grpc, "DeviceCommandChimesModeServiceStub", _StubFactory):
+            await api.set_chimes_mode("hub-1", enable=enable)
+
+        assert len(captured) == 1
+        req = captured[0]
+        assert req.hub_id == "hub-1"
+        assert req.WhichOneof("additional_param") == "chimes_status"
+        assert req.chimes_status == getattr(
+            request_pb2.DeviceCommandChimesModeRequest, expected_attr
+        )
+
+    @pytest.mark.asyncio
+    async def test_failure_raises_with_reason(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_chimes_mode import (
+            endpoint_pb2_grpc,
+            response_pb2,
+        )
+
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        api = self._make_api()
+        failure = response_pb2.DeviceCommandChimesModeResponse(
+            failure=response_pb2.DeviceCommandChimesModeResponse.Failure(
+                permission_denied=common_response_pb2.Error(),
+            )
+        )
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.execute = AsyncMock(return_value=failure)
+
+        with (
+            patch.object(endpoint_pb2_grpc, "DeviceCommandChimesModeServiceStub", _StubFactory),
+            pytest.raises(DeviceCommandError) as exc_info,
+        ):
+            await api.set_chimes_mode("hub-1", enable=True)
+
+        assert exc_info.value.reason == "permission_denied"

--- a/tests/unit/test_spaces.py
+++ b/tests/unit/test_spaces.py
@@ -13,7 +13,7 @@ from custom_components.aegis_ajax.api.models import (
     SpaceSnapshot,
 )
 from custom_components.aegis_ajax.api.spaces import SpacesApi
-from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
+from custom_components.aegis_ajax.const import ChimeStatus, ConnectionStatus, SecurityState
 
 _FIND_SPACES_BASE = "v3.mobilegwsvc.service.find_user_spaces_with_pagination"
 _STREAM_SPACE_REQUEST = "systems.ajax.api.mobile.v2.space.stream_space_updates_request_pb2"
@@ -39,6 +39,53 @@ class TestParseSpace:
         assert result.security_state == SecurityState.DISARMED
         assert result.connection_status == ConnectionStatus.ONLINE
         assert result.monitoring_companies_loaded is False
+
+
+class TestExtractChimeStatus:
+    """Real-proto coverage of the `tqs.a(space)` hub-Chime walk (#239).
+
+    Reads off the full `Space` snapshot (the only response carrying `devices`).
+    """
+
+    @staticmethod
+    def _build_space(chime_value: int | None) -> object:
+        from systems.ajax.api.mobile.v2.common.space import space_pb2
+        from systems.ajax.api.mobile.v2.common.space.device import (
+            standalone_device_pb2,
+        )
+
+        space = space_pb2.Space(id="s1")
+        if chime_value is not None:
+            hub_dev = standalone_device_pb2.StandaloneDevice()
+            hub_dev.hub.chime_status = chime_value
+            space.devices.append(hub_dev)
+        return space
+
+    @pytest.mark.parametrize(
+        ("chime_value", "expected"),
+        [
+            (1, ChimeStatus.ENABLED),
+            (2, ChimeStatus.CAN_BE_ENABLED),
+            (3, ChimeStatus.MALFUNCTION),
+            (4, ChimeStatus.DISABLED),
+            (0, ChimeStatus.UNSPECIFIED),
+        ],
+    )
+    def test_reads_chime_status_off_hub_device(
+        self, chime_value: int, expected: ChimeStatus
+    ) -> None:
+        space = self._build_space(chime_value)
+        assert SpacesApi.extract_chime_status(space) == expected
+
+    def test_no_hub_device_yields_unspecified(self) -> None:
+        space = self._build_space(None)
+        assert SpacesApi.extract_chime_status(space) == ChimeStatus.UNSPECIFIED
+
+    def test_no_devices_attribute_yields_unspecified(self) -> None:
+        # `spec=[]` makes attribute access raise AttributeError, emulating a
+        # response object that doesn't carry `devices` (e.g. a LiteSpace).
+        proto_space = MagicMock(spec=[])
+        assert SpacesApi.extract_chime_status(proto_space) == ChimeStatus.UNSPECIFIED
 
     def test_parse_space_armed(self) -> None:
         proto_space = MagicMock()
@@ -439,6 +486,45 @@ class TestGetSpaceSnapshot:
         assert snapshot.monitoring_companies[1].name == "Central Two"
         assert snapshot.monitoring_companies[1].status == MonitoringCompanyStatus.PENDING_APPROVAL
         assert snapshot.monitoring_companies_loaded is True
+
+    @pytest.mark.asyncio
+    async def test_reads_hub_chime_status_from_snapshot(self) -> None:
+        """The snapshot's full Space carries the hub Chime status (#239)."""
+        from systems.ajax.api.mobile.v2.common.space.device import (
+            standalone_device_pb2,
+        )
+
+        mock_client = MagicMock()
+        mock_client._get_channel.return_value = MagicMock()
+        mock_client._session.get_call_metadata.return_value = []
+        api = SpacesApi(mock_client)
+
+        hub_dev = standalone_device_pb2.StandaloneDevice()
+        hub_dev.hub.chime_status = 1  # ENABLED
+
+        snapshot_msg = MagicMock()
+        snapshot_msg.HasField.side_effect = lambda f: f == "success"
+        snapshot_msg.success.WhichOneof.return_value = "snapshot"
+        snapshot_msg.success.snapshot.rooms = []
+        snapshot_msg.success.snapshot.monitoring_companies = []
+        snapshot_msg.success.snapshot.devices = [hub_dev]
+
+        stream = _async_iter([snapshot_msg])
+        stub_instance = MagicMock()
+        stub_instance.stream = MagicMock(return_value=stream)
+        grpc_module = MagicMock(SpaceServiceStub=MagicMock(return_value=stub_instance))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                _STREAM_SPACE_REQUEST: MagicMock(),
+                _SPACE_GRPC: grpc_module,
+                _SPACE_LOCATOR: MagicMock(),
+            },
+        ):
+            snapshot = await api.get_space_snapshot("space-1")
+
+        assert snapshot.chime_status == ChimeStatus.ENABLED
 
 
 _PANIC_REQUEST = "systems.ajax.api.mobile.v2.space.press_panic_button_request_pb2"

--- a/tests/unit/test_switch.py
+++ b/tests/unit/test_switch.py
@@ -434,3 +434,233 @@ class TestBypassOrphanEviction:
             ],
         )
         assert removed == []
+
+
+class TestAjaxChimeSwitch:
+    """Hub-wide Chime switch (#239)."""
+
+    def _make(self, chime_status: object = None, online: bool = True) -> tuple[object, MagicMock]:
+        from custom_components.aegis_ajax.const import ChimeStatus
+        from custom_components.aegis_ajax.switch import AjaxChimeSwitch
+
+        if chime_status is None:
+            chime_status = ChimeStatus.ENABLED
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        hub = MagicMock(device_type="hub_two_plus")
+        coordinator.devices = {"hub-1": hub}
+        space = MagicMock(id="s1", hub_id="hub-1")
+        space.is_online = online
+        space.chime_status = chime_status
+        coordinator.spaces = {"s1": space}
+        sw = AjaxChimeSwitch(coordinator=coordinator, space_id="s1", hub_id="hub-1")
+        return sw, coordinator
+
+    def test_unique_id(self) -> None:
+        sw, _ = self._make()
+        assert sw.unique_id == "aegis_ajax_hub-1_chime"
+
+    def test_translation_key(self) -> None:
+        sw, _ = self._make()
+        assert sw._attr_translation_key == "chime"
+
+    def test_is_config_entity(self) -> None:
+        from homeassistant.helpers.entity import EntityCategory
+
+        sw, _ = self._make()
+        assert sw._attr_entity_category == EntityCategory.CONFIG
+
+    def test_is_on_when_enabled(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        sw, _ = self._make(chime_status=ChimeStatus.ENABLED)
+        assert sw.is_on is True
+
+    def test_is_off_when_can_be_enabled(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        sw, _ = self._make(chime_status=ChimeStatus.CAN_BE_ENABLED)
+        assert sw.is_on is False
+
+    def test_is_off_when_disabled(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        sw, _ = self._make(chime_status=ChimeStatus.DISABLED)
+        assert sw.is_on is False
+
+    def test_available_requires_online_and_supported(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        sw, _ = self._make(chime_status=ChimeStatus.ENABLED, online=True)
+        assert sw.available is True
+
+    def test_unavailable_when_offline(self) -> None:
+        sw, _ = self._make(online=False)
+        assert sw.available is False
+
+    def test_unavailable_when_unspecified(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        sw, _ = self._make(chime_status=ChimeStatus.UNSPECIFIED)
+        assert sw.available is False
+
+    def test_is_on_none_when_space_missing(self) -> None:
+        sw, coordinator = self._make()
+        coordinator.spaces = {}
+        assert sw.is_on is None
+
+    @pytest.mark.asyncio
+    async def test_turn_on_enables(self) -> None:
+        sw, coordinator = self._make()
+        coordinator.devices_api.set_chimes_mode = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+
+        await sw.async_turn_on()
+
+        coordinator.devices_api.set_chimes_mode.assert_awaited_once_with("hub-1", enable=True)
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_disables(self) -> None:
+        sw, coordinator = self._make()
+        coordinator.devices_api.set_chimes_mode = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+
+        await sw.async_turn_off()
+
+        coordinator.devices_api.set_chimes_mode.assert_awaited_once_with("hub-1", enable=False)
+
+    @pytest.mark.asyncio
+    async def test_permission_denied_surfaces_homeassistant_error(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        sw, coordinator = self._make()
+        coordinator.devices_api.set_chimes_mode = AsyncMock(
+            side_effect=DeviceCommandError(
+                "chimes_mode: permission_denied", reason="permission_denied"
+            )
+        )
+        coordinator.async_request_refresh = AsyncMock()
+
+        with pytest.raises(HomeAssistantError) as exc:
+            await sw.async_turn_on()
+
+        assert exc.value.translation_key == "command_permission_denied"
+        coordinator.async_request_refresh.assert_not_awaited()
+
+
+class TestChimeSwitchSetup:
+    """`async_setup_entry` creates a Chime switch only for hubs that expose it."""
+
+    async def _run(self, *, chime_status: object) -> set[str]:
+        from custom_components.aegis_ajax.switch import AjaxChimeSwitch, async_setup_entry
+
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        hub = MagicMock(device_type="hub_two_plus", hub_id="hub-1")
+        coordinator.devices = {"hub-1": hub}
+        space = MagicMock(id="s1", hub_id="hub-1")
+        space.chime_status = chime_status
+        coordinator.spaces = {"s1": space}
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.runtime_data = coordinator
+        entry.data = {"user_hex_id": "ABCD1234"}
+        entry.options = {"bypass_switches": "never"}
+        added: list = []
+
+        def _add(entities: list, *a: object, **k: object) -> None:
+            added.extend(entities)
+
+        with (
+            patch("custom_components.aegis_ajax.switch.er.async_get", return_value=MagicMock()),
+            patch(
+                "custom_components.aegis_ajax.switch.er.async_entries_for_config_entry",
+                return_value=[],
+            ),
+        ):
+            await async_setup_entry(MagicMock(), entry, _add)
+        return {e.unique_id for e in added if isinstance(e, AjaxChimeSwitch)}
+
+    @pytest.mark.asyncio
+    async def test_creates_when_enabled(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        ids = await self._run(chime_status=ChimeStatus.ENABLED)
+        assert ids == {"aegis_ajax_hub-1_chime"}
+
+    @pytest.mark.asyncio
+    async def test_creates_when_can_be_enabled(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        ids = await self._run(chime_status=ChimeStatus.CAN_BE_ENABLED)
+        assert ids == {"aegis_ajax_hub-1_chime"}
+
+    @pytest.mark.asyncio
+    async def test_no_switch_when_unspecified(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        ids = await self._run(chime_status=ChimeStatus.UNSPECIFIED)
+        assert ids == set()
+
+
+class TestChimeOrphanEviction:
+    """Chime switches no longer provided are evicted (#239)."""
+
+    async def _run(self, *, chime_status: object, registry_entries: list) -> list[str]:
+        from custom_components.aegis_ajax.switch import async_setup_entry
+
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        hub = MagicMock(device_type="hub_two_plus", hub_id="hub-1")
+        coordinator.devices = {"hub-1": hub}
+        space = MagicMock(id="s1", hub_id="hub-1")
+        space.chime_status = chime_status
+        coordinator.spaces = {"s1": space}
+        coordinator.spaces_api.get_member_space_permissions = AsyncMock(return_value=None)
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.runtime_data = coordinator
+        entry.data = {"user_hex_id": "ABCD1234"}
+        entry.options = {"bypass_switches": "never"}
+
+        removed: list[str] = []
+        entity_reg = MagicMock()
+        entity_reg.async_remove.side_effect = removed.append
+
+        def _add(entities: list, *a: object, **k: object) -> None:
+            pass
+
+        with (
+            patch("custom_components.aegis_ajax.switch.er.async_get", return_value=entity_reg),
+            patch(
+                "custom_components.aegis_ajax.switch.er.async_entries_for_config_entry",
+                return_value=registry_entries,
+            ),
+        ):
+            await async_setup_entry(MagicMock(), entry, _add)
+        return removed
+
+    @pytest.mark.asyncio
+    async def test_evicts_when_unspecified(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        removed = await self._run(
+            chime_status=ChimeStatus.UNSPECIFIED,
+            registry_entries=[_reg_entry("switch.hub_chime", "aegis_ajax_hub-1_chime")],
+        )
+        assert removed == ["switch.hub_chime"]
+
+    @pytest.mark.asyncio
+    async def test_keeps_when_supported(self) -> None:
+        from custom_components.aegis_ajax.const import ChimeStatus
+
+        removed = await self._run(
+            chime_status=ChimeStatus.ENABLED,
+            registry_entries=[_reg_entry("switch.hub_chime", "aegis_ajax_hub-1_chime")],
+        )
+        assert removed == []


### PR DESCRIPTION
## What

Adds a per-hub **Chime** switch that toggles the hub-wide Chime — the Ajax app's bottom-left toggle that plays a tone on opening monitored doors while disarmed. Requested in #239.

## State (read)

Read from the hub's `chime_status` (`DisplayedChimeStatus`) in the space snapshot — the same field the app shows — so the switch reflects changes made from the app.

- Only the full `Space` snapshot (`get_space_snapshot`) carries it; the lighter `list_spaces` poll returns a `LiteSpace` without `devices`, so Chime rides the hourly snapshot path (preserved across plain polls), with an **optimistic update** for instant feedback on HA-initiated toggles.
- `ENABLED` → on; `CAN_BE_ENABLED` / `DISABLED` → off; `UNSPECIFIED` → feature not exposed (no switch).

## Command (write)

`device_command_chimes_mode` with hub-wide `chimes_status` ENABLE/DISABLE. Requires the account's `EDIT_CHIMES` permission; a limited account surfaces a clear translated `permission_denied` error on toggle (reuses the existing command-error mapping).

## Details

- One switch per hub that exposes the feature; orphan-evicted when it stops (mirrors the bypass switch).
- `EntityCategory.CONFIG`, icon `mdi:bell` / `bell-ring` / `bell-off`.
- Added `chime_status` to diagnostics; entity name translated across all 14 locales.

## Tests

New unit coverage for `extract_chime_status` (real protos), `set_chimes_mode`, `set_chime_optimistic`, the snapshot read, and `AjaxChimeSwitch` (state / availability / toggle / error mapping / setup / eviction). Full `make check` green (1609 tests, 88.7% coverage).

Related to #239.