### PR TITLE
fix(notification): marshal FCM future resolution onto the event loop

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -464,16 +464,18 @@ class AjaxNotificationListener:
                     resolved = False
                     for device_id, future in list(self._photo_callbacks.items()):
                         if not future.done() and device_id.upper() in photo_url.upper():
-                            future.set_result(photo_url)
-                            self._photo_callbacks.pop(device_id, None)
+                            self._resolve_future_on_loop(
+                                self._photo_callbacks, device_id, photo_url
+                            )
                             resolved = True
                             break
                     if not resolved:
                         # Fallback: resolve first pending (single-device case)
                         for device_id, future in list(self._photo_callbacks.items()):
                             if not future.done():
-                                future.set_result(photo_url)
-                                self._photo_callbacks.pop(device_id, None)
+                                self._resolve_future_on_loop(
+                                    self._photo_callbacks, device_id, photo_url
+                                )
                                 break
                     break
             except Exception:
@@ -490,8 +492,9 @@ class AjaxNotificationListener:
                 # notification_id contains the device_id (e.g., ...A1B2C3D4...)
                 for device_id, future in list(self._notification_id_callbacks.items()):
                     if not future.done() and device_id.upper() in notif_id.upper():
-                        future.set_result(notif_id)
-                        self._notification_id_callbacks.pop(device_id, None)
+                        self._resolve_future_on_loop(
+                            self._notification_id_callbacks, device_id, notif_id
+                        )
                         _LOGGER.debug("Resolved notification_id for device %s", device_id)
                         break
 
@@ -757,6 +760,28 @@ class AjaxNotificationListener:
             )
         elif event_type == MOTION_EVENT_TYPE:
             self._dispatch_to_loop(self._coordinator.apply_push_device_motion, resolved)
+
+    def _resolve_future_on_loop(
+        self,
+        callbacks: dict[str, asyncio.Future[str | None]],
+        device_id: str,
+        value: str,
+    ) -> None:
+        """Resolve a `wait_for_*` future from the FCM worker thread (#274).
+
+        `Future.set_result` is loop-only, and the future may be cancelled by
+        a `wait_for_*` timeout racing this push — so the done-check, the
+        set_result and the dict cleanup all run on the HA event loop. The
+        worker-side match that selected `device_id` is only a best-effort
+        filter over a snapshot.
+        """
+
+        def _resolve() -> None:
+            future = callbacks.pop(device_id, None)
+            if future is not None and not future.done():
+                future.set_result(value)
+
+        self._dispatch_to_loop(_resolve)
 
     def _dispatch_to_loop(self, func: Callable[..., object], *args: object) -> None:
         """Marshal a coordinator state-write from the FCM worker thread onto the

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -97,17 +98,25 @@ class TestNotificationListener:
 
     @pytest.mark.asyncio
     async def test_on_notification_extracts_photo_url(self) -> None:
-        """ENCODED_DATA with an HTTPS URL resolves pending photo futures."""
+        """ENCODED_DATA with an HTTPS URL resolves pending photo futures.
+
+        Resolution must be marshaled to the event loop (#274):
+        `_on_notification` runs on the FCM worker thread and
+        `Future.set_result` is loop-only.
+        """
         hass = MagicMock()
         hass.loop = MagicMock()
         hass.loop.is_running.return_value = True
+        scheduled: list[tuple[Any, tuple[Any, ...]]] = []
+        hass.loop.call_soon_threadsafe.side_effect = lambda func, *args: scheduled.append(
+            (func, args)
+        )
         coordinator = MagicMock()
-        coordinator.async_request_refresh = AsyncMock()
 
         listener = AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
 
         # Create a pending future
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         future: asyncio.Future[str | None] = loop.create_future()
         listener._photo_callbacks["dev-1"] = future
 
@@ -117,7 +126,13 @@ class TestNotificationListener:
 
         listener._on_notification({"ENCODED_DATA": encoded}, "persistent-2")
 
-        assert future.done()
+        # The (simulated) worker thread must not resolve the future inline.
+        assert not future.done()
+
+        # Run what the worker scheduled onto the loop.
+        for func, args in scheduled:
+            func(*args)
+
         assert future.result() == "https://app.prod.ajax.systems/photo/test.jpg"
         assert listener._photo_callbacks == {}
 
@@ -141,8 +156,13 @@ class TestNotificationListener:
         hass = MagicMock()
         hass.loop = MagicMock()
         hass.loop.is_running.return_value = True
+        # Route worker-thread dispatches onto the real test loop so the
+        # marshaled future resolution (#274) actually executes.
+        real_loop = asyncio.get_running_loop()
+        hass.loop.call_soon_threadsafe.side_effect = lambda func, *args: real_loop.call_soon(
+            func, *args
+        )
         coordinator = MagicMock()
-        coordinator.async_request_refresh = AsyncMock()
 
         listener = AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
 
@@ -377,17 +397,24 @@ class TestNotificationListener:
 
     @pytest.mark.asyncio
     async def test_on_notification_extracts_notification_id(self) -> None:
-        """ENCODED_DATA with a notification_id resolves pending notification_id futures."""
+        """ENCODED_DATA with a notification_id resolves pending notification_id futures.
+
+        Resolution must be marshaled to the event loop (#274), same as the
+        photo-URL futures: `Future.set_result` is loop-only.
+        """
         hass = MagicMock()
         hass.loop = MagicMock()
         hass.loop.is_running.return_value = True
+        scheduled: list[tuple[Any, tuple[Any, ...]]] = []
+        hass.loop.call_soon_threadsafe.side_effect = lambda func, *args: scheduled.append(
+            (func, args)
+        )
         coordinator = MagicMock()
-        coordinator.async_request_refresh = AsyncMock()
         coordinator._space_ids = []
 
         listener = AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         future: asyncio.Future[str | None] = loop.create_future()
         listener._notification_id_callbacks["A1B2C3D4"] = future
 
@@ -396,10 +423,51 @@ class TestNotificationListener:
             {"ENCODED_DATA": _restamp_push(_REAL_PUSH_ENCODED_DATA)}, "persistent-n1"
         )
 
-        assert future.done()
+        # The (simulated) worker thread must not resolve the future inline.
+        assert not future.done()
+
+        for func, args in scheduled:
+            func(*args)
+
         assert future.result() == _EXPECTED_NOTIFICATION_ID
         assert listener._notification_id_callbacks == {}
         assert listener._last_notification_id == _EXPECTED_NOTIFICATION_ID
+
+    @pytest.mark.asyncio
+    async def test_scheduled_resolution_skips_future_cancelled_before_loop_runs(self) -> None:
+        """A `wait_for_*` timeout can cancel the future after the worker
+        thread matched it but before the loop runs the scheduled resolution
+        (#274). The loop-side callback must re-check the future state instead
+        of raising InvalidStateError.
+        """
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.is_running.return_value = True
+        scheduled: list[tuple[Any, tuple[Any, ...]]] = []
+        hass.loop.call_soon_threadsafe.side_effect = lambda func, *args: scheduled.append(
+            (func, args)
+        )
+        coordinator = MagicMock()
+        coordinator._space_ids = []
+
+        listener = AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[str | None] = loop.create_future()
+        listener._notification_id_callbacks["A1B2C3D4"] = future
+
+        listener._on_notification(
+            {"ENCODED_DATA": _restamp_push(_REAL_PUSH_ENCODED_DATA)}, "persistent-n2"
+        )
+
+        # Timeout fires on the loop before the scheduled resolution runs.
+        future.cancel()
+
+        for func, args in scheduled:
+            func(*args)  # must not raise InvalidStateError
+
+        assert future.cancelled()
+        assert "A1B2C3D4" not in listener._notification_id_callbacks
 
     @pytest.mark.asyncio
     async def test_wait_for_notification_id_timeout(self) -> None:


### PR DESCRIPTION
## Summary

The FCM push callback (`_on_notification`) runs on the `firebase_messaging` worker thread. Three paths resolved photo-URL / notification_id futures inline there via `Future.set_result()`, which is loop-only — the same partial-coverage failure mode as #208, where the sibling dispatch paths in the same method were already correctly marshaled.

- New `_resolve_future_on_loop()` helper: pops the callback dict, re-checks the future state and calls `set_result()` on the HA event loop through the existing `_dispatch_to_loop()` dispatcher.
- Replaces all three inline resolution sites (photo with device match, photo single-device fallback, notification_id).
- The loop-side re-check also closes a latent race: a `wait_for_*` timeout cancelling the future between the worker-side match and the scheduled resolution would have raised `InvalidStateError` on the FCM thread.

## Tests

TDD: the two existing tests that encoded the inline-resolution behavior were rewritten to assert marshaled resolution (verified failing before the fix), plus a new test covering the cancelled-future race.

- `make check` green in Docker: lint, format, mypy, vulture, 1671 tests passing, coverage 88.97% (gate 80%).

Related to #274