### PR TITLE
feat(keyfobs): surface SpaceControl keyfobs grouped under a "Keyfobs" device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - unreleased
+
+### Added
+- **SpaceControl keyfobs now appear in Home Assistant, with an experimental "Active" sensor.** Keyfobs (llaveros) are reported only over the hub's HTS link, never in the gRPC device snapshot, so they were invisible until now. They are grouped under a single **Keyfobs** device per hub, with one diagnostic **Active** binary sensor per keyfob (named after it). The active value is **experimental and unverified**: every observed keyfob reports as active and we have no deactivated sample to confirm against (only an installer/CRA can deactivate a keyfob), so the sensor reads "active" until a diagnostic from a genuinely deactivated keyfob confirms the indicator. To help with that, keyfob detail is logged at debug level (names redacted) and included in the diagnostics download. Who armed/disarmed via a keyfob already appeared in the logbook ("Disarmed (via NAME)") and is unaffected.
+
+### Documentation
+- **Documented keyfobs as experimental and asked for deactivated-keyfob logs.** README now lists keyfobs in Supported Devices, adds a Keyfobs (experimental) entity section explaining the unconfirmed active/inactive state, and a Help Wanted entry inviting a diagnostics dump + debug log from anyone with a keyfob deactivated by their installer/CRA so the indicator can be confirmed.
+
 ## [1.9.1] - 2026-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ You can type any custom label during setup if yours is not listed.
 | Hub Chime | Hubs that expose the chime setting | `switch.<hub>_chime` toggles the hub-wide chime tone (door-open alert while disarmed); reflects app-side changes instantly. Requires the account's chime-edit permission |
 | Doorbells | Wireless DoorBell (standalone Jeweller ring button), MotionCam Video Doorbell, SmartLock / LockBridge variants with integrated ring button | `doorbell_pressed` on the hub's security event entity, plus a **per-device `event` entity** (`device_class: doorbell`) that emits Home Assistant's canonical `ring` event; a doorbell motion push also flips the doorbell's `motion_detected` on (30 s auto-off). Video doorbell also exposes photo capture; SmartLock variant exposes lock state on the lock entity. Requires FCM credentials configured |
 | Keypads | Keypad, KeypadPlus, KeypadCombi, KeypadTouchscreen | Battery, tamper, temperature, signal, NFC status |
+| Keyfobs (experimental) | SpaceControl, SpaceControl S | Grouped under a single **Keyfobs** device, with one **Active** binary sensor per keyfob (diagnostic). The active/inactive value is **experimental and not yet confirmed** — see [Keyfobs (experimental)](#keyfobs-experimental). Who armed/disarmed via a keyfob already appears in the logbook regardless |
 | Sirens | HomeSiren, HomeSiren S, HomeSiren Fibra, HomeSiren G3, StreetSiren, StreetSiren S, StreetSiren Plus, StreetSiren Plus Fibra/G3, StreetSiren Fibra, StreetSiren Double Deck (& S / Fibra) | Battery, tamper, signal, internal temperature (HomeSiren / StreetSiren family) |
 | Range extenders | ReX, ReX 2, ReX 2 Fire | Battery, signal |
 | Wired-Input Modules | MultiTransmitter, MultiTransmitter Fibra, Hub Hybrid wired inputs | Tamper of the module itself; each registered wired sensor appears as its own device with an alert binary sensor and an `alarm_type` attribute (intrusion / fire / glass_break / vibration / …) |
@@ -335,6 +336,15 @@ Use these in automation templates, e.g. `{{ trigger.event.data.device_name }}`.
 - **External contact fault** — circuit-fault indicator for the same external wiring (cable disconnect or short)
 - **Wire input alert** — triggered state of a third-party sensor wired into a MultiTransmitter or a Hub Hybrid wire input. Exposes an `alarm_type` attribute reflecting the category Ajax assigned to that input (intrusion, fire, glass_break, vibration, etc.). Available on `wire_input_mt` and `wire_input` device types
 
+### Keyfobs (experimental)
+SpaceControl keyfobs are grouped under a single **Keyfobs** device (one per hub), with one **Active** binary sensor per keyfob, named after it (using the keyfob name set in the Ajax app).
+
+> **The active/inactive state is experimental and not yet confirmed.** On every install seen so far each keyfob reports as **active**, and a keyfob can only be deactivated by an installer or monitoring company (there's no toggle in the Ajax app, or here), so there has been no *inactive* example to validate against — the sensor may not yet reflect a genuinely deactivated keyfob.
+>
+> **You can help finalize it:** if you have a keyfob that your installer/CRA has deactivated, a **Download diagnostics** (Settings → Devices & Services → Aegis for Ajax → ⋮ → Download diagnostics) plus a debug log (`custom_components.aegis_ajax: debug`) attached to a [GitHub issue](https://github.com/bvis/aegis-hass/issues/new) would let us confirm the indicator and get it right. See [Help Wanted](#help-wanted).
+
+Who armed or disarmed the system with a keyfob already appears in the logbook ("Disarmed (via …)") and on the hub's security event entity — that's independent of these sensors.
+
 ## Automation Blueprints
 
 Aegis includes 8 ready-to-use automation blueprints. Import them via URL in **Settings → Automations → Blueprints → Import Blueprint**:
@@ -393,7 +403,7 @@ If a specific group of sensors stops working:
 - [ ] Valve platform — bidirectional control. Read-only `valve` entity ships in `1.3.0`; full open / close still waits on capturing the official app's command-side calls (no `SwitchWaterStopService` in the v3 protos)
 - [ ] Per-device firmware update entities. Hub-level entity ships in `1.4.0` via `streamHubObject` field 201; field 200 (`device_firmware_updates`) carries the same shape per device for the per-device entities, same read-only-by-design pattern
 - [ ] Number/Select platforms for device settings (sensitivity, brightness)
-- [ ] SpaceControl (keyfob) event support
+- [x] SpaceControl (keyfob) detection — keyfobs surface as a **Keyfobs** device with an experimental per-keyfob active sensor (`1.10.0`); the active/inactive value still awaits confirmation from a deactivated-keyfob log. (Who armed/disarmed via a keyfob was already attributed in the logbook.)
 
 ## Help Wanted
 
@@ -403,7 +413,8 @@ Areas where the integration could grow with community input:
 
 - **Video streaming** (live view on MotionCam Video, Video Edge cameras) — the biggest open gap.
 - **Bidirectional WaterStop control** — read-only valve entity ships since `1.3.0`; full open / close is still pending.
-- **SpaceControl (keyfob) events**, **per-device firmware updates**, **device settings** (sensitivity, brightness, alert thresholds).
+- **A deactivated SpaceControl keyfob** — keyfobs now appear as a *Keyfobs* device with an experimental per-keyfob **Active** sensor (`1.10.0`), but the active/inactive value is unconfirmed because every keyfob seen so far is active. If yours has one deactivated by your installer/CRA, a diagnostics dump + debug log would let us finalize the indicator.
+- **Per-device firmware updates**, **device settings** (sensitivity, brightness, alert thresholds).
 - **Co-branded apps** the integration doesn't yet recognise in the `App Label` dropdown.
 - **Any new device family** that shows up in the snapshot without entities.
 

--- a/custom_components/aegis_ajax/api/hts/keyfobs.py
+++ b/custom_components/aegis_ajax/api/hts/keyfobs.py
@@ -1,0 +1,130 @@
+"""Parser for Ajax SpaceControl keyfob rows in the HTS SETTINGS_BODY.
+
+Keyfobs (the physical "llaveros") are **HTS-only**: they never appear in the
+gRPC `StreamLightDevices` snapshot that populates `coordinator.devices`. Instead
+they arrive as device rows inside `SETTINGS_BODY` (HTS sub-key 5) over the same
+`on_device_kv` callback used for #123 electrical readings, and were simply
+unmapped until now.
+
+Empirically (live capture, 6 keyfobs) every keyfob row carries an identical
+15-sub-key set; only the name (`0x02`) and a per-device index (`0x0a`) differ:
+
+    0x02 = name (UTF-8)                 the keyfob's display name
+    0x0a = per-device index/handle      sequential, distinct per keyfob
+    0x0b..0x0e = four 1-byte flags      all observed as 0x01
+    0x07/0x08  = 00000000ffffffff       constant placeholders
+    0x09/0x10/0x11/0x0f/0x13/0x14 = zeros
+    0x16 = ffff
+
+**The "active" flag is EXPERIMENTAL/unverified.** Every observed keyfob reads
+`0x0b == 0x01`; we have no `inactive` sample (only a CRA admin can deactivate a
+keyfob server-side, and that toggle is not in the mobile app). We assume
+`0x0b == 0x01` means "active" and expose it as an experimental diagnostic, while
+DEBUG-logging the full row (`looks_like_keyfob_candidate`) so a user who *does*
+have a deactivated keyfob can paste their log and let us confirm the real flag.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from custom_components.aegis_ajax.api.hts.hub_state import _bool_val, _int_be_val, _str_val
+
+# The exact sub-key set every captured keyfob row shares. No other device row,
+# user/member row, or section marker observed in SETTINGS_BODY collides with it.
+KEYFOB_SHAPE: frozenset[int] = frozenset(
+    {0x02, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x13, 0x14, 0x16}
+)
+
+# Sub-keys, all single-byte. `0x02` name, `0x0a` index, `0x0b..0x0e` flags.
+KEYFOB_SUBKEY_NAME = 0x02
+KEYFOB_SUBKEY_INDEX = 0x0A
+# Assumed-experimental "active" byte (see module docstring). The 0x0b..0x0e
+# quartet is more likely the four button-function flags; 0x0b is treated as the
+# activation indicator until a deactivated-keyfob capture says otherwise.
+KEYFOB_ACTIVE_SUBKEY = 0x0B
+KEYFOB_FLAG_SUBKEYS = (0x0B, 0x0C, 0x0D, 0x0E)
+
+# User/member rows carry both a name (0x01) and a phone (0x03); keyfob rows
+# never do. Used to exclude members from the debug-candidate predicate.
+_USER_ROW_MARKER_SUBKEYS = frozenset({0x01, 0x03})
+
+# Section/company marker rows use low integer ids (e.g. 0x00000001, 0x0000016A);
+# real device ids are well above this. Excludes those from both predicates.
+_MIN_DEVICE_ID = 0x10000
+
+
+@dataclasses.dataclass(frozen=True)
+class Keyfob:
+    """Immutable snapshot of a single Ajax SpaceControl keyfob.
+
+    `active` is EXPERIMENTAL — derived from the unverified `0x0b` flag (see
+    module docstring). `flags_hex` preserves the raw `0x0b..0x0e` quartet so a
+    user diagnostic / DEBUG log can later confirm which byte truly encodes the
+    CRA-controlled activation state.
+    """
+
+    id: str
+    hub_id: str
+    name: str
+    index: int | None
+    active: bool
+    flags_hex: str
+
+
+def _flags_hex(kv: dict[int, bytes]) -> str:
+    """Render the raw `0x0b..0x0e` flag quartet as a stable hex string."""
+    return ":".join(kv.get(sk, b"").hex() for sk in KEYFOB_FLAG_SUBKEYS)
+
+
+def parse_keyfob(device_id_hex: str, hub_id: str, kv: dict[int, bytes]) -> Keyfob | None:
+    """Return a `Keyfob` iff *kv* is a keyfob row, else `None`.
+
+    Classification is install-independent and relies on the unique 15-sub-key
+    shape plus a printable name — no dependence on the device-id prefix (which
+    was coincidental). The caller (`coordinator._on_hts_device_kv`) only reaches
+    this for rows absent from the gRPC device snapshot, so modeled devices and
+    the hub are already excluded; this adds the user-row and marker guards.
+    """
+    if frozenset(kv) != KEYFOB_SHAPE:
+        return None
+    try:
+        if int(device_id_hex, 16) < _MIN_DEVICE_ID:
+            return None
+    except ValueError:
+        return None
+    name = _str_val(kv[KEYFOB_SUBKEY_NAME])
+    if not name or not name.isprintable():
+        return None
+    return Keyfob(
+        id=device_id_hex,
+        hub_id=hub_id,
+        name=name,
+        index=_int_be_val(kv.get(KEYFOB_SUBKEY_INDEX)),
+        active=_bool_val(kv.get(KEYFOB_ACTIVE_SUBKEY, b"")),
+        flags_hex=_flags_hex(kv),
+    )
+
+
+def looks_like_keyfob_candidate(device_id_hex: str, kv: dict[int, bytes]) -> bool:
+    """Loose predicate for *whether to DEBUG-log* a row as a keyfob candidate.
+
+    Deliberately broader than `parse_keyfob`: it matches a row that has a
+    printable name (`0x02`) and an index (`0x0a`), is not a user/member row, and
+    is not a low-id marker — even if its sub-key set differs from the strict
+    shape. That way a CRA-deactivated keyfob whose bytes diverge from every
+    observed (active) sample still surfaces in logs for diffing, instead of being
+    silently dropped.
+    """
+    keys = frozenset(kv)
+    if KEYFOB_SUBKEY_NAME not in keys or KEYFOB_SUBKEY_INDEX not in keys:
+        return False
+    if keys >= _USER_ROW_MARKER_SUBKEYS:
+        return False
+    try:
+        if int(device_id_hex, 16) < _MIN_DEVICE_ID:
+            return False
+    except ValueError:
+        return False
+    name = _str_val(kv[KEYFOB_SUBKEY_NAME])
+    return bool(name) and name.isprintable()

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -9,8 +9,11 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.const import EntityCategory
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER, SIGNAL_NEW_DEVICE
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 from custom_components.aegis_ajax.entity import build_device_info
 
@@ -404,6 +407,29 @@ async def async_setup_entry(
         )
     async_add_entities(entities)
 
+    # SpaceControl keyfobs are HTS-only and discovered seconds after setup (when
+    # the first SETTINGS_BODY arrives), so they are not in `coordinator.devices`
+    # here. Add any already known, then listen on the generic SIGNAL_NEW_DEVICE
+    # dispatcher to add each new one as it is discovered at runtime.
+    seen_keyfobs: set[str] = set()
+
+    def _add_keyfobs(keyfob_ids: list[str]) -> None:
+        new = [
+            AjaxKeyfobActiveSensor(coordinator, kid)
+            for kid in keyfob_ids
+            if kid not in seen_keyfobs and kid in coordinator.keyfobs
+        ]
+        if new:
+            seen_keyfobs.update(e._keyfob_id for e in new)
+            async_add_entities(new)
+
+    _add_keyfobs(list(coordinator.keyfobs))
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, SIGNAL_NEW_DEVICE, lambda device_id: _add_keyfobs([device_id])
+        )
+    )
+
 
 def _evict_orphan_co_sensors(
     hass: HomeAssistant, entry: ConfigEntry, *, provided: set[str]
@@ -545,6 +571,61 @@ class AjaxProblemSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySenso
         if device:
             return {"malfunctions_count": device.malfunctions}
         return {}
+
+
+class AjaxKeyfobActiveSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensorEntity):
+    """EXPERIMENTAL "Active" state for an Ajax SpaceControl keyfob.
+
+    Keyfobs are HTS-only (not in the gRPC device snapshot). They carry no
+    per-device data (no battery/online), so rather than one HA device each they
+    are grouped under a single virtual "Keyfobs" device (one per hub), with one
+    entity per keyfob named after it. The `active` value is derived from an
+    UNVERIFIED flag byte (`0x0b`) — every observed keyfob reads "active" and we
+    have no deactivated sample, so the value is surfaced experimentally.
+    `flags_hex` is exposed as an attribute so a user with a CRA-deactivated
+    keyfob can confirm which byte actually flips.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, keyfob_id: str) -> None:
+        super().__init__(coordinator)
+        self._keyfob_id = keyfob_id
+        self._attr_unique_id = f"aegis_ajax_{keyfob_id}_active"
+        keyfob = coordinator.keyfobs.get(keyfob_id)
+        if keyfob:
+            # The entity's own name is the keyfob name; with has_entity_name the
+            # device page lists it (e.g. "Front fob") under the "Keyfobs" device.
+            self._attr_name = keyfob.name
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, f"{keyfob.hub_id}_keyfobs")},
+                name="Keyfobs",
+                manufacturer=MANUFACTURER,
+                model="SpaceControl keyfobs (experimental)",
+                via_device=(DOMAIN, keyfob.hub_id),
+            )
+
+    @property
+    def available(self) -> bool:
+        return self._keyfob_id in self.coordinator.keyfobs
+
+    @property
+    def is_on(self) -> bool:
+        keyfob = self.coordinator.keyfobs.get(self._keyfob_id)
+        return keyfob is not None and keyfob.active
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        keyfob = self.coordinator.keyfobs.get(self._keyfob_id)
+        if keyfob is None:
+            return {}
+        return {
+            "index": keyfob.index,
+            "flags_hex": keyfob.flags_hex,
+            "experimental": True,
+        }
 
 
 class AjaxCraConnectionSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensorEntity):

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -527,6 +527,13 @@ ALL_EVENT_TYPES: list[str] = sorted(
     | set(SMARTLOCK_EVENT_TAG_MAP.values())
 )
 
+# Dispatcher signal for entities discovered at runtime (after platform setup),
+# rather than from the gRPC `coordinator.devices` snapshot available at setup.
+# Payload is the discovered device id (str); subscribers filter for what they
+# create. Currently only SpaceControl keyfobs (HTS-only, discovered seconds after
+# startup) use it; kept generic so future runtime discovery can reuse it.
+SIGNAL_NEW_DEVICE = f"{DOMAIN}_new_device"
+
 # Device types that get their own per-device doorbell `event` entity on their
 # device card (#173). The ring event is also fired on the hub-level event
 # entity for backwards compatibility; this surfaces it where users look first.

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
@@ -37,6 +38,7 @@ from custom_components.aegis_ajax.const import (
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
     MOTION_PUSH_AUTO_OFF_SECONDS,
+    SIGNAL_NEW_DEVICE,
     ChimeStatus,
     ConnectionStatus,
 )
@@ -58,6 +60,7 @@ if TYPE_CHECKING:
         DeviceReadings,
         HubNetworkState,
     )
+    from custom_components.aegis_ajax.api.hts.keyfobs import Keyfob
     from custom_components.aegis_ajax.api.models import Device, Room, Space
     from custom_components.aegis_ajax.notification import AjaxNotificationListener
 
@@ -201,6 +204,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # (same shape as `self.devices` keys). Empty dict = no readings
         # snapshotted yet OR no electrical devices in the install.
         self.device_readings: dict[str, DeviceReadings] = {}
+        # SpaceControl keyfobs (HTS-only; not in the gRPC device snapshot).
+        # Populated from SETTINGS_BODY rows via `_on_hts_device_kv`. Keyed by
+        # upper-case 8-char device id. The binary_sensor platform creates a
+        # device + experimental "Active" sensor per entry, added at runtime via
+        # the `SIGNAL_NEW_DEVICE` dispatcher as keyfobs are discovered.
+        self.keyfobs: dict[str, Keyfob] = {}
         # One-shot guard for the #206 Bug-B SmartLock id probe (DEBUG-only).
         self._smart_lock_probe_done = False
         # Per-space monotonic timestamp of when the hub first reported
@@ -782,6 +791,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         device = self.devices.get(device_id_hex)
         if device is None:
+            # Not a gRPC-modeled device — it may be a SpaceControl keyfob, which
+            # only ever appears in the HTS SETTINGS_BODY (never in the gRPC
+            # snapshot). Classify and surface it; everything else (users,
+            # markers) is ignored. See api/hts/keyfobs.py.
+            self._handle_keyfob_kv(hub_id, device_id_hex, kv)
             return
         readings = parse_device_readings(
             device.device_type,
@@ -795,6 +809,42 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.device_readings[device_id_hex] = readings
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         _ = hub_id  # currently unused; kept in the signature for symmetry with on_state_update
+
+    def _handle_keyfob_kv(self, hub_id: str, device_id_hex: str, kv: dict[int, bytes]) -> None:
+        """Classify a non-gRPC SETTINGS_BODY row as a SpaceControl keyfob.
+
+        Keyfobs are HTS-only — they never appear in the gRPC device snapshot, so
+        they reach this path (where `self.devices` has no entry). A recognised
+        keyfob is stored in `self.keyfobs` and announced via `SIGNAL_NEW_DEVICE`
+        so the binary_sensor platform can add its device + experimental "Active"
+        sensor at runtime. Rows that merely *look* like keyfobs are DEBUG-logged
+        (name redacted) so a user with a CRA-deactivated keyfob can share a log
+        and let us confirm the still-unverified active flag — see keyfobs.py.
+        """
+        from custom_components.aegis_ajax.api.hts.keyfobs import (  # noqa: PLC0415
+            looks_like_keyfob_candidate,
+            parse_keyfob,
+        )
+        from custom_components.aegis_ajax.notification import _redact_printable  # noqa: PLC0415
+
+        if looks_like_keyfob_candidate(device_id_hex, kv):
+            _LOGGER.debug(
+                "Keyfob candidate %s on hub %s: %s",
+                device_id_hex,
+                hub_id,
+                {f"0x{k:02x}": _redact_printable(v) for k, v in sorted(kv.items())},
+            )
+
+        keyfob = parse_keyfob(device_id_hex, hub_id, kv)
+        if keyfob is None:
+            return
+        if self.keyfobs.get(device_id_hex) == keyfob:
+            return
+        is_new = device_id_hex not in self.keyfobs
+        self.keyfobs[device_id_hex] = keyfob
+        if is_new:
+            async_dispatcher_send(self.hass, SIGNAL_NEW_DEVICE, device_id_hex)
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     def _on_hts_chime_event(self, hub_id: str, payload_hex: str, candidate: int | None) -> None:
         """React to a hub Chime-toggle event pushed over HTS in real time (#239).

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -68,6 +68,15 @@ async def async_get_config_entry_diagnostics(
             }
             for did, d in coordinator.devices.items()
         },
+        "keyfobs": {
+            kid: {
+                "name": k.name,
+                "index": k.index,
+                "active": k.active,
+                "flags_hex": k.flags_hex,
+            }
+            for kid, k in coordinator.keyfobs.items()
+        },
         "stream_tasks": len(coordinator._stream_tasks),
         "notification_listener": coordinator.notification_listener is not None,
     }

--- a/tests/unit/hts/test_keyfobs.py
+++ b/tests/unit/hts/test_keyfobs.py
@@ -1,0 +1,158 @@
+"""Tests for the SpaceControl keyfob parser (HTS SETTINGS_BODY rows → Keyfob).
+
+The `kv` fixtures mirror the byte SHAPE of real captured rows (sub-key set,
+field lengths) — what the classifier keys on — but with synthetic text content
+(names, account fields, company labels) so no personal data lives in the repo.
+"""
+
+from __future__ import annotations
+
+from custom_components.aegis_ajax.api.hts.keyfobs import (
+    KEYFOB_SHAPE,
+    Keyfob,
+    looks_like_keyfob_candidate,
+    parse_keyfob,
+)
+
+HUB_ID = "002B1A51"
+
+
+def _kv(hexmap: dict[int, str]) -> dict[int, bytes]:
+    return {k: bytes.fromhex(v) for k, v in hexmap.items()}
+
+
+def _hx(text: str) -> str:
+    return text.encode("utf-8").hex()
+
+
+# --- Keyfob row template (active install reads 0x0b=01) ----------------------
+
+_KEYFOB_TEMPLATE = {
+    0x02: _hx("ALICE"),  # name
+    0x07: "00000000ffffffff",
+    0x08: "00000000ffffffff",
+    0x09: "00000000",
+    0x0A: "02ef",  # per-device index/handle
+    0x0B: "01",
+    0x0C: "01",
+    0x0D: "01",
+    0x0E: "01",
+    0x0F: "0000000000000000",
+    0x10: "00",
+    0x11: "00000000",
+    0x13: "00000000000000000000000000000000",
+    0x14: "00000000000000000000000000000000",
+    0x16: "ffff",
+}
+
+
+def _keyfob_row(name: str, index_hex: str) -> dict[int, bytes]:
+    row = dict(_KEYFOB_TEMPLATE)
+    row[0x02] = _hx(name)
+    row[0x0A] = index_hex
+    return _kv(row)
+
+
+KEYFOBS = {
+    "2ACCB91C": ("ALICE", "02ef"),
+    "2A70EFF7": ("BOB", "02f0"),
+    "2A4B126E": ("T3", "02f1"),
+    "2A11F080": ("T4", "02f2"),
+    "2AE66FEC": ("T5", "02f3"),
+    "2A64AECB": ("T6", "02f4"),
+}
+
+
+# --- Negative rows (same shapes as real markers/members, synthetic content) ---
+
+# User/member row — carries a name (0x01), email (0x02) and phone (0x03).
+USER_ROW = _kv(
+    {
+        0x01: _hx("Home Assistant"),
+        0x02: _hx("user@example.com"),
+        0x03: _hx("+10000000000"),
+        0x09: "01",
+        0x0E: _hx("en"),
+        0x21: "4cd98b62",
+    }
+)
+
+# Company/installer marker row — single key, low id.
+COMPANY_MARKER = _kv({0x01: _hx("ACME")})
+
+# Electrical device row (WallSwitch family) — distinct sub-keys.
+ELECTRICAL_ROW = _kv({0x42: "00000028", 0x43: "00000969", 0x35: "00e6"})
+
+
+class TestParseKeyfob:
+    def test_all_six_keyfobs(self) -> None:
+        for dev_id, (name, index_hex) in KEYFOBS.items():
+            kv = _keyfob_row(name, index_hex)
+            kf = parse_keyfob(dev_id, HUB_ID, kv)
+            assert kf is not None, f"{name} not classified"
+            assert kf == Keyfob(
+                id=dev_id,
+                hub_id=HUB_ID,
+                name=name,
+                index=int(index_hex, 16),
+                active=True,
+                flags_hex="01:01:01:01",
+            )
+
+    def test_shape_matches_fixture(self) -> None:
+        assert frozenset(_keyfob_row("ALICE", "02ef")) == KEYFOB_SHAPE
+
+    def test_deactivated_flag_value_flip(self) -> None:
+        # Same keyset, 0x0b flipped to 00 → still a keyfob, but active=False.
+        row = dict(_KEYFOB_TEMPLATE)
+        row[0x0B] = "00"
+        kf = parse_keyfob("2ACCB91C", HUB_ID, _kv(row))
+        assert kf is not None
+        assert kf.active is False
+        assert kf.flags_hex == "00:01:01:01"
+
+    def test_user_row_rejected(self) -> None:
+        assert parse_keyfob("1B99007F", HUB_ID, USER_ROW) is None
+
+    def test_company_marker_rejected(self) -> None:
+        assert parse_keyfob("0000016A", HUB_ID, COMPANY_MARKER) is None
+
+    def test_low_int_marker_rejected_even_with_keyfob_shape(self) -> None:
+        # A keyfob-shaped row at a low id is a section marker, not a keyfob.
+        kv = _keyfob_row("T3", "0001")
+        assert parse_keyfob("00000001", HUB_ID, kv) is None
+
+    def test_electrical_row_rejected(self) -> None:
+        assert parse_keyfob("311B058D", HUB_ID, ELECTRICAL_ROW) is None
+
+    def test_non_hex_id_rejected(self) -> None:
+        kv = _keyfob_row("T3", "02f1")
+        assert parse_keyfob("ZZZZ", HUB_ID, kv) is None
+
+    def test_empty_name_rejected(self) -> None:
+        row = dict(_KEYFOB_TEMPLATE)
+        row[0x02] = ""
+        assert parse_keyfob("2ACCB91C", HUB_ID, _kv(row)) is None
+
+
+class TestLooksLikeKeyfobCandidate:
+    def test_strict_keyfob_is_candidate(self) -> None:
+        kv = _keyfob_row("ALICE", "02ef")
+        assert looks_like_keyfob_candidate("2ACCB91C", kv) is True
+
+    def test_shape_variant_keyfob_still_candidate(self) -> None:
+        # A keyfob whose keyset diverges (e.g. drops 0x16) must still be logged
+        # so a deactivated-keyfob capture is not silently dropped.
+        row = dict(_KEYFOB_TEMPLATE)
+        del row[0x16]
+        assert looks_like_keyfob_candidate("2ACCB91C", _kv(row)) is True
+
+    def test_user_row_not_candidate(self) -> None:
+        assert looks_like_keyfob_candidate("1B99007F", USER_ROW) is False
+
+    def test_company_marker_not_candidate(self) -> None:
+        assert looks_like_keyfob_candidate("0000016A", COMPANY_MARKER) is False
+
+    def test_low_int_not_candidate(self) -> None:
+        kv = _keyfob_row("T3", "0001")
+        assert looks_like_keyfob_candidate("00000001", kv) is False

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -1215,3 +1215,101 @@ class TestOrphanCoSensorEviction:
             registry_entries=[_reg_entry("binary_sensor.d1_co", "aegis_ajax_d1_co_detected")],
         )
         assert removed == []
+
+
+class TestKeyfobActiveSensor:
+    """Experimental SpaceControl keyfob 'Active' diagnostic sensor."""
+
+    @staticmethod
+    def _keyfob():  # noqa: ANN205
+        from custom_components.aegis_ajax.api.hts.keyfobs import Keyfob
+
+        return Keyfob(
+            id="2ACCB91C",
+            hub_id="002B1A51",
+            name="ALICE",
+            index=751,
+            active=True,
+            flags_hex="01:01:01:01",
+        )
+
+    def test_entity_reflects_keyfob_state(self) -> None:
+        from custom_components.aegis_ajax.binary_sensor import AjaxKeyfobActiveSensor
+
+        coordinator = MagicMock()
+        coordinator.keyfobs = {"2ACCB91C": self._keyfob()}
+        sensor = AjaxKeyfobActiveSensor(coordinator, "2ACCB91C")
+
+        assert sensor.unique_id == "aegis_ajax_2ACCB91C_active"
+        assert sensor.available is True
+        assert sensor.is_on is True
+        assert sensor.extra_state_attributes == {
+            "index": 751,
+            "flags_hex": "01:01:01:01",
+            "experimental": True,
+        }
+        # Grouped under a single virtual "Keyfobs" device per hub; the entity
+        # itself is named after the keyfob.
+        assert sensor.name == "ALICE"
+        assert sensor.device_info["identifiers"] == {("aegis_ajax", "002B1A51_keyfobs")}
+        assert sensor.device_info["via_device"] == ("aegis_ajax", "002B1A51")
+        assert sensor.device_info["name"] == "Keyfobs"
+
+    def test_unavailable_when_keyfob_gone(self) -> None:
+        from custom_components.aegis_ajax.binary_sensor import AjaxKeyfobActiveSensor
+
+        coordinator = MagicMock()
+        coordinator.keyfobs = {"2ACCB91C": self._keyfob()}
+        sensor = AjaxKeyfobActiveSensor(coordinator, "2ACCB91C")
+        coordinator.keyfobs = {}
+
+        assert sensor.available is False
+        assert sensor.is_on is False
+        assert sensor.extra_state_attributes == {}
+
+    @pytest.mark.asyncio
+    async def test_dynamic_add_via_dispatcher(self) -> None:
+        from custom_components.aegis_ajax.binary_sensor import AjaxKeyfobActiveSensor
+
+        coordinator = MagicMock()
+        coordinator.devices = {}
+        coordinator.spaces = {}
+        coordinator.rooms = {}
+        coordinator.keyfobs = {}  # none known at setup
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.runtime_data = coordinator
+
+        added: list = []
+
+        def _add(entities: list, *a: object, **k: object) -> None:
+            added.extend(entities)
+
+        captured: dict = {}
+
+        def _fake_connect(hass: object, signal: str, cb: object):  # noqa: ANN202
+            captured["signal"] = signal
+            captured["cb"] = cb
+            return lambda: None
+
+        with patch(
+            "custom_components.aegis_ajax.binary_sensor.async_dispatcher_connect",
+            side_effect=_fake_connect,
+        ):
+            await async_setup_entry(MagicMock(), entry, _add)
+
+        # No keyfobs at setup → none added yet, but the dispatcher is wired.
+        assert not [e for e in added if isinstance(e, AjaxKeyfobActiveSensor)]
+        assert captured["signal"].endswith("_new_device")
+
+        # Keyfob discovered at runtime → dispatcher callback adds exactly one.
+        coordinator.keyfobs = {"2ACCB91C": self._keyfob()}
+        captured["cb"]("2ACCB91C")
+        kf_entities = [e for e in added if isinstance(e, AjaxKeyfobActiveSensor)]
+        assert len(kf_entities) == 1
+        assert kf_entities[0].unique_id == "aegis_ajax_2ACCB91C_active"
+
+        # Idempotent: a duplicate signal for the same id does not double-add.
+        captured["cb"]("2ACCB91C")
+        assert len([e for e in added if isinstance(e, AjaxKeyfobActiveSensor)]) == 1

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2440,3 +2440,90 @@ class TestHtsChimeEvent:
         await coordinator._refresh_chime_from_event("s1", "deadbeef", 0x39)
 
         coordinator.async_set_updated_data.assert_not_called()
+
+
+def _keyfob_kv(name: bytes = b"ALICE", index: bytes = b"\x02\xef", active: int = 0x01) -> dict:
+    """Build a real-shape SpaceControl keyfob SETTINGS_BODY row (synthetic name)."""
+    return {
+        0x02: name,
+        0x07: bytes.fromhex("00000000ffffffff"),
+        0x08: bytes.fromhex("00000000ffffffff"),
+        0x09: bytes.fromhex("00000000"),
+        0x0A: index,
+        0x0B: bytes([active]),
+        0x0C: b"\x01",
+        0x0D: b"\x01",
+        0x0E: b"\x01",
+        0x0F: bytes(8),
+        0x10: b"\x00",
+        0x11: bytes(4),
+        0x13: bytes(16),
+        0x14: bytes(16),
+        0x16: b"\xff\xff",
+    }
+
+
+class TestOnHtsDeviceKvKeyfob:
+    """Keyfobs are HTS-only — they reach _on_hts_device_kv with no gRPC device."""
+
+    def test_new_keyfob_is_stored_and_announced(self) -> None:
+        from custom_components.aegis_ajax.api.hts.keyfobs import Keyfob
+        from custom_components.aegis_ajax.const import SIGNAL_NEW_DEVICE
+
+        coordinator = _make_coordinator()
+        coordinator.async_set_updated_data = MagicMock()
+
+        with patch("custom_components.aegis_ajax.coordinator.async_dispatcher_send") as mock_send:
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", _keyfob_kv())
+
+        assert coordinator.keyfobs["2ACCB91C"] == Keyfob(
+            id="2ACCB91C",
+            hub_id="002B1A51",
+            name="ALICE",
+            index=751,
+            active=True,
+            flags_hex="01:01:01:01",
+        )
+        mock_send.assert_called_once()
+        assert mock_send.call_args.args[1:] == (SIGNAL_NEW_DEVICE, "2ACCB91C")
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_unchanged_keyfob_no_refresh(self) -> None:
+        from custom_components.aegis_ajax.api.hts.keyfobs import parse_keyfob
+
+        coordinator = _make_coordinator()
+        coordinator.keyfobs["2ACCB91C"] = parse_keyfob("2ACCB91C", "002B1A51", _keyfob_kv())
+        coordinator.async_set_updated_data = MagicMock()
+
+        with patch("custom_components.aegis_ajax.coordinator.async_dispatcher_send") as mock_send:
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", _keyfob_kv())
+
+        coordinator.async_set_updated_data.assert_not_called()
+        mock_send.assert_not_called()
+
+    def test_changed_keyfob_refreshes_without_reannouncing(self) -> None:
+        from custom_components.aegis_ajax.api.hts.keyfobs import parse_keyfob
+
+        coordinator = _make_coordinator()
+        coordinator.keyfobs["2ACCB91C"] = parse_keyfob("2ACCB91C", "002B1A51", _keyfob_kv())
+        coordinator.async_set_updated_data = MagicMock()
+
+        # Active flag flips (e.g. a deactivated keyfob): refresh, but not "new".
+        with patch("custom_components.aegis_ajax.coordinator.async_dispatcher_send") as mock_send:
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", _keyfob_kv(active=0x00))
+
+        assert coordinator.keyfobs["2ACCB91C"].active is False
+        coordinator.async_set_updated_data.assert_called_once()
+        mock_send.assert_not_called()
+
+    def test_non_keyfob_unknown_row_ignored(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.async_set_updated_data = MagicMock()
+
+        # A 1-key company marker row at an unknown id — not a keyfob.
+        with patch("custom_components.aegis_ajax.coordinator.async_dispatcher_send") as mock_send:
+            coordinator._on_hts_device_kv("0000016A", "0000016A", {0x01: b"ACME"})
+
+        assert coordinator.keyfobs == {}
+        coordinator.async_set_updated_data.assert_not_called()
+        mock_send.assert_not_called()


### PR DESCRIPTION
## What
Surfaces Ajax **SpaceControl keyfobs** in Home Assistant, grouped under a single virtual **Keyfobs** device per hub, with one diagnostic **Active** binary sensor per keyfob (named after it).

## Why
Keyfobs are reported only over the hub's HTS link (existing `on_device_kv` path) and never in the gRPC device snapshot, so they were unmapped. They carry no per-device data (no battery/online), so grouping under one device avoids sparse per-keyfob pages. (Who armed/disarmed via a keyfob already showed in the logbook — unchanged.)

## How
- Parser (`api/hts/keyfobs.py`): install-independent classifier by the unique sub-key shape; reuses `hub_state` byte helpers.
- Coordinator: keyfob rows are stored and announced via a generic, reusable `SIGNAL_NEW_DEVICE` dispatcher (runtime discovery; the static platforms are unchanged).
- binary_sensor: one `Active` entity per keyfob under the shared **Keyfobs** device, added at runtime.
- diagnostics `keyfobs` block; README documents the feature as experimental.

## Experimental: the "Active" flag is unverified
Every observed keyfob reports active and there is no deactivated sample (only an installer/CRA can deactivate one). The flag is assumed; the integration debug-logs keyfob rows (names redacted) and exposes the raw flags in diagnostics so a deactivated-keyfob log can confirm it. README invites such a log.

## Tests
Parser (synthetic, non-personal fixtures), coordinator discovery/announce, binary_sensor runtime add. Full suite green (1650, 88.89%); ruff/mypy/vulture/hassfest pass.

## Release
New functionality ⇒ MINOR; `1.10.0-beta.1` bump + tag applied on `main` after merge (per the beta-release process), not here.

_(Supersedes #260, which was recreated on a clean branch to drop personal data from its history.)_