### PR TITLE
fix(coordinator): refresh group security state on space arm/disarm event (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - unreleased
+
+### Fixed
+- **Per-group/zone alarm panels follow an app-side arm/disarm without push (#266).** Arming or disarming a single group (e.g. a dedicated "Garage" zone) from the Ajax app only changes that group's state, which the lightweight per-cycle poll doesn't carry — per-group state comes from the heavier hourly snapshot. The space-level panel already re-read its state on the hub's arm/disarm event, but group panels didn't, so without FCM push a zone panel could lag up to an hour behind. The same hub event now also forces an immediate re-read of group states, so per-group panels update within about a second on installs without push (and remain instant with push). The heavier read runs only on an actual arm/disarm event, not on every poll.
+
 ## [1.10.0] - 2026-06-06
 
 ### Added

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -185,6 +185,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Rooms rarely change — cache and refresh once per hour. None means
         # never fetched yet so the first poll always populates rooms.
         self._rooms_last_fetch: float | None = None
+        # Per-group security state lives only on the hourly snapshot, not the
+        # lighter `list_spaces` poll (like chime/groups). A space HTS event
+        # (#258) re-reads the space state but not the groups, so without FCM
+        # per-group panels lagged up to an hour (#266). The space-event handler
+        # sets this flag so the next refresh bypasses the hourly snapshot gate
+        # and re-reads group states immediately. Consumed in `_maybe_refresh_rooms`.
+        self._force_snapshot_refresh: bool = False
         # Per-device internal temperature (#220 sirens, #229 outdoor curtain
         # PIRs) — refreshed on a dedicated timer (`async_track_time_interval`),
         # NOT the poll cycle. On push-heavy hubs every HTS update resets HA's
@@ -475,10 +482,17 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         rooms_refresh_interval = 3600.0
         if (
-            self._rooms_last_fetch is not None
+            not self._force_snapshot_refresh
+            and self._rooms_last_fetch is not None
             and now - self._rooms_last_fetch <= rooms_refresh_interval
         ):
             return
+        # Consume the event-triggered override (#266): a space arm/disarm event
+        # forces this one snapshot read so per-group panels follow immediately;
+        # the next event re-sets it. Consumed even if the snapshot below fails,
+        # so a transient error can't pin the integration into snapshotting on
+        # every poll — the 300s poll and hourly gate remain the backstops.
+        self._force_snapshot_refresh = False
         refreshed_rooms: dict[str, Room] = {}
         for space_id in self.spaces:
             try:
@@ -892,6 +906,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "none" if candidate is None else f"0x{candidate:02X}",
                 payload_hex,
             )
+            # Force the next refresh to re-read group security states too (#266):
+            # arming/disarming a single group changes only per-group state, which
+            # the lighter `list_spaces` poll doesn't carry. Without this the group
+            # panel would lag until the hourly snapshot when push is off.
+            self._force_snapshot_refresh = True
             self.hass.async_create_task(self.async_request_refresh())
             return
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -415,6 +415,61 @@ class TestAsyncUpdateData:
         assert coordinator.spaces["s1"].group_mode_enabled is True
 
     @pytest.mark.asyncio
+    async def test_space_event_forces_group_state_refresh_within_the_hour(self) -> None:
+        """A space arm/disarm HTS event (#266) sets `_force_snapshot_refresh`, so
+        the next poll re-reads group security states from the heavier snapshot
+        even inside the hourly window — without it, per-group panels lag up to an
+        hour when FCM push is off. The flag is consumed so later polls stay light.
+        """
+        from custom_components.aegis_ajax.api.models import Group
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        # Pretend the hourly snapshot just ran — the gate would normally skip it.
+        coordinator._rooms_last_fetch = asyncio.get_running_loop().time()
+        coordinator.spaces["s1"] = replace(
+            _make_space("s1"),
+            groups=(
+                Group(
+                    id="g1",
+                    space_id="s1",
+                    name="Garage",
+                    security_state=SecurityState.DISARMED,
+                    sorting_key="01",
+                ),
+            ),
+            group_mode_enabled=True,
+        )
+        # A space event arrived → forces the next refresh to re-read groups.
+        coordinator._force_snapshot_refresh = True
+
+        fresh_groups = (
+            Group(
+                id="g1",
+                space_id="s1",
+                name="Garage",
+                security_state=SecurityState.ARMED,
+                sorting_key="01",
+            ),
+        )
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(
+            return_value=SpaceSnapshot(groups=fresh_groups, group_mode_enabled=True)
+        )
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        # Snapshot was read despite being inside the hour, and group state moved.
+        coordinator._spaces_api.get_space_snapshot.assert_awaited_once()
+        assert coordinator.spaces["s1"].groups[0].security_state == SecurityState.ARMED
+        # Flag consumed so it doesn't snapshot on every subsequent poll.
+        assert coordinator._force_snapshot_refresh is False
+
+    @pytest.mark.asyncio
     async def test_update_data_raises_update_failed_on_error(self) -> None:
         from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -2452,6 +2507,23 @@ class TestHtsSecurityEvent:
         coordinator._on_hts_space_event("OTHER", "deadbeef", 0x01)
         coordinator.async_request_refresh.assert_not_called()
         coordinator.async_set_updated_data.assert_not_called()
+
+    def test_arm_disarm_event_forces_group_snapshot_refresh(self) -> None:
+        # #266: per-group security state lives only on the hourly snapshot, so
+        # the arm/disarm event must force the next refresh to re-read it — else
+        # group panels lag up to an hour without FCM.
+        coordinator = self._make_coordinator(SecurityState.DISARMED)
+        coordinator.async_request_refresh = MagicMock()
+        assert coordinator._force_snapshot_refresh is False
+        coordinator._on_hts_space_event("HUB1", "deadbeef", 0x01)
+        assert coordinator._force_snapshot_refresh is True
+
+    def test_chime_event_does_not_force_group_snapshot_refresh(self) -> None:
+        # Chime is decoded directly from the event and doesn't touch group state,
+        # so it must not trigger the heavier snapshot read.
+        coordinator = self._make_coordinator(SecurityState.DISARMED)
+        coordinator._on_hts_space_event("HUB1", "deadbeef", 0x38)
+        assert coordinator._force_snapshot_refresh is False
 
 
 def _keyfob_kv(name: bytes = b"ALICE", index: bytes = b"\x02\xef", active: int = 0x01) -> dict:


### PR DESCRIPTION
## Problem (#266)

A dedicated zone (Ajax group, e.g. "Garage") creates its `alarm_control_panel` entity correctly, but arming/disarming that zone from the Ajax app doesn't update the panel — while the **space-level** panel updates instantly.

## Root cause

Per-group `security_state` lives only on the heavier hourly `get_space_snapshot`, not the lightweight per-cycle `list_spaces` poll (same class as chime/groups, which `_refresh_spaces` deliberately preserves across polls). The space HTS `0x08` arm/disarm event (#258) triggers an authoritative refresh of the **space** state, but that refresh runs the light poll and the group snapshot stays gated to once per hour. So:

- **With FCM push:** per-group push updates the panel instantly (unaffected).
- **Without FCM push:** the zone panel lags up to an hour behind the space panel.

Confirmed from a reporter debug log: FCM was off, the `0x08` event fired and refreshed the space, but the group panel never moved.

## Fix

The space-event handler sets a one-shot `_force_snapshot_refresh` flag before requesting the refresh; `_maybe_refresh_rooms` bypasses the hourly gate when set and consumes it (consumed even on snapshot failure, so a transient error can't pin the integration into snapshotting every poll). Arm/disarm is infrequent and the coordinator debouncer coalesces bursts, so the heavier read happens only when group state actually changed — ordinary polls stay light. Chime events (decoded directly, idempotent) don't set the flag.

## Tests

- `test_space_event_forces_group_state_refresh_within_the_hour` — snapshot is read inside the hourly window and the group state moves; flag consumed.
- `test_arm_disarm_event_forces_group_snapshot_refresh` / `test_chime_event_does_not_force_group_snapshot_refresh` — flag set on arm/disarm, not on chime.

`make check`: 1658 passed, 88.89% coverage. Relates to #266.