### PR TITLE
feat(sensor): Curtain Outdoor Plus/Base temperature from HTS 0x02 (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.10.1] - unreleased
+## [1.11.0] - unreleased
+
+### Added
+- **Internal temperature for the MotionProtect Curtain Outdoor Plus / Base (#229).** Unlike the Mini, the Plus and Base variants don't carry an internal-temperature field in the per-device gRPC data, so no temperature sensor appeared. Their temperature is now read from the hub's HTS status channel (the same channel the WallSwitch electrical readings use) and surfaced as the standard temperature sensor. The reading is additive and safe: it only fills in when no temperature is already provided over gRPC, so every other device is untouched, and an implausible value is declined rather than shown.
 
 ### Fixed
 - **Per-group/zone alarm panels follow an app-side arm/disarm without push (#266).** Arming or disarming a single group (e.g. a dedicated "Garage" zone) from the Ajax app only changes that group's state, which the lightweight per-cycle poll doesn't carry — per-group state comes from the heavier hourly snapshot. The space-level panel already re-read its state on the hub's arm/disarm event, but group panels didn't, so without FCM push a zone panel could lag up to an hour behind. The same hub event now also forces an immediate re-read of group states, so per-group panels update within about a second on installs without push (and remain instant with push). The heavier read runs only on an actual arm/disarm event, not on every poll.

--- a/custom_components/aegis_ajax/api/hts/hub_state.py
+++ b/custom_components/aegis_ajax/api/hts/hub_state.py
@@ -241,6 +241,55 @@ DIRECT_POWER_DEVICE_TYPES: frozenset[str] = frozenset(
     {"socket_outlet_type_e", "socket_outlet_type_f"}
 )
 
+# Internal temperature (#229). A device's STATUS_BODY row carries its internal
+# temperature in whole degrees Celsius at sub-key 0x02, as a signed int8 (a
+# sub-zero outdoor reading is a negative byte). Verified by correlating
+# bvis-home's STATUS_BODY 0x02 against the gRPC-sourced temperature of every
+# temperature-reporting device (Door Protect / Keypad / MotionCam): the 0x02
+# value matched the known reading on all of them. This is the ONLY temperature
+# source for device families whose gRPC `HubDevice` message has no
+# `device_temperature` field — see the Curtain Outdoor Plus/Base note in
+# const.py. Indoor motion/door sensors and the Curtain Outdoor *Mini* already
+# get temperature over gRPC, so they are intentionally NOT read here.
+DEVICE_KEY_TEMPERATURE_C = 0x02
+
+# Device types whose internal temperature is sourced from HTS 0x02 because they
+# expose no gRPC temperature. When a future device family reports temperature
+# only over HTS, add it here (and keep it in
+# const.HUB_DEVICE_TEMPERATURE_DEVICE_TYPES so the merged value carries across
+# gRPC snapshots).
+HTS_TEMPERATURE_DEVICE_TYPES: frozenset[str] = frozenset(
+    {
+        "motion_protect_curtain_outdoor_plus",
+        "motion_protect_curtain_outdoor_base",
+    }
+)
+
+# Plausible internal-temperature window (°C). A 0x02 value outside it means the
+# byte isn't a temperature on this row, so we decline it rather than surface a
+# bogus reading.
+_HTS_TEMP_MIN_C = -40
+_HTS_TEMP_MAX_C = 85
+
+
+def parse_device_temperature_c(device_type: str, kv: dict[int, bytes]) -> float | None:
+    """Decode a device's internal temperature (°C) from its HTS kv block (#229).
+
+    Returns the temperature as a float for device types in
+    `HTS_TEMPERATURE_DEVICE_TYPES` when sub-key 0x02 is present and within a
+    plausible range; otherwise `None`. The byte is a signed int8 so a sub-zero
+    outdoor reading decodes correctly.
+    """
+    if device_type not in HTS_TEMPERATURE_DEVICE_TYPES:
+        return None
+    raw = kv.get(DEVICE_KEY_TEMPERATURE_C)
+    if not raw:
+        return None
+    value = int.from_bytes(raw[:1], "big", signed=True)
+    if not (_HTS_TEMP_MIN_C <= value <= _HTS_TEMP_MAX_C):
+        return None
+    return float(value)
+
 
 def parse_device_readings(
     device_type: str,

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -165,9 +165,12 @@ HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
         "home_siren_g3",
         "home_siren_s",
         "home_siren_fibra",
-        # Outdoor curtain PIRs (#229) — all map to the rich `HubDevice`
-        # oneof case `motion_protect_curtain_outdoor`, which carries
-        # `device_temperature`.
+        # Outdoor curtain PIRs (#229). Only the *Mini* carries
+        # `device_temperature` in its gRPC `HubDevice` message; the Plus/Base
+        # messages are stubs with no temperature field, so their temperature is
+        # sourced from HTS sub-key 0x02 instead (see
+        # api/hts/hub_state.HTS_TEMPERATURE_DEVICE_TYPES). All three stay in
+        # this set so the merged temperature carries across gRPC snapshots.
         "motion_protect_curtain_outdoor_base",
         "motion_protect_curtain_outdoor_mini",
         "motion_protect_curtain_outdoor_plus",

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -817,6 +817,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # markers) is ignored. See api/hts/keyfobs.py.
             self._handle_keyfob_kv(hub_id, device_id_hex, kv)
             return
+        # Internal temperature via HTS 0x02 (#229), for device families with no
+        # gRPC temperature source (Curtain Outdoor Plus/Base). Additive: only
+        # fills when the device doesn't already carry a temperature, so devices
+        # that get it over gRPC are untouched. Returns early if it applied a
+        # value (a temperature device isn't also an electrical one).
+        if self._maybe_apply_hts_device_temperature(device_id_hex, device, kv):
+            return
         readings = parse_device_readings(
             device.device_type,
             kv,
@@ -829,6 +836,51 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.device_readings[device_id_hex] = readings
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         _ = hub_id  # currently unused; kept in the signature for symmetry with on_state_update
+
+    def _maybe_apply_hts_device_temperature(
+        self, device_id_hex: str, device: Device, kv: dict[int, bytes]
+    ) -> bool:
+        """Merge an HTS-sourced internal temperature into a device (#229).
+
+        For device families that report temperature only over HTS (Curtain
+        Outdoor Plus/Base — their gRPC `HubDevice` message has no
+        `device_temperature` field), decode sub-key 0x02 and merge it into
+        `device.statuses["temperature"]`, which is all `sensor.py` needs to
+        materialise the temperature sensor. Mirrors the gRPC per-device-temp
+        merge in `_async_refresh_hub_device_temperatures`; the carry-forward in
+        the device-snapshot path keeps it across gRPC refreshes.
+
+        Additive and safe: skips devices that already carry a temperature (gRPC
+        wins) and devices not in `HTS_TEMPERATURE_DEVICE_TYPES`. Returns True
+        when a value was applied. Runs on the loop (HTS listen task).
+        """
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        from custom_components.aegis_ajax.api.hts.hub_state import (  # noqa: PLC0415
+            HTS_TEMPERATURE_DEVICE_TYPES,
+            parse_device_temperature_c,
+        )
+
+        if device.device_type not in HTS_TEMPERATURE_DEVICE_TYPES:
+            return False
+        if "temperature" in device.statuses:
+            return False
+        temperature = parse_device_temperature_c(device.device_type, kv)
+        if temperature is None:
+            # Gated type but no usable 0x02 — log once-per-row so a reporter on
+            # DEBUG can confirm whether the firmware sends it at all (#229).
+            _LOGGER.debug(
+                "Device %s (%s): no usable HTS temperature in 0x02 (kv keys=%s)",
+                device_id_hex,
+                device.device_type,
+                sorted(kv),
+            )
+            return False
+        self.devices[device_id_hex] = dc_replace(
+            device, statuses={**device.statuses, "temperature": temperature}
+        )
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+        return True
 
     def _handle_keyfob_kv(self, hub_id: str, device_id_hex: str, kv: dict[int, bytes]) -> None:
         """Classify a non-gRPC SETTINGS_BODY row as a SpaceControl keyfob.

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -330,12 +330,15 @@ from custom_components.aegis_ajax.api.hts.hub_state import (  # noqa: E402
     DEVICE_KEY_OUTLET_POWER_W,
     DEVICE_KEY_OUTLET_VOLTAGE_V,
     DEVICE_KEY_POWER_CONSUMED_WH,
+    DEVICE_KEY_TEMPERATURE_C,
     DEVICE_KEY_VOLTAGE_V,
     DIRECT_POWER_DEVICE_TYPES,
     ELECTRICAL_DEVICE_TYPES,
+    HTS_TEMPERATURE_DEVICE_TYPES,
     DeviceReadings,
     _int_be_val,
     parse_device_readings,
+    parse_device_temperature_c,
 )
 
 
@@ -558,3 +561,64 @@ class TestParseDeviceReadings:
         )
         assert r is not None
         assert r.power_w is None
+
+
+class TestParseDeviceTemperatureC:
+    """HTS sub-key 0x02 → internal temperature for gRPC-temp-less devices (#229)."""
+
+    def test_curtain_plus_decodes_whole_celsius(self) -> None:
+        # 0x1b = 27 °C, matching the value the Ajax app shows for the Plus.
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_curtain_outdoor_plus", {DEVICE_KEY_TEMPERATURE_C: b"\x1b"}
+            )
+            == 27.0
+        )
+
+    def test_curtain_base_decodes(self) -> None:
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_curtain_outdoor_base", {DEVICE_KEY_TEMPERATURE_C: b"\x17"}
+            )
+            == 23.0
+        )
+
+    def test_subzero_decodes_as_signed_int8(self) -> None:
+        # Outdoor detector below freezing: 0xFB = -5 °C, not 251.
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_curtain_outdoor_plus", {DEVICE_KEY_TEMPERATURE_C: b"\xfb"}
+            )
+            == -5.0
+        )
+
+    def test_non_gated_type_returns_none(self) -> None:
+        # Mini gets temperature over gRPC, so it's intentionally not read here;
+        # neither are indoor sensors that already carry it in the light stream.
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_curtain_outdoor_mini", {DEVICE_KEY_TEMPERATURE_C: b"\x1b"}
+            )
+            is None
+        )
+        assert (
+            parse_device_temperature_c("motion_protect", {DEVICE_KEY_TEMPERATURE_C: b"\x1b"})
+            is None
+        )
+
+    def test_missing_subkey_returns_none(self) -> None:
+        assert parse_device_temperature_c("motion_protect_curtain_outdoor_plus", {}) is None
+
+    def test_out_of_range_value_rejected(self) -> None:
+        # 0x7f = 127 °C is outside the plausible window → declined, not surfaced.
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_curtain_outdoor_plus", {DEVICE_KEY_TEMPERATURE_C: b"\x7f"}
+            )
+            is None
+        )
+
+    def test_gated_types_present(self) -> None:
+        assert "motion_protect_curtain_outdoor_plus" in HTS_TEMPERATURE_DEVICE_TYPES
+        assert "motion_protect_curtain_outdoor_base" in HTS_TEMPERATURE_DEVICE_TYPES
+        assert "motion_protect_curtain_outdoor_mini" not in HTS_TEMPERATURE_DEVICE_TYPES

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2611,3 +2611,46 @@ class TestOnHtsDeviceKvKeyfob:
         assert coordinator.keyfobs == {}
         coordinator.async_set_updated_data.assert_not_called()
         mock_send.assert_not_called()
+
+
+class TestHtsDeviceTemperature:
+    """HTS 0x02 → temperature for gRPC-temp-less device families (#229)."""
+
+    def _coordinator_with_device(
+        self, device_type: str, statuses: dict | None = None
+    ) -> AjaxCobrandedCoordinator:  # noqa: F821
+        coordinator = _make_coordinator()
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.devices["d1"] = replace(
+            _make_device("d1"), device_type=device_type, statuses=statuses or {}
+        )
+        return coordinator
+
+    def test_curtain_plus_temperature_merged_from_0x02(self) -> None:
+        coordinator = self._coordinator_with_device("motion_protect_curtain_outdoor_plus")
+        coordinator._on_hts_device_kv("hub-1", "d1", {0x02: b"\x1b"})
+        assert coordinator.devices["d1"].statuses["temperature"] == 27.0
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_existing_grpc_temperature_not_overwritten(self) -> None:
+        # gRPC wins: an already-present temperature is left untouched.
+        coordinator = self._coordinator_with_device(
+            "motion_protect_curtain_outdoor_plus", statuses={"temperature": 21.0}
+        )
+        coordinator._on_hts_device_kv("hub-1", "d1", {0x02: b"\x1b"})
+        assert coordinator.devices["d1"].statuses["temperature"] == 21.0
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_non_gated_device_not_given_hts_temperature(self) -> None:
+        # A door sensor's 0x02 is not turned into a temperature here (it gets
+        # temperature over gRPC); the HTS path must not fabricate one.
+        coordinator = self._coordinator_with_device("door_protect")
+        coordinator._on_hts_device_kv("hub-1", "d1", {0x02: b"\x1b"})
+        assert "temperature" not in coordinator.devices["d1"].statuses
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_gated_device_without_usable_0x02_is_noop(self) -> None:
+        coordinator = self._coordinator_with_device("motion_protect_curtain_outdoor_base")
+        coordinator._on_hts_device_kv("hub-1", "d1", {0x05: b"\x01"})
+        assert "temperature" not in coordinator.devices["d1"].statuses
+        coordinator.async_set_updated_data.assert_not_called()


### PR DESCRIPTION
## Problem (#229)

The MotionProtect Curtain Outdoor **Plus** reports its internal temperature in the Ajax app (confirmed by the reporter: `Temperatura 27 °C`), but no temperature sensor appeared in Home Assistant. Debug showed `HubDevice oneof case=None`.

## Root cause

The per-device gRPC `HubDevice` message has variants per product. Only the **Mini** (`MotionProtectCurtainOutdoorMini`) carries a `device_temperature` field; the **Plus** and **Base** messages are stubs with no temperature field at all. So the gRPC per-device temperature path (#220/#229 Mini) has nothing to read for Plus/Base.

## Where the temperature actually is

The hub's **HTS `STATUS_BODY`** per-device row carries each device's internal temperature at sub-key **`0x02`** (signed int8 °C) — the same status channel the WallSwitch electrical readings already use. Verified by correlating bvis-home's live `0x02` against the gRPC-sourced temperature of **every** temperature-reporting device:

| device | HTS 0x02 | matches HA temp |
|---|---|---|
| puerta_entrada (Door Protect Plus) | 0x1b = 27 | ✓ |
| puerta_exterior_cocina (Door Protect) | 0x17 = 23 | ✓ |
| keypad / motioncam / windows | 0x19–0x1c = 25–28 | ✓ |

9/9 temperature devices carry it; the Plus's app value (27 °C) is exactly `0x1b`.

## Fix

- `hub_state.parse_device_temperature_c` + `HTS_TEMPERATURE_DEVICE_TYPES` (currently the curtain Plus/Base): decode `0x02` as signed int8, range-validated (−40..85 °C).
- The coordinator's HTS device-kv handler merges it into `device.statuses['temperature']` **only when no gRPC temperature is already present** — additive, so every other device is untouched and there's no duplication. Out-of-range / missing values are a no-op (DEBUG-logged for diagnosis). The existing carry-forward keeps the value across gRPC snapshots.

Scope is deliberately limited to the gRPC-temp-less curtain variants; the universal `0x02` finding is documented so a future HTS-only-temperature device is a one-line addition to the gated set.

## Tests

`make check`: 1669 passed, 88.94% coverage. New: `TestParseDeviceTemperatureC` (decode/sign/range/gating) + `TestHtsDeviceTemperature` (merge / gRPC-wins / non-gated no-op). Relates to #229.