### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -15,4 +15,4 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "home-assistant/actions/hassfest@master"
+      - uses: "home-assistant/actions/hassfest@d05c25388490cd662baef8495e1bc764c3386153" # master @ 2026-06-09

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
           body: ${{ steps.changelog.outputs.notes }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -14,6 +14,6 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: HACS validation
-        uses: "hacs/action@main"
+        uses: "hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa" # main @ 2026-06-09
         with:
           category: "integration"


### PR DESCRIPTION
## What

Pin the three third-party GitHub Actions to immutable commit SHAs instead of mutable branch/tag refs.

| Action | Before | After |
|---|---|---|
| `home-assistant/actions/hassfest` | `@master` | SHA (`master @ 2026-06-09`) |
| `hacs/action` | `@main` | SHA (`main @ 2026-06-09`) |
| `softprops/action-gh-release` | `@v3` | SHA (`v3.0.0`, latest) |

`actions/checkout@v6` is left as a tag (first-party, GitHub-maintained).

## Why

HIGH-severity security audit finding. A mutable ref lets a compromise of the upstream repo inject code into our CI on the next run. The most sensitive case is `action-gh-release`, which runs in `release.yml` with `contents: write` — release tampering that would reach HACS users.

## Follow-up (out of scope)

Dependabot for `github-actions` to keep these SHAs fresh. Tracked in the internal cleanup plan.