### PR TITLE
chore: add make setup to auto-configure git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ Everything runs in Docker. No local dependencies needed.
 git clone https://github.com/bvis/aegis-hass.git
 cd aegis-hass
 
+# Configure git hooks (one-time; pre-push runs the full CI pipeline locally)
+make setup
+
 # Build dev container
 make build-docker
 
@@ -24,6 +27,7 @@ make check
 
 | Command | Description |
 |---|---|
+| `make setup` | One-time: configure git hooks (`core.hooksPath = .githooks`) |
 | `make check` | Run all checks (lint, format, typecheck, tests, dead code) |
 | `make test` | Run unit tests with coverage |
 | `make test-e2e` | Run E2E tests (requires AJAX_EMAIL + AJAX_PASSWORD) |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: check test test-e2e lint format typecheck dead-code proto cli build
+.PHONY: setup check test test-e2e lint format typecheck dead-code proto cli build
 
 DOCKER_IMAGE = aegis-ajax-dev
 DOCKER_RUN = docker run --rm -v $(PWD):/app -w /app $(DOCKER_IMAGE)
+
+setup:
+	git config --local core.hooksPath .githooks
+	@echo "Git hooks configured (core.hooksPath = .githooks); pre-push now runs the full CI pipeline."
 
 build-docker:
 	docker build -f Dockerfile.dev -t $(DOCKER_IMAGE) .


### PR DESCRIPTION
## Summary

`.githooks/pre-push` implements the full local CI pipeline, but git only runs hooks from `core.hooksPath`, which a fresh clone never has configured — so the hook was silently inactive for new contributors until they discovered and wired it manually.

- New one-time `make setup` target: `git config --local core.hooksPath .githooks` (option 2 from the issue, preferred since the project standardizes everything through the Makefile).
- Documented as the first step in CONTRIBUTING's Development Setup and added to the commands table.

Note on `.pre-commit-config.yaml`: `core.hooksPath` takes precedence over `.git/hooks`, so on a clone configured this way the pre-commit framework's hooks don't fire — which is already the status quo on the maintainer's clone today (hooksPath was set there manually). Secret scanning still runs in CI on every push. If gitleaks-on-commit is wanted locally, a `.githooks/pre-commit` running gitleaks via Docker can be a follow-up.

## Verification

Simulated a fresh clone: `git config --local --unset core.hooksPath`, then `make setup` → `core.hooksPath = .githooks` restored, and the pre-push hook executed the full pipeline on this branch's push.

Related to #275