### PR TITLE
fix(coordinator): dedicated short-cooldown debouncer for security re-reads (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - unreleased
+
+### Fixed
+- **Alarm panel could miss a rapid arm/disarm/arm transition without push (#270).** When the panel state had to fall back on the hub's arm/disarm event (because an FCM push didn't arrive promptly), the re-read of the authoritative state went through Home Assistant's shared refresh debouncer, whose 10-second cooldown collapsed a quick arm→disarm→arm sequence into a single delayed re-read — so the panel could keep showing the previous state for up to ~10 seconds (until the next event or the periodic poll). The event-triggered re-read now uses a dedicated ~1-second debouncer, so each transition is picked up within about a second while true sub-second duplicate frames are still collapsed. Installs where FCM push delivers promptly were already instant and are unaffected.
+
 ## [1.11.0] - 2026-06-07
 
 ### Added

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -137,6 +137,14 @@ STREAM_RECONNECT_MAX_BACKOFF = 60  # seconds
 MIN_POLL_INTERVAL = 60  # seconds
 MAX_POLL_INTERVAL = 300  # seconds
 DEFAULT_POLL_INTERVAL = 300  # seconds fallback (stream handles real-time updates)
+# Cooldown for the dedicated debouncer that re-reads `security_state` after a
+# space arm/disarm HTS event (#270). HA's default request-refresh debouncer
+# uses a 10 s cooldown, which coalesces a rapid arm→disarm→arm burst into a
+# single trailing re-read that can lag the alarm panel by up to ~10 s when FCM
+# push doesn't deliver promptly. A short dedicated cooldown keeps the panel
+# responsive while still collapsing true sub-second duplicate frames; the small
+# trailing settle also gives the gRPC snapshot time to propagate the new state.
+SECURITY_EVENT_REFRESH_COOLDOWN = 1.0  # seconds
 # Auto-off window for a device `motion_detected` status set from an FCM motion
 # push (#173). Video-edge devices only report motion over FCM, so the binary
 # sensor has no "cleared" event — we self-clear it like a PIR detector.

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -38,6 +39,7 @@ from custom_components.aegis_ajax.const import (
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
     MOTION_PUSH_AUTO_OFF_SECONDS,
+    SECURITY_EVENT_REFRESH_COOLDOWN,
     SIGNAL_NEW_DEVICE,
     ChimeStatus,
     ConnectionStatus,
@@ -192,6 +194,21 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # sets this flag so the next refresh bypasses the hourly snapshot gate
         # and re-reads group states immediately. Consumed in `_maybe_refresh_rooms`.
         self._force_snapshot_refresh: bool = False
+        # Dedicated debouncer for event-triggered `security_state` re-reads (#270).
+        # The shared request-refresh debouncer HA gives us has a 10 s cooldown,
+        # which coalesced a rapid arm→disarm→arm burst into a single trailing
+        # re-read that lagged the alarm panel by up to ~10 s when FCM push didn't
+        # deliver promptly. A short dedicated cooldown fires the re-read ~1 s
+        # after each event (still collapsing true sub-second duplicate frames),
+        # and the small settle gives the gRPC snapshot time to propagate. Built
+        # with the `hass` param (not `self.hass`, unset until `super().__init__`).
+        self._security_refresh_debouncer = Debouncer(
+            hass,
+            _LOGGER,
+            cooldown=SECURITY_EVENT_REFRESH_COOLDOWN,
+            immediate=False,
+            function=self.async_refresh,
+        )
         # Per-device internal temperature (#220 sirens, #229 outdoor curtain
         # PIRs) — refreshed on a dedicated timer (`async_track_time_interval`),
         # NOT the poll cycle. On push-heavy hubs every HTS update resets HA's
@@ -931,9 +948,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
           over gRPC. The byte is deliberately NOT decoded as state — arm-initiated
           ≠ armed, a disarm during the exit delay emits no event, and events can
           be dropped on an HTS reconnect, so a decoded state can stick wrong on an
-          alarm panel (observed live 2026-06-06). `async_request_refresh` is
-          debounced, so a burst of frames coalesces into one re-read; the 300s
-          poll backstops a missed nudge.
+          alarm panel (observed live 2026-06-06). The re-read goes through a
+          dedicated short-cooldown debouncer (#270), so a burst of frames
+          coalesces into a re-read ~1s after the last frame — fast enough that
+          the panel doesn't visibly lag — instead of the up-to-10s lag the
+          shared request-refresh debouncer caused; the 300s poll backstops a
+          missed nudge.
 
         Runs on the event loop (HTS listen task).
         """
@@ -963,7 +983,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # the lighter `list_spaces` poll doesn't carry. Without this the group
             # panel would lag until the hourly snapshot when push is off.
             self._force_snapshot_refresh = True
-            self.hass.async_create_task(self.async_request_refresh())
+            # Route through the dedicated short-cooldown debouncer (#270), NOT the
+            # shared 10 s request-refresh debouncer — the latter coalesced a rapid
+            # arm→disarm→arm burst into one trailing re-read that left the panel on
+            # the stale state for up to ~10 s when FCM push didn't arrive first.
+            self.hass.async_create_task(self._security_refresh_debouncer.async_call())
             return
 
         _LOGGER.debug(
@@ -1441,6 +1465,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._unsub_poll_safety is not None:
             self._unsub_poll_safety()
             self._unsub_poll_safety = None
+
+        # Cancel any pending security-event re-read (#270)
+        self._security_refresh_debouncer.async_shutdown()
 
         # Cancel all stream tasks
         for task in self._stream_tasks:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -469,6 +469,36 @@ class TestAsyncUpdateData:
         # Flag consumed so it doesn't snapshot on every subsequent poll.
         assert coordinator._force_snapshot_refresh is False
 
+    def test_security_event_uses_dedicated_short_cooldown_debouncer(self) -> None:
+        """A non-chime space event (#270) must re-read `security_state` through a
+        dedicated short-cooldown debouncer, NOT the shared 10 s request-refresh
+        debouncer. The default 10 s cooldown coalesces a rapid arm→disarm→arm
+        burst into one trailing re-read that lags the alarm panel by up to ~10 s
+        when FCM push doesn't deliver; the dedicated debouncer keeps the panel
+        responsive while still setting `_force_snapshot_refresh` for group state.
+        """
+        from homeassistant.helpers.update_coordinator import REQUEST_REFRESH_DEFAULT_COOLDOWN
+
+        from custom_components.aegis_ajax.const import SECURITY_EVENT_REFRESH_COOLDOWN
+
+        # Far shorter than HA's shared request-refresh cooldown — that gap is the bug.
+        assert SECURITY_EVENT_REFRESH_COOLDOWN < REQUEST_REFRESH_DEFAULT_COOLDOWN
+
+        coordinator = _make_coordinator()
+        coordinator.spaces["s1"] = _make_space("s1")
+        coordinator._security_refresh_debouncer = MagicMock()
+        coordinator.hass = MagicMock()
+
+        # Non-chime byte (0x02) → security nudge branch, not the chime decode.
+        coordinator._on_hts_space_event("hub-1", "deadbeef", 0x02)
+
+        # Routed through the dedicated debouncer, and groups are forced to refresh.
+        coordinator._security_refresh_debouncer.async_call.assert_called_once()
+        assert coordinator._force_snapshot_refresh is True
+        # The dedicated debouncer wraps an immediate refresh, never the shared
+        # `async_request_refresh` whose 10 s cooldown caused the lag.
+        coordinator.hass.async_create_task.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_update_data_raises_update_failed_on_error(self) -> None:
         from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -2446,8 +2476,8 @@ class TestHtsSecurityEvent:
     Arm/disarm/night share the chime event frame. Their byte is NOT decoded as
     state (arm-initiated ≠ armed; a disarm during the exit delay emits no event;
     events drop on reconnect → a decoded state sticks wrong). Instead the event
-    triggers `async_request_refresh` to re-read the real `security_state`; the
-    state is never set straight from the byte.
+    triggers a re-read of the real `security_state` through the dedicated
+    short-cooldown debouncer (#270); the state is never set straight from the byte.
     """
 
     def _make_coordinator(
@@ -2481,10 +2511,11 @@ class TestHtsSecurityEvent:
 
     def _arm_disarm_triggers_refresh(self, byte: int, initial: SecurityState) -> None:
         coordinator = self._make_coordinator(initial)
-        coordinator.async_request_refresh = MagicMock()
+        coordinator._security_refresh_debouncer = MagicMock()
         coordinator._on_hts_space_event("HUB1", "deadbeef", byte)
-        # Re-reads authoritative state; never decodes the byte into the panel.
-        coordinator.async_request_refresh.assert_called_once()
+        # Re-reads authoritative state via the dedicated debouncer (#270); never
+        # decodes the byte into the panel.
+        coordinator._security_refresh_debouncer.async_call.assert_called_once()
         assert coordinator.spaces["s1"].security_state == initial
         coordinator.async_set_updated_data.assert_not_called()
 
@@ -2503,9 +2534,9 @@ class TestHtsSecurityEvent:
 
     def test_unknown_hub_is_ignored(self) -> None:
         coordinator = self._make_coordinator(SecurityState.DISARMED)
-        coordinator.async_request_refresh = MagicMock()
+        coordinator._security_refresh_debouncer = MagicMock()
         coordinator._on_hts_space_event("OTHER", "deadbeef", 0x01)
-        coordinator.async_request_refresh.assert_not_called()
+        coordinator._security_refresh_debouncer.async_call.assert_not_called()
         coordinator.async_set_updated_data.assert_not_called()
 
     def test_arm_disarm_event_forces_group_snapshot_refresh(self) -> None:
@@ -2513,7 +2544,7 @@ class TestHtsSecurityEvent:
         # the arm/disarm event must force the next refresh to re-read it — else
         # group panels lag up to an hour without FCM.
         coordinator = self._make_coordinator(SecurityState.DISARMED)
-        coordinator.async_request_refresh = MagicMock()
+        coordinator._security_refresh_debouncer = MagicMock()
         assert coordinator._force_snapshot_refresh is False
         coordinator._on_hts_space_event("HUB1", "deadbeef", 0x01)
         assert coordinator._force_snapshot_refresh is True


### PR DESCRIPTION
## Problem (#270)

A reporter hit an intermittent failure where a rapid **night-arm → disarm → night-arm** sequence done from the Ajax app updated the app but left the Home Assistant alarm panel on the previous state.

### Root cause

The panel has three update paths for `security_state`, in order of reliability:

1. **FCM push** → `apply_push_security_state` — instant, authoritative from the payload, but depends on FCM delivery (known account-side flakiness).
2. **HTS space event** → re-read `list_spaces` over gRPC — the backstop.
3. **300s poll** — last resort.

In the failing capture there were **no FCM lines** — only HTS `type=0x08` events — so the system fell back on path 2. But the event handler routed the re-read through HA's **shared request-refresh debouncer** (default `cooldown=10s, immediate=True`). Trace:

```
21:39:42  event 0x00 → immediate refresh → Finished fetching ✅  (starts 10s cooldown)
21:39:47  event 0x02 (NIGHT, +4.9s) → within cooldown → COALESCED into one trailing read
          → no "Finished fetching" near it → fires only when the cooldown expires (~+10s)
```

So the second transition's re-read was delayed up to ~10s; during that window the panel showed the stale state. When FCM delivers promptly (path 1) it masks this entirely — hence the intermittency and the reporter's inability to reproduce reliably.

## Fix

Give event-triggered security re-reads their **own dedicated `Debouncer`** with a short cooldown (`SECURITY_EVENT_REFRESH_COOLDOWN = 1.0s`, `immediate=False`), independent of the shared 10s coordinator debouncer used for device-snapshot refreshes.

- Each arm/disarm/night transition is re-read within ~1s instead of up to ~10s.
- True sub-second duplicate frames are still collapsed.
- The small trailing settle also gives the gRPC snapshot time to propagate (mitigates the documented stale-re-read).
- `_force_snapshot_refresh` group re-read (#266) and the chime decode path are unchanged.
- The debouncer is shut down with the coordinator.

## Tests

- New regression test: a non-chime space event routes through the dedicated debouncer (cooldown asserted `< REQUEST_REFRESH_DEFAULT_COOLDOWN`) and still sets `_force_snapshot_refresh`.
- Updated the existing `TestHtsSecurityEvent` cases to the new mechanism (behavioral intent — re-read, never byte-decode — preserved).
- Full unit suite green (1670 passed), ruff + format + mypy + vulture clean on a no-mount rebuild.

Relates to #270.