### PR TITLE
fix(alarm): report armed_night when night mode is active in group mode

### DIFF
--- a/custom_components/aegis_ajax/alarm_control_panel.py
+++ b/custom_components/aegis_ajax/alarm_control_panel.py
@@ -396,6 +396,11 @@ class AjaxAlarmControlPanel(_AjaxAlarmPanelBase):
         space = self._space
         if space is None:
             return None
+        # In group mode the server reports PARTIALLY_ARMED while night mode
+        # is active — identical to "some groups armed" in the lite state.
+        # `night_mode_enabled` (snapshot + push events) disambiguates (#284).
+        if space.security_state == SecurityState.PARTIALLY_ARMED and space.night_mode_enabled:
+            return AlarmControlPanelState.ARMED_NIGHT
         return map_security_state(space.security_state)
 
     @property
@@ -464,8 +469,18 @@ class AjaxAlarmControlPanel(_AjaxAlarmPanelBase):
         space = self._space
         if space is None:
             return
+        # Mirror the push-event rule (#284): arming night sets the flag,
+        # full arm / disarm clears it, so the debounced lite re-read
+        # (PARTIALLY_ARMED in group mode) still maps to armed_night.
+        night_mode_enabled = space.night_mode_enabled
+        if new_state == SecurityState.NIGHT_MODE:
+            night_mode_enabled = True
+        elif new_state in (SecurityState.ARMED, SecurityState.DISARMED):
+            night_mode_enabled = False
         try:
-            self.coordinator.spaces[self._space_id] = replace(space, security_state=new_state)
+            self.coordinator.spaces[self._space_id] = replace(
+                space, security_state=new_state, night_mode_enabled=night_mode_enabled
+            )
         except TypeError:
             return  # space is not a real dataclass (e.g., during tests)
         expiry = asyncio.get_running_loop().time() + 10

--- a/custom_components/aegis_ajax/api/models.py
+++ b/custom_components/aegis_ajax/api/models.py
@@ -79,6 +79,10 @@ class Space:
     monitoring_companies_loaded: bool = False
     groups: tuple[Group, ...] = field(default_factory=tuple)
     group_mode_enabled: bool = False
+    # Night mode currently active (#284). In group mode the server's
+    # DisplayedSpaceSecurityState reports PARTIALLY_ARMED while night mode is
+    # on — this flag is the only wire signal that tells the two apart.
+    night_mode_enabled: bool = False
     # Hub-wide Chime on/off setting (#239). UNSPECIFIED = the hub doesn't
     # expose the feature, so no Chime switch is created for it.
     chime_status: ChimeStatus = ChimeStatus.UNSPECIFIED
@@ -129,6 +133,8 @@ class SpaceSnapshot:
     monitoring_companies_loaded: bool = False
     groups: tuple[Group, ...] = field(default_factory=tuple)
     group_mode_enabled: bool = False
+    # Night mode currently active, read off `mode.group_mode` (#284).
+    night_mode_enabled: bool = False
     # Hub-wide Chime status read off the full snapshot's hub device (#239).
     chime_status: ChimeStatus = ChimeStatus.UNSPECIFIED
 

--- a/custom_components/aegis_ajax/api/spaces.py
+++ b/custom_components/aegis_ajax/api/spaces.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from custom_components.aegis_ajax.api.models import (
     Group,
@@ -34,6 +34,14 @@ _FIND_SPACES_METHOD = (
     "/systems.ajax.api.ecosystem.v3.mobilegwsvc.service"
     ".find_user_spaces_with_pagination.FindUserSpacesWithPaginationService/execute"
 )
+
+
+class ParsedGroups(NamedTuple):
+    """Result of `SpacesApi.parse_groups` over a `SpaceSecurity` proto."""
+
+    groups: tuple[Group, ...]
+    group_mode_enabled: bool
+    night_mode_enabled: bool
 
 
 class SpacesApi:
@@ -77,8 +85,8 @@ class SpacesApi:
         return ChimeStatus.UNSPECIFIED
 
     @staticmethod
-    def parse_groups(proto_security: Any, space_id: str) -> tuple[tuple[Group, ...], bool]:  # noqa: ANN401
-        """Extract groups + group-mode flag from a `SpaceSecurity` proto.
+    def parse_groups(proto_security: Any, space_id: str) -> ParsedGroups:  # noqa: ANN401
+        """Extract groups + group-mode + night-mode flags from a `SpaceSecurity` proto.
 
         Combines the group definitions in `security.groups[]` (id, name,
         sorting_key) with the per-group security states in
@@ -86,13 +94,19 @@ class SpacesApi:
         space is in regular mode (no group_mode oneof), returns an empty
         tuple regardless of whether group definitions exist — the official
         Ajax UI does the same.
+
+        `night_mode_enabled` is `mode.group_mode.night_mode_enabled`: whether
+        night mode is currently active. It matters because in group mode the
+        lite `DisplayedSpaceSecurityState` reports PARTIALLY_ARMED while night
+        mode is on, and this flag is the only wire signal that distinguishes
+        that from "some groups armed" (#284).
         """
         if not hasattr(proto_security, "groups") or not hasattr(proto_security, "mode"):
-            return (), False
+            return ParsedGroups((), False, False)
         mode = proto_security.mode
         group_mode_active = hasattr(mode, "WhichOneof") and mode.WhichOneof("mode") == "group_mode"
         if not group_mode_active:
-            return (), False
+            return ParsedGroups((), False, False)
 
         # Per-group state map keyed by group_id.
         states: dict[str, SecurityState] = {}
@@ -119,7 +133,8 @@ class SpacesApi:
                 )
             )
         groups.sort(key=lambda g: (g.sorting_key, g.name))
-        return tuple(groups), True
+        night_mode_enabled = bool(getattr(mode.group_mode, "night_mode_enabled", False))
+        return ParsedGroups(tuple(groups), True, night_mode_enabled)
 
     @staticmethod
     def parse_monitoring_company(proto_company: Any) -> MonitoringCompany:  # noqa: ANN401
@@ -235,6 +250,7 @@ class SpacesApi:
         monitoring_companies: list[MonitoringCompany] = []
         groups: tuple[Group, ...] = ()
         group_mode_enabled: bool = False
+        night_mode_enabled: bool = False
         chime_status = ChimeStatus.UNSPECIFIED
         try:
             async for msg in stream:
@@ -251,7 +267,9 @@ class SpacesApi:
                 for proto_company in snapshot.monitoring_companies:
                     monitoring_companies.append(self.parse_monitoring_company(proto_company))
                 if hasattr(snapshot, "security"):
-                    groups, group_mode_enabled = self.parse_groups(snapshot.security, space_id)
+                    groups, group_mode_enabled, night_mode_enabled = self.parse_groups(
+                        snapshot.security, space_id
+                    )
                 chime_status = self.extract_chime_status(snapshot)
                 break
         finally:
@@ -275,6 +293,7 @@ class SpacesApi:
             monitoring_companies_loaded=True,
             groups=groups,
             group_mode_enabled=group_mode_enabled,
+            night_mode_enabled=night_mode_enabled,
             chime_status=chime_status,
         )
 

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -461,12 +461,16 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # Group definitions + group_mode_enabled only come from the
                 # hourly snapshot path; without preservation across plain
                 # `list_spaces` polls, per-group alarm panels go
-                # `unavailable` for the rest of the hour.
+                # `unavailable` for the rest of the hour. `night_mode_enabled`
+                # rides along: LiteSpace doesn't carry it either, and losing
+                # it flips the panel from armed_night to armed_custom_bypass
+                # on every plain poll while night mode is on (#284).
                 if previous.groups or previous.group_mode_enabled:
                     s = dc_replace(
                         s,
                         groups=previous.groups,
                         group_mode_enabled=previous.group_mode_enabled,
+                        night_mode_enabled=previous.night_mode_enabled,
                     )
                 # Chime status (#239) also only comes from the hourly snapshot;
                 # `list_spaces` (LiteSpace) doesn't carry it, so preserve the
@@ -539,6 +543,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     monitoring_companies_loaded=snapshot.monitoring_companies_loaded,
                     groups=snapshot.groups,
                     group_mode_enabled=snapshot.group_mode_enabled,
+                    night_mode_enabled=snapshot.night_mode_enabled,
                     chime_status=snapshot.chime_status,
                 )
         self.rooms = refreshed_rooms
@@ -1161,6 +1166,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         import time  # noqa: PLC0415
         from dataclasses import replace as dc_replace  # noqa: PLC0415
 
+        from custom_components.aegis_ajax.const import SecurityState  # noqa: PLC0415
+
         space = self.spaces.get(space_id)
         if space is None:
             return
@@ -1170,9 +1177,21 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         opt = self._optimistic_space_states.get(space_id)
         if opt and opt[0] > now:
             return
-        if space.security_state == new_state:
+        # Track night-mode activity off the push itself: the debounced lite
+        # re-read that follows reports PARTIALLY_ARMED in group mode, and the
+        # flag is what keeps the panel on `armed_night` (#284). PARTIALLY_ARMED
+        # pushes are ambiguous (night mode vs subset of groups) and leave the
+        # flag untouched; the hourly snapshot reconciles.
+        night_mode_enabled = space.night_mode_enabled
+        if new_state == SecurityState.NIGHT_MODE:
+            night_mode_enabled = True
+        elif new_state in (SecurityState.ARMED, SecurityState.DISARMED):
+            night_mode_enabled = False
+        if space.security_state == new_state and space.night_mode_enabled == night_mode_enabled:
             return
-        self.spaces[space_id] = dc_replace(space, security_state=new_state)
+        self.spaces[space_id] = dc_replace(
+            space, security_state=new_state, night_mode_enabled=night_mode_enabled
+        )
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     def apply_push_group_security_state(

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -41,6 +41,7 @@ async def async_get_config_entry_diagnostics(
                 "online": s.is_online,
                 "malfunctions": s.malfunctions_count,
                 "group_mode_enabled": s.group_mode_enabled,
+                "night_mode_enabled": s.night_mode_enabled,
                 "chime_status": s.chime_status.name,
                 "groups": [
                     {

--- a/tests/unit/test_alarm_control_panel.py
+++ b/tests/unit/test_alarm_control_panel.py
@@ -191,6 +191,35 @@ class TestAlarmControlPanel:
         panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
         assert panel.alarm_state is None
 
+    def test_alarm_state_partially_armed_with_night_mode_is_armed_night(self) -> None:
+        # In group mode the server reports PARTIALLY_ARMED while night mode
+        # is active; `night_mode_enabled` is the discriminator (#284).
+        from dataclasses import replace
+
+        from homeassistant.components.alarm_control_panel import (
+            AlarmControlPanelState,  # type: ignore[attr-defined]
+        )
+
+        coordinator = MagicMock()
+        coordinator.spaces = {
+            "s1": replace(
+                self._make_space(SecurityState.PARTIALLY_ARMED),
+                night_mode_enabled=True,
+            )
+        }
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        assert panel.alarm_state == AlarmControlPanelState.ARMED_NIGHT
+
+    def test_alarm_state_partially_armed_without_night_mode_is_custom_bypass(self) -> None:
+        from homeassistant.components.alarm_control_panel import (
+            AlarmControlPanelState,  # type: ignore[attr-defined]
+        )
+
+        coordinator = MagicMock()
+        coordinator.spaces = {"s1": self._make_space(SecurityState.PARTIALLY_ARMED)}
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        assert panel.alarm_state == AlarmControlPanelState.ARMED_CUSTOM_BYPASS
+
     def test_extra_state_attributes(self) -> None:
         coordinator = MagicMock()
         coordinator.spaces = {"s1": self._make_space()}
@@ -235,6 +264,40 @@ class TestAlarmControlPanel:
         panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
         await panel.async_alarm_arm_night()
         coordinator.security_api.arm_night_mode.assert_called_once_with("s1", ignore_alarms=False)
+
+    @pytest.mark.asyncio
+    async def test_alarm_arm_night_sets_night_mode_flag_optimistically(self) -> None:
+        # The optimistic Space write must carry night_mode_enabled too, so the
+        # debounced lite re-read (PARTIALLY_ARMED in group mode) maps back to
+        # armed_night instead of armed_custom_bypass (#284).
+        coordinator = MagicMock()
+        coordinator.security_api.arm_night_mode = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.config_entry.options = {"use_pin_code": False}
+        coordinator.spaces = {"s1": self._make_space(SecurityState.DISARMED)}
+        coordinator._optimistic_space_states = {}
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        await panel.async_alarm_arm_night()
+        assert coordinator.spaces["s1"].night_mode_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_alarm_disarm_clears_night_mode_flag_optimistically(self) -> None:
+        from dataclasses import replace
+
+        coordinator = MagicMock()
+        coordinator.security_api.disarm = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.config_entry.options = {"use_pin_code": False}
+        coordinator.spaces = {
+            "s1": replace(
+                self._make_space(SecurityState.NIGHT_MODE),
+                night_mode_enabled=True,
+            )
+        }
+        coordinator._optimistic_space_states = {}
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        await panel.async_alarm_disarm()
+        assert coordinator.spaces["s1"].night_mode_enabled is False
 
     @pytest.mark.asyncio
     async def test_alarm_disarm(self) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -415,6 +415,67 @@ class TestAsyncUpdateData:
         assert coordinator.spaces["s1"].group_mode_enabled is True
 
     @pytest.mark.asyncio
+    async def test_update_data_preserves_night_mode_enabled_between_snapshot_refreshes(
+        self,
+    ) -> None:
+        """`list_spaces()` (LiteSpace) doesn't carry `night_mode_enabled`; the
+        coordinator must keep the cached flag or the panel flips from
+        `armed_night` to `armed_custom_bypass` on every plain poll (#284).
+        """
+        from custom_components.aegis_ajax.api.models import Group
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._rooms_last_fetch = asyncio.get_running_loop().time()
+        coordinator.spaces["s1"] = replace(
+            _make_space("s1"),
+            groups=(
+                Group(
+                    id="g1",
+                    space_id="s1",
+                    name="Villa",
+                    security_state=SecurityState.ARMED,
+                    sorting_key="01",
+                ),
+            ),
+            group_mode_enabled=True,
+            night_mode_enabled=True,
+        )
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        assert coordinator.spaces["s1"].night_mode_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_snapshot_refresh_applies_night_mode_enabled(self) -> None:
+        """The hourly/forced snapshot is the authoritative source for
+        `night_mode_enabled` — it must overwrite the cached flag (#284)."""
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._rooms_last_fetch = asyncio.get_running_loop().time()
+        coordinator.spaces["s1"] = replace(_make_space("s1"), night_mode_enabled=False)
+        coordinator._force_snapshot_refresh = True
+
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(
+            return_value=SpaceSnapshot(group_mode_enabled=True, night_mode_enabled=True)
+        )
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        assert coordinator.spaces["s1"].night_mode_enabled is True
+
+    @pytest.mark.asyncio
     async def test_space_event_forces_group_state_refresh_within_the_hour(self) -> None:
         """A space arm/disarm HTS event (#266) sets `_force_snapshot_refresh`, so
         the next poll re-reads group security states from the heavier snapshot
@@ -1408,6 +1469,48 @@ class TestApplyPushSecurityState:
 
         assert coordinator.spaces["s1"].security_state == SecurityState.ARMED
         coordinator.async_set_updated_data.assert_called_once()
+
+    def test_night_mode_push_sets_night_mode_enabled(self) -> None:
+        # The push is the only real-time night-mode signal in group mode —
+        # the debounced lite re-read that follows reports PARTIALLY_ARMED,
+        # so the flag must flip here for the panel to keep `armed_night` (#284).
+        coordinator = self._make_coordinator_with_space(SecurityState.DISARMED)
+
+        coordinator.apply_push_security_state("s1", SecurityState.NIGHT_MODE)
+
+        assert coordinator.spaces["s1"].night_mode_enabled is True
+
+    def test_disarm_push_clears_night_mode_enabled(self) -> None:
+        from dataclasses import replace as dc_replace
+
+        coordinator = self._make_coordinator_with_space(SecurityState.NIGHT_MODE)
+        coordinator.spaces["s1"] = dc_replace(coordinator.spaces["s1"], night_mode_enabled=True)
+
+        coordinator.apply_push_security_state("s1", SecurityState.DISARMED)
+
+        assert coordinator.spaces["s1"].night_mode_enabled is False
+
+    def test_full_arm_push_clears_night_mode_enabled(self) -> None:
+        from dataclasses import replace as dc_replace
+
+        coordinator = self._make_coordinator_with_space(SecurityState.NIGHT_MODE)
+        coordinator.spaces["s1"] = dc_replace(coordinator.spaces["s1"], night_mode_enabled=True)
+
+        coordinator.apply_push_security_state("s1", SecurityState.ARMED)
+
+        assert coordinator.spaces["s1"].night_mode_enabled is False
+
+    def test_partial_push_keeps_night_mode_enabled(self) -> None:
+        # PARTIALLY_ARMED is ambiguous (night mode vs subset of groups armed),
+        # so it must not clobber a known night-mode flag.
+        from dataclasses import replace as dc_replace
+
+        coordinator = self._make_coordinator_with_space(SecurityState.NIGHT_MODE)
+        coordinator.spaces["s1"] = dc_replace(coordinator.spaces["s1"], night_mode_enabled=True)
+
+        coordinator.apply_push_security_state("s1", SecurityState.PARTIALLY_ARMED)
+
+        assert coordinator.spaces["s1"].night_mode_enabled is True
 
 
 class TestApplyPushDeviceMotion:

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -174,12 +174,17 @@ class TestAsyncGetConfigEntryDiagnostics:
             ),
         )
         entry.runtime_data.spaces = {
-            "space-1": replace(_make_space(), groups=groups, group_mode_enabled=True)
+            "space-1": replace(
+                _make_space(), groups=groups, group_mode_enabled=True, night_mode_enabled=True
+            )
         }
 
         result = await async_get_config_entry_diagnostics(MagicMock(), entry)
         space_info = result["spaces"]["space-1"]
         assert space_info["group_mode_enabled"] is True
+        # Drives the panel's armed_night-vs-custom_bypass discrimination (#284),
+        # so it must be dumped — a missing key must mean "stale integration".
+        assert space_info["night_mode_enabled"] is True
         assert len(space_info["groups"]) == 2
         assert space_info["groups"][0] == {
             "id": "g1",
@@ -203,4 +208,5 @@ class TestAsyncGetConfigEntryDiagnostics:
         result = await async_get_config_entry_diagnostics(MagicMock(), entry)
         space_info = result["spaces"]["space-1"]
         assert space_info["group_mode_enabled"] is False
+        assert space_info["night_mode_enabled"] is False
         assert space_info["groups"] == []

--- a/tests/unit/test_spaces.py
+++ b/tests/unit/test_spaces.py
@@ -142,6 +142,7 @@ class TestParseGroups:
         groups: list[tuple[str, str, str]] | None = None,
         states: dict[str, int] | None = None,
         mode: str = "group_mode",
+        night_mode_enabled: bool = False,
     ):
         # Imports inside the method so they don't pollute sys.modules with
         # real proto packages at collection time — that breaks unrelated tests
@@ -171,6 +172,7 @@ class TestParseGroups:
             mode_msg = space_security_mode_pb2.SpaceSecurityMode(
                 group_mode=group_mode_space_security_pb2.GroupModeSpaceSecurity(
                     groups=group_securities,
+                    night_mode_enabled=night_mode_enabled,
                 )
             )
         else:
@@ -184,7 +186,7 @@ class TestParseGroups:
             groups=[("g1", "Villa", "01"), ("g2", "Apartment", "02")],
             states={"g1": 1, "g2": 2},  # ARMED, DISARMED
         )
-        groups, enabled = SpacesApi.parse_groups(security, space_id="space-1")
+        groups, enabled, _ = SpacesApi.parse_groups(security, space_id="space-1")
 
         assert enabled is True
         assert [g.id for g in groups] == ["g1", "g2"]
@@ -200,7 +202,7 @@ class TestParseGroups:
             ],
             states={"g1": 2, "g2": 2},
         )
-        groups, _ = SpacesApi.parse_groups(security, space_id="space-1")
+        groups, _, _ = SpacesApi.parse_groups(security, space_id="space-1")
         assert [g.sorting_key for g in groups] == ["01", "02"]
         assert groups[0].name == "A-Second-Insertion"
 
@@ -209,7 +211,7 @@ class TestParseGroups:
             groups=[("g1", "Villa", "01")],
             states={},  # no per-group state in mode.group_mode.groups
         )
-        groups, enabled = SpacesApi.parse_groups(security, space_id="s")
+        groups, enabled, _ = SpacesApi.parse_groups(security, space_id="s")
         assert enabled is True
         assert groups[0].security_state == SecurityState.NONE
 
@@ -218,7 +220,7 @@ class TestParseGroups:
             groups=[("g1", "Villa", "01")],  # definitions exist but mode is regular
             mode="regular_mode",
         )
-        groups, enabled = SpacesApi.parse_groups(security, space_id="s")
+        groups, enabled, _ = SpacesApi.parse_groups(security, space_id="s")
         assert groups == ()
         assert enabled is False
 
@@ -227,8 +229,31 @@ class TestParseGroups:
             groups=[("", "Bad", "00"), ("g1", "Good", "01")],
             states={"g1": 1},
         )
-        groups, _ = SpacesApi.parse_groups(security, space_id="s")
+        groups, _, _ = SpacesApi.parse_groups(security, space_id="s")
         assert [g.id for g in groups] == ["g1"]
+
+    def test_night_mode_enabled_parsed_from_group_mode(self) -> None:
+        # In group mode the lite `DisplayedSpaceSecurityState` reports
+        # PARTIALLY_ARMED while night mode is active — the only wire signal
+        # that distinguishes "night mode" from "some groups armed" is
+        # `mode.group_mode.night_mode_enabled` on the full snapshot (#284).
+        security = self._build_security(
+            groups=[("g1", "Villa", "01")],
+            states={"g1": 1},
+            night_mode_enabled=True,
+        )
+        result = SpacesApi.parse_groups(security, space_id="s")
+        assert result.night_mode_enabled is True
+
+    def test_night_mode_disabled_by_default(self) -> None:
+        security = self._build_security(groups=[("g1", "Villa", "01")], states={"g1": 1})
+        result = SpacesApi.parse_groups(security, space_id="s")
+        assert result.night_mode_enabled is False
+
+    def test_night_mode_false_in_regular_mode(self) -> None:
+        security = self._build_security(groups=[("g1", "Villa", "01")], mode="regular_mode")
+        result = SpacesApi.parse_groups(security, space_id="s")
+        assert result.night_mode_enabled is False
 
 
 class TestListSpaces:


### PR DESCRIPTION
## Problem

With groups enabled, activating Partial Arming / Night Mode from the Ajax app or a keypad left the central alarm entity on `armed_custom_bypass`, while the same action from Home Assistant settled on `armed_night` (#284). Night arming also never showed up in the panel history.

## Root cause

In group mode the server's lite `DisplayedSpaceSecurityState` (what `list_spaces` returns and what FCM-triggered re-reads consume) reports `PARTIALLY_ARMED` while night mode is active — indistinguishable from "some groups armed". The `night_mode_on` push correctly set `armed_night` for a moment, but the debounced lite re-read (#270) immediately overwrote it. HA-initiated arming only survived because the 10s optimistic window masked the same overwrite.

The full space snapshot carries the discriminator we weren't reading: `mode.group_mode.night_mode_enabled` (verified as the live night-mode indicator, not a settings toggle).

## Fix

Track `night_mode_enabled` on `Space`:

- parsed off the full snapshot (authoritative; hourly + forced refreshes)
- flipped by arm/disarm push events: night → on, away/disarm → off, partial → unchanged (ambiguous)
- mirrored on HA-initiated optimistic updates
- preserved across plain `list_spaces` polls (LiteSpace doesn't carry it)

The space panel maps `PARTIALLY_ARMED` + `night_mode_enabled` → `armed_night`; plain partial arming keeps `armed_custom_bypass`. The flag is exposed in diagnostics.

## Testing

- 12 new unit tests (real protos for the parser; coordinator merge/push/snapshot paths; panel mapping + optimistic flow)
- Full suite: 1685 passed, 89% coverage; lint/format/typecheck/vulture clean (no-volume-mount CI build)

Refs #284