### PR TITLE
fix(coordinator): prune manual-refresh rate-limit entries for removed hubs

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -345,6 +345,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             await self._ensure_authenticated()
             self.spaces = await self._refresh_spaces()
+            self._prune_manual_refresh()
             now = asyncio.get_running_loop().time()
             self._update_hub_offline_repairs(now)
             await self._maybe_refresh_sim_and_firmware(now)
@@ -403,6 +404,17 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise ConfigEntryAuthFailed(str(err)) from err
         configured = max(MIN_POLL_INTERVAL, min(MAX_POLL_INTERVAL, self._poll_interval))
         self.update_interval = timedelta(seconds=configured)
+
+    def _prune_manual_refresh(self) -> None:
+        """Drop manual-refresh rate-limit entries for hubs no longer on the
+        account (#276). `_last_manual_refresh` gains a key per hub on every
+        manual-refresh button press; without pruning, a hub removed from
+        the account keeps its entry for the life of the session.
+        """
+        live_hubs = {s.hub_id for s in self.spaces.values() if s.hub_id}
+        for hub_id in list(self._last_manual_refresh):
+            if hub_id not in live_hubs:
+                del self._last_manual_refresh[hub_id]
 
     async def _refresh_spaces(self) -> dict[str, Space]:
         """List spaces, recover once from a stale-token `UNAUTHENTICATED`,

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2021,6 +2021,28 @@ class TestManualHubRefresh:
         hts.request_full_status.assert_any_await("hub-1")
         hts.request_full_status.assert_any_await("hub-2")
 
+    @pytest.mark.asyncio
+    async def test_poll_prunes_rate_limit_entries_for_removed_hubs(self) -> None:
+        """`_last_manual_refresh` keys must follow the account's hub set
+        (#276) — a hub removed from the account otherwise keeps its
+        rate-limit entry for the life of the session.
+        """
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._spaces_api = MagicMock()
+        # _make_space carries hub_id="hub-1" — the only hub still on the account.
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        coordinator._last_manual_refresh = {"hub-1": 100.0, "hub-gone": 50.0}
+
+        await coordinator._async_update_data()
+
+        assert coordinator._last_manual_refresh == {"hub-1": 100.0}
+
 
 class TestSmartLockProbeOrchestration:
     """#206 Bug B: the one-shot probe correlates lock hub-devices to their


### PR DESCRIPTION
## Summary

`_last_manual_refresh` (the per-hub rate-limit map behind the manual refresh button, #179) gained a key per hub on every press and never dropped them — the only cache in the coordinator without cleanup discipline. Entries for hubs removed from the account now get pruned after each spaces refresh, via a `_prune_manual_refresh()` sub-step of `_async_update_data`.

TDD: regression test added in `TestManualHubRefresh` (verified failing before the fix). Full local pipeline green via the pre-push hook (lint, format, mypy, vulture, 1672 tests).

## On the second item of the issue (`__pycache__`)

Already covered, no change needed: `.gitignore` line 7 has `__pycache__/` and `git ls-files` confirms nothing under `__pycache__` is tracked. The directory observed during the audit was a local runtime artifact only.

Related to #276