### PR TITLE
fix(coordinator): independent poll safety-net timer (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - unreleased
+
+### Fixed
+- **Alarm state and the hourly refresh now update on their own on active hubs, without relying on push (#178).** On a hub that streams frequent network updates, every update reset Home Assistant's poll timer before it could fire, so the periodic refresh that reads the alarm state (and hourly re-reads rooms, groups, chime, monitoring company, SIM and firmware) effectively never ran on its own — leaving those values dependent entirely on FCM push. If push was delayed or not configured, the panel only updated on a manual reload. A dedicated refresh timer now runs the poll on a fixed cadence regardless of stream activity, restoring the safety net behind push.
+
 ## [1.9.0] - 2026-06-04
 
 ### Added

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -179,6 +179,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # poll timer, so the scheduled poll never fires again after startup; a
         # poll-driven refresh would be starved.
         self._unsub_hub_device_temp: CALLBACK_TYPE | None = None
+        # Independent poll safety-net timer (#178). On active hubs every HTS
+        # update reschedules HA's built-in poll timer faster than
+        # `poll_interval`, starving the scheduled `_async_update_data`; this
+        # dedicated timer drives a periodic refresh regardless of HTS chatter.
+        self._unsub_poll_safety: CALLBACK_TYPE | None = None
         # HTS client for hub network data (ethernet, wifi, gsm, power)
         self._hts_client: HtsClient | None = None
         self._hts_task: asyncio.Task[None] | None = None
@@ -543,6 +548,42 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if changed:
             self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
+    def _schedule_poll_safety_refresh(self) -> None:
+        """Start the independent poll safety-net timer (#178).
+
+        On any active hub every HTS network/device update calls
+        `async_set_updated_data`, which reschedules HA's built-in poll timer.
+        HTS pushes arrive every ~30-60 s — well under `poll_interval` — so the
+        scheduled `_async_update_data` is starved and never fires on its own,
+        leaving `security_state` and the hourly snapshot refresh
+        (rooms/groups/chime/CRA/SIM/firmware) dependent 100% on FCM push with
+        no safety net when push is delayed or absent (#178, #239).
+
+        This dedicated `async_track_time_interval` fires on wall-clock time,
+        independent of the coordinator's internal scheduler, and requests a
+        refresh so `_async_update_data` runs on a fixed cadence regardless of
+        HTS chatter. The startup refresh already populated state, so no initial
+        kick is needed — the first fire is one interval out by design.
+
+        `self._poll_interval` is already clamped to [MIN, MAX] in `__init__`.
+        """
+        if self._unsub_poll_safety is not None:
+            return
+        self._unsub_poll_safety = async_track_time_interval(
+            self.hass,
+            self._async_poll_safety_refresh,
+            timedelta(seconds=self._poll_interval),
+        )
+
+    async def _async_poll_safety_refresh(self, _now: datetime | None = None) -> None:
+        """Timer-driven safety-net refresh (#178). See `_schedule_poll_safety_refresh`.
+
+        Routes through the public `async_request_refresh` so it reuses the
+        whole polled path (`list_spaces` + hourly snapshot gating) and the
+        coordinator's debouncer coalesces it with any concurrent refresh.
+        """
+        await self.async_request_refresh()
+
     async def _first_startup_init(self) -> None:
         """First-cycle bootstrap: warm devices cache, start persistent
         streams + HTS lifecycle, log a one-line startup summary.
@@ -583,6 +624,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._start_device_streams()
         await self._start_hts()
         self._schedule_hub_device_temperature_refresh()
+        self._schedule_poll_safety_refresh()
         self._last_update_success_time = dt_util.utcnow()
         # One-line summary so users debugging "HTS streams: 0/1" or
         # "FCM clients: 0/1" reports (#111) can see at a glance which
@@ -1297,6 +1339,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._unsub_hub_device_temp is not None:
             self._unsub_hub_device_temp()
             self._unsub_hub_device_temp = None
+
+        # Stop the poll safety-net timer (#178)
+        if self._unsub_poll_safety is not None:
+            self._unsub_poll_safety()
+            self._unsub_poll_safety = None
 
         # Cancel all stream tasks
         for task in self._stream_tasks:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2179,6 +2179,82 @@ class TestHubDeviceTemperatureRefresh:
         assert "temperature" not in coordinator.devices["d1"].statuses
 
 
+class TestPollSafetyTimer:
+    """Independent poll safety-net timer (#178) — backstop when push is starved.
+
+    On any active hub every HTS update calls `async_set_updated_data`, which
+    reschedules HA's built-in poll timer faster than `poll_interval`, so the
+    scheduled `_async_update_data` never fires on its own and `security_state`
+    plus the hourly snapshot refresh depend 100% on FCM push. A dedicated
+    `async_track_time_interval` fires on wall-clock time regardless of HTS
+    chatter and requests a refresh, restoring the polled safety net.
+    """
+
+    def test_schedule_registers_independent_timer(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        with patch(
+            "custom_components.aegis_ajax.coordinator.async_track_time_interval",
+            return_value=MagicMock(),
+        ) as mock_track:
+            coordinator._schedule_poll_safety_refresh()
+
+        mock_track.assert_called_once()
+        # poll_interval=30 (from _make_coordinator) is clamped to MIN (60) in __init__.
+        assert mock_track.call_args.args[2] == timedelta(seconds=60)
+        assert coordinator._unsub_poll_safety is mock_track.return_value
+
+    def test_schedule_is_idempotent(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator._unsub_poll_safety = MagicMock()
+        with patch(
+            "custom_components.aegis_ajax.coordinator.async_track_time_interval",
+        ) as mock_track:
+            coordinator._schedule_poll_safety_refresh()
+
+        mock_track.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_requests_coordinator_refresh(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.async_request_refresh = AsyncMock()
+
+        await coordinator._async_poll_safety_refresh()
+
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_startup_init_schedules_timer(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._devices_cache = None
+        coordinator.spaces = {}
+        coordinator._probe_smart_locks_once = AsyncMock()
+        coordinator._start_device_streams = AsyncMock()
+        coordinator._start_hts = AsyncMock()
+        coordinator._schedule_hub_device_temperature_refresh = MagicMock()
+        coordinator._schedule_poll_safety_refresh = MagicMock()
+
+        await coordinator._first_startup_init()
+
+        coordinator._schedule_poll_safety_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_timer(self) -> None:
+        coordinator = _make_coordinator()
+        unsub = MagicMock()
+        coordinator._unsub_poll_safety = unsub
+        coordinator._unsub_hub_device_temp = None
+        coordinator._stream_tasks = []
+        coordinator._hts_task = None
+        coordinator._hts_client = None
+        coordinator._notification_listener = None
+        coordinator._client.close = AsyncMock()
+
+        await coordinator.async_shutdown()
+
+        unsub.assert_called_once()
+        assert coordinator._unsub_poll_safety is None
+
+
 class TestSetChimeOptimistic:
     """Immediate optimistic Chime state after an HA-initiated toggle (#239)."""
 


### PR DESCRIPTION
## Problem

On any active hub the scheduled poll never fires on its own. `DataUpdateCoordinator.async_set_updated_data` reschedules HA's built-in poll timer every time it's called, and the coordinator calls it on **every** HTS network/device update (`_on_hts_update` / `_on_hts_device_kv` / `_on_hts_chime_event`) — roughly every 30-60s, well under the 60-300s `poll_interval`. So `_async_update_data` (the only path that calls `list_spaces()` and refreshes `security_state`, plus the hourly snapshot refresh of rooms/groups/chime/CRA/SIM/firmware) is **starved and never fires autonomously**.

Empirically confirmed on a live hub: a 2h13m debug window logged **0** autonomous scheduled polls against **137** HTS-driven timer resets. The only refreshes were the startup one and two that happened to be push-triggered by an arm/disarm.

Consequences:
- `security_state` depends 100% on FCM push. When push is delayed (degraded delivery) or not configured, the alarm panel only updates on a manual reload — exactly the #178 report.
- The hourly snapshot refresh also never runs, so rooms/groups/chime/CRA/SIM/firmware go stale too.

The code already half-knew this: the per-device temperature refresh (#220) was given its own `async_track_time_interval` for the same reason.

## Fix

Add a dedicated `async_track_time_interval` (`_schedule_poll_safety_refresh`) that fires on wall-clock time, independent of the coordinator's internal scheduler, and requests a refresh via the public `async_request_refresh`. This makes the polled path run on a fixed `poll_interval` cadence regardless of HTS chatter, restoring the safety net behind push and reusing the entire existing refresh logic (list_spaces + hourly gating + the coordinator's debouncer). Mirrors the temperature-timer pattern (#220).

- Started in `_first_startup_init` alongside the temperature timer; idempotent.
- Torn down in `async_shutdown`.
- No initial kick needed — the startup refresh already populates state; first fire is one interval out by design.

## Tests

New `TestPollSafetyTimer`: registers an independent timer at the clamped `poll_interval`, idempotent, drives `async_request_refresh`, wired into startup init, cancelled on shutdown. Full suite: 1629 passed, 88.76% coverage. Verified in a clean no-mount Docker build.

References #178.