### PR TITLE
ci: pin actions/checkout to commit SHA (#280)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build dev container
         run: docker build -f Dockerfile.dev --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t aegis-ajax-dev .
       - name: Run tests
@@ -50,7 +50,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build dev container
         run: docker build -f Dockerfile.dev -t aegis-ajax-dev .
       - name: Run linter
@@ -59,7 +59,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build dev container
         run: docker build -f Dockerfile.dev -t aegis-ajax-dev .
       - name: Check formatting
@@ -68,7 +68,7 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build dev container
         run: docker build -f Dockerfile.dev -t aegis-ajax-dev .
       - name: Run type checker
@@ -77,7 +77,7 @@ jobs:
   dead-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build dev container
         run: docker build -f Dockerfile.dev -t aegis-ajax-dev .
       - name: Run dead code analysis

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -14,7 +14,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Scan for secrets

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -14,5 +14,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.3
       - uses: "home-assistant/actions/hassfest@d05c25388490cd662baef8495e1bc764c3386153" # master @ 2026-06-09

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Determine pre-release
         id: prerelease

--- a/.github/workflows/update-version-dropdown.yml
+++ b/.github/workflows/update-version-dropdown.yml
@@ -21,7 +21,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
 


### PR DESCRIPTION
## Summary

Follow-up to #272, addressing #280: tags are mutable (an attacker who compromises an upstream action repo can force-push them), while full commit SHAs are immutable.

- Pin the remaining `actions/checkout@v6` references (8 occurrences across 5 workflows) to the `v6.0.3` commit SHA `df4cb1c069e1874edd31b4311f1884172cec0e10`, verified by dereferencing the annotated tag via the GitHub API.
- Audited the existing pins from #272 — all already SHA-pinned and current:
  - `softprops/action-gh-release` → v3.0.0 (latest)
  - `gitleaks/gitleaks-action` → v3.0.0 (latest)
  - `hacs/action` → main HEAD
  - `home-assistant/actions/hassfest` → master HEAD

After this change, every `uses:` in `.github/workflows/` is pinned to a full 40-char commit SHA with a human-readable version comment.

Ref #280