### PR TITLE
chore: post-audit cleanup (secret scanning, docs, .gstack ignore)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -20,4 +20,5 @@ jobs:
       - name: Scan for secrets
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,23 @@
+name: Secret scan
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # AI assistant config
 .claude/
 CLAUDE.md
+.gstack/
 
 # Python
 __pycache__/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+# Gitleaks configuration for aegis-hass.
+# Extends the built-in default ruleset and adds allowlisting for known
+# non-secret values so the pre-commit hook stays low-noise.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known non-secrets and test fixtures"
+
+# Paths that only ever contain placeholders or synthesized values.
+paths = [
+  '''tests/.*''',
+  '''scripts/test_.*\.py''',
+]
+
+# The Firebase Web API key shipped inside the public Ajax cobranded APKs is a
+# public client identifier (extracted from a published app), not a secret.
+# See SECURITY.md and the aegis-ajax-cobranded-fcm docs.
+regexes = [
+  '''AIza[0-9A-Za-z_-]{35}''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        name: Detect hardcoded secrets (gitleaks)
+        stages: [pre-commit]
+
   - repo: local
     hooks:
       - id: check

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,3 +27,30 @@ This integration communicates with Ajax Systems cloud servers using the same pro
 ## Supported Versions
 
 Only the latest release is supported with security updates.
+
+## Threat model notes
+
+These are known, accepted design constraints rather than open issues. They are
+documented here so users can reason about the integration's security posture.
+
+### HTS transport confidentiality relies on TLS
+
+The Ajax HTS binary protocol (`api/hts/`) frames are wrapped in AES-128-CBC using
+a fixed key and IV that are constants mandated by the protocol; integrity is a
+non-cryptographic CRC-16. This inner layer therefore provides no meaningful
+confidentiality or integrity on its own. Real protection comes from the TLS
+tunnel the HTS connection runs over (`ssl.create_default_context()`, full
+certificate validation). An attacker would have to defeat TLS first; the static
+AES layer cannot be changed without breaking compatibility with Ajax hubs.
+
+### FCM push depends on a reverse-engineered client
+
+Push notifications use `firebase-messaging`, an unofficial reverse-engineered FCM
+client, not a Google-supported library. Push is an optional feature: if the
+library is missing or Google changes the FCM protocol, the integration logs a
+warning and continues without push (polling still works). Treat push delivery as
+best-effort rather than a guaranteed channel.
+
+The Firebase Web/Android API key bundled in the public Ajax cobranded apps is a
+public client identifier (extracted from a published APK), not a secret. It is
+allowlisted in `.gitleaks.toml` for that reason.


### PR DESCRIPTION
Follow-up to the security audit. Tooling and docs only, no runtime code changes.

## Changes

- **Secret scanning**: new `Secret scan` workflow running gitleaks (action pinned to a commit SHA) on push, PR, and a daily cron, plus a gitleaks pre-commit hook. `.gitleaks.toml` extends the default ruleset and allowlists test fixtures and the public Firebase API key from the cobranded apps.
- **Ignore `.gstack/`**: local-only audit reports and internal plans no longer risk being committed.
- **Threat model docs** in `SECURITY.md`: HTS confidentiality relies on the TLS tunnel (static AES layer is a protocol constant), and FCM push uses the unofficial reverse-engineered client (optional, best-effort).

## Notes

Dependabot already covers the `github-actions` ecosystem, so the SHA pins from #272 will be kept fresh automatically.