### PR TITLE
fix(notification): harden FCM client against reconnect storms

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -21,6 +21,7 @@ from custom_components.aegis_ajax.const import (
     RAW_TAG_TO_GROUP_SECURITY_STATE,
     RAW_TAG_TO_SECURITY_STATE,
 )
+from custom_components.aegis_ajax.notification_fcm_guard import attach_fcm_log_guard
 from custom_components.aegis_ajax.repairs import (
     async_clear_fcm_credentials_invalid,
     async_clear_fcm_credentials_malformed,
@@ -51,6 +52,19 @@ STORAGE_VERSION = 1
 # Both share the same Ajax notification_id, so we suppress duplicate event-fire
 # and refresh paths within this window. See #80.
 NOTIFICATION_DEDUPE_WINDOW_SECONDS = 5.0
+
+# #285: supervision of the FCM push client. firebase-messaging terminates
+# itself (`do_listen = False`) after `abort_on_sequential_error_count`
+# sequential errors or repeated failed reconnects; without supervision push
+# silently stays dead until the next HA restart. The restart is delayed with
+# a doubling backoff (5 → 10 → 15 min cap) so a Google-side outage can't be
+# turned into a reconnect storm by our own retries.
+FCM_SUPERVISE_INTERVAL_SECONDS = 60
+FCM_RESTART_BACKOFF_INITIAL_SECONDS = 300.0
+FCM_RESTART_BACKOFF_MAX_SECONDS = 900.0
+# A client that has stayed alive this long earns the backoff reset, so the
+# next incident starts again at the 5-minute delay.
+FCM_HEALTHY_RUN_RESET_SECONDS = 1800.0
 
 # Issue #174: when the underlying TCP socket against `mtalk.google.com:5228`
 # (FCM's MCS endpoint) gets reset, Google replays any push that wasn't acked
@@ -137,6 +151,12 @@ class AjaxNotificationListener:
         self._app_label = app_label
         self._disable_push_warning = disable_push_warning
         self._push_client: Any = None
+        # FCM register config kept for supervised client restarts (#285).
+        self._fcm_config: Any = None
+        self._fcm_supervisor_unsub: Callable[[], None] | None = None
+        self._fcm_restart_at: float | None = None
+        self._fcm_restart_backoff: float = FCM_RESTART_BACKOFF_INITIAL_SECONDS
+        self._fcm_client_started_at: float | None = None
         self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
         self._rejected_store: Store[dict[str, Any]] = Store(
             hass, STORAGE_VERSION, REJECTED_STORAGE_KEY
@@ -239,7 +259,6 @@ class AjaxNotificationListener:
             return
 
         try:
-            from firebase_messaging import FcmPushClient  # noqa: PLC0415
             from firebase_messaging.fcmregister import (  # noqa: PLC0415
                 FcmRegister,
                 FcmRegisterConfig,
@@ -359,23 +378,123 @@ class AjaxNotificationListener:
                 "integration README and re-enter them in Options."
             )
 
-        # Start push client
+        # Start push client (supervised, #285)
+        self._fcm_config = fcm_config
+        if await self._async_start_push_client():
+            self._start_push_client_supervisor()
+
+    async def _async_start_push_client(self, *, register_repair_on_failure: bool = True) -> bool:
+        """Create and start the FcmPushClient; True when it started.
+
+        Shared by the initial `async_start` path and supervised restarts
+        (#285). Restarts pass `register_repair_on_failure=False`: a transient
+        network failure during a backoff retry must not raise the
+        "credentials invalid" Repair card — the credentials already worked.
+        """
+        try:
+            from firebase_messaging import (  # noqa: PLC0415
+                FcmPushClient,
+                FcmPushClientConfig,
+            )
+        except ImportError:
+            return False
+
+        # Defuse the traceback CPU bomb before the listen loop exists (#285).
+        attach_fcm_log_guard()
         try:
             self._push_client = FcmPushClient(
                 callback=self._on_notification,
-                fcm_config=fcm_config,
+                fcm_config=self._fcm_config,
                 credentials=self._credentials,
+                # Explicit so supervision can rely on the library terminating
+                # itself (do_listen → False) instead of erroring forever; the
+                # supervisor then owns the restart cadence (#285).
+                config=FcmPushClientConfig(abort_on_sequential_error_count=3),
             )
             if asyncio.iscoroutinefunction(self._push_client.start):
                 await self._push_client.start()
             else:
                 await self._hass.async_add_executor_job(self._push_client.start)
+            self._fcm_client_started_at = time.monotonic()
             _LOGGER.info("FCM push client started — push notifications active")
         except Exception as exc:
             _LOGGER.warning(_classify_fcm_failure(exc), exc_info=True)
             self._push_client = None
-            if self._entry_id:
+            if register_repair_on_failure and self._entry_id:
                 async_register_fcm_credentials_invalid(self._hass, entry_id=self._entry_id)
+            return False
+        return True
+
+    def _start_push_client_supervisor(self) -> None:
+        """Start the periodic liveness check for the push client (#285)."""
+        if self._fcm_supervisor_unsub is not None:
+            return
+        from datetime import timedelta  # noqa: PLC0415
+
+        from homeassistant.helpers.event import async_track_time_interval  # noqa: PLC0415
+
+        async def _tick(_now: Any) -> None:  # noqa: ANN401
+            await self._async_supervise_push_client()
+
+        self._fcm_supervisor_unsub = async_track_time_interval(
+            self._hass, _tick, timedelta(seconds=FCM_SUPERVISE_INTERVAL_SECONDS)
+        )
+
+    async def _async_supervise_push_client(self, now: float | None = None) -> None:
+        """Detect a self-terminated FCM client and restart it with backoff (#285).
+
+        `do_listen` is the library's own "I gave up" signal — it goes False
+        when `_terminate()` fires (sequential-error abort, exhausted
+        reconnects) and stays True through normal RESETTING cycles, so a
+        routine reconnect never triggers a restart here. Tearing the client
+        down also flips `is_fcm_connected`, so the hub reachability logic
+        (#236) correctly reports push as down during the backoff window.
+        """
+        if now is None:
+            now = time.monotonic()
+        client = self._push_client
+        if client is not None:
+            if getattr(client, "do_listen", True):
+                if (
+                    self._fcm_client_started_at is not None
+                    and now - self._fcm_client_started_at >= FCM_HEALTHY_RUN_RESET_SECONDS
+                ):
+                    self._fcm_restart_backoff = FCM_RESTART_BACKOFF_INITIAL_SECONDS
+                return
+            delay = self._fcm_restart_backoff
+            self._fcm_restart_at = now + delay
+            self._fcm_restart_backoff = min(
+                self._fcm_restart_backoff * 2, FCM_RESTART_BACKOFF_MAX_SECONDS
+            )
+            _LOGGER.warning(
+                "FCM push client terminated after repeated connection errors — "
+                "restarting in %.0f minutes. Until then real-time events "
+                "(doorbell ring, arm/disarm, alarm) fall back to polling.",
+                delay / 60,
+            )
+            try:
+                stop_result = client.stop()
+                if hasattr(stop_result, "__await__"):
+                    await stop_result
+            except Exception:
+                _LOGGER.debug("Error stopping terminated FCM client", exc_info=True)
+            self._push_client = None
+            return
+        if self._fcm_restart_at is None or now < self._fcm_restart_at:
+            return
+        self._fcm_restart_at = None
+        if await self._async_start_push_client(register_repair_on_failure=False):
+            _LOGGER.info("FCM push client restarted — push notifications active again")
+        else:
+            delay = self._fcm_restart_backoff
+            self._fcm_restart_at = now + delay
+            self._fcm_restart_backoff = min(
+                self._fcm_restart_backoff * 2, FCM_RESTART_BACKOFF_MAX_SECONDS
+            )
+            _LOGGER.warning(
+                "FCM push client restart failed — next attempt in %.0f minutes.",
+                delay / 60,
+            )
 
     async def _register_push_token(self, fcm_token: str) -> None:
         """Register the FCM token with Ajax servers via gRPC."""
@@ -879,6 +998,10 @@ class AjaxNotificationListener:
 
     async def async_stop(self) -> None:
         """Stop the FCM push client."""
+        if self._fcm_supervisor_unsub is not None:
+            self._fcm_supervisor_unsub()
+            self._fcm_supervisor_unsub = None
+        self._fcm_restart_at = None
         if self._push_client:
             try:
                 stop_result = self._push_client.stop()

--- a/custom_components/aegis_ajax/notification_fcm_guard.py
+++ b/custom_components/aegis_ajax/notification_fcm_guard.py
@@ -1,0 +1,86 @@
+"""Logging guard against firebase-messaging reconnect storms (#285).
+
+On 2026-06-11 a Google-side MCS condition (connect succeeds, session resets
+shortly after) drove `firebase_messaging==0.4.5`'s listen loop into logging a
+full traceback on every iteration. asyncio re-raises the same exception
+object stored on the poisoned `StreamReader`, so its `__traceback__` grows a
+few frames per iteration, and on Python 3.14 traceback formatting runs
+`ast.parse` per frame (caret anchors) — quadratic cost executed inside the
+HA event loop. Result: event loop pegged at 100%, watchdog kill, crash loop.
+
+Logging filters run before handlers format the record, so stripping
+`exc_info` here defuses the CPU bomb regardless of what the library does.
+The one-line message still gets through, keeping a trace for operators.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# The module logger firebase-messaging's `_listen` loop emits on.
+FCM_PUSH_LOGGER_NAME = "firebase_messaging.fcmpushclient"
+
+# More than this many exception logs inside the window is a storm, not
+# operations: healthy reconnects log at most one exception per reset cycle
+# (3s+ apart), so 5-in-60s only triggers on pathological tight loops.
+DEFAULT_MAX_EXCEPTIONS = 5
+DEFAULT_WINDOW_SECONDS = 60.0
+
+
+class FcmExceptionLogThrottle(logging.Filter):
+    """Strip tracebacks from over-frequent exception records.
+
+    Never drops a record — `filter` always returns True. Past the threshold
+    the record loses `exc_info` (and the cached `exc_text` / `stack_info`)
+    and gains a short suffix explaining the suppression, so the message
+    itself remains visible at one line per occurrence.
+    """
+
+    def __init__(
+        self,
+        max_exceptions: int = DEFAULT_MAX_EXCEPTIONS,
+        window_seconds: float = DEFAULT_WINDOW_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        super().__init__()
+        self._max = max_exceptions
+        self._window = window_seconds
+        self._clock = clock
+        self._timestamps: deque[float] = deque()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not record.exc_info or record.exc_info == (None, None, None):
+            return True
+        now = self._clock()
+        while self._timestamps and now - self._timestamps[0] > self._window:
+            self._timestamps.popleft()
+        if len(self._timestamps) < self._max:
+            self._timestamps.append(now)
+            return True
+        record.exc_info = None
+        record.exc_text = None
+        record.stack_info = None
+        record.msg = (
+            f"{str(record.msg).rstrip()} "
+            f"[traceback suppressed: more than {self._max} exception logs "
+            f"in {self._window:.0f}s]"
+        )
+        return True
+
+
+def attach_fcm_log_guard() -> None:
+    """Attach the throttle to firebase-messaging's push-client logger.
+
+    Idempotent: reloads and supervised client restarts call this freely
+    without stacking duplicate filters.
+    """
+    logger = logging.getLogger(FCM_PUSH_LOGGER_NAME)
+    if any(isinstance(f, FcmExceptionLogThrottle) for f in logger.filters):
+        return
+    logger.addFilter(FcmExceptionLogThrottle())

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -481,6 +481,126 @@ class TestNotificationListener:
         assert "dev-99" not in listener._notification_id_callbacks
 
 
+class TestFcmPushClientSupervision:
+    """Supervised restart of a self-terminated FCM client (#285).
+
+    firebase-messaging shuts itself down (`do_listen = False`) after
+    `abort_on_sequential_error_count` sequential errors or repeated failed
+    reconnects. Without supervision push silently stays dead until the next
+    HA restart; with it, the client is restarted with a delayed backoff so
+    a Google-side outage can't turn into a reconnect storm.
+    """
+
+    def _make_listener(self) -> AjaxNotificationListener:
+        hass = MagicMock()
+        coordinator = MagicMock()
+        return AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
+
+    @pytest.mark.asyncio
+    async def test_alive_client_is_left_alone(self) -> None:
+        listener = self._make_listener()
+        client = MagicMock()
+        client.do_listen = True
+        listener._push_client = client
+
+        await listener._async_supervise_push_client(now=1000.0)
+
+        assert listener._push_client is client
+        assert listener._fcm_restart_at is None
+
+    @pytest.mark.asyncio
+    async def test_dead_client_schedules_delayed_restart(self) -> None:
+        listener = self._make_listener()
+        client = MagicMock()
+        client.do_listen = False
+        client.stop = AsyncMock()
+        listener._push_client = client
+
+        await listener._async_supervise_push_client(now=1000.0)
+
+        # Torn down (also flips `is_fcm_connected` → reachability shows
+        # "push down") and scheduled, NOT restarted inline.
+        assert listener._push_client is None
+        assert listener._fcm_restart_at == 1000.0 + 300.0
+
+    @pytest.mark.asyncio
+    async def test_restart_fires_only_after_backoff_elapses(self) -> None:
+        listener = self._make_listener()
+        listener._fcm_restart_at = 1300.0
+        listener._async_start_push_client = AsyncMock(return_value=True)
+
+        await listener._async_supervise_push_client(now=1299.0)
+        listener._async_start_push_client.assert_not_awaited()
+
+        await listener._async_supervise_push_client(now=1300.0)
+        listener._async_start_push_client.assert_awaited_once()
+        assert listener._fcm_restart_at is None
+
+    @pytest.mark.asyncio
+    async def test_backoff_doubles_and_caps(self) -> None:
+        listener = self._make_listener()
+
+        def _dead_client() -> MagicMock:
+            client = MagicMock()
+            client.do_listen = False
+            client.stop = AsyncMock()
+            return client
+
+        listener._push_client = _dead_client()
+        await listener._async_supervise_push_client(now=0.0)
+        assert listener._fcm_restart_at == 300.0
+
+        listener._push_client = _dead_client()
+        await listener._async_supervise_push_client(now=2000.0)
+        assert listener._fcm_restart_at == 2000.0 + 600.0
+
+        listener._push_client = _dead_client()
+        await listener._async_supervise_push_client(now=4000.0)
+        assert listener._fcm_restart_at == 4000.0 + 900.0
+
+        # Capped: never exceeds 15 minutes.
+        listener._push_client = _dead_client()
+        await listener._async_supervise_push_client(now=6000.0)
+        assert listener._fcm_restart_at == 6000.0 + 900.0
+
+    @pytest.mark.asyncio
+    async def test_failed_restart_reschedules(self) -> None:
+        listener = self._make_listener()
+        listener._fcm_restart_at = 1000.0
+        listener._fcm_restart_backoff = 600.0
+        listener._async_start_push_client = AsyncMock(return_value=False)
+
+        await listener._async_supervise_push_client(now=1000.0)
+
+        assert listener._fcm_restart_at == 1000.0 + 600.0
+
+    @pytest.mark.asyncio
+    async def test_long_healthy_run_resets_backoff(self) -> None:
+        listener = self._make_listener()
+        client = MagicMock()
+        client.do_listen = True
+        listener._push_client = client
+        listener._fcm_restart_backoff = 900.0
+        listener._fcm_client_started_at = 0.0
+
+        await listener._async_supervise_push_client(now=1800.0)
+
+        assert listener._fcm_restart_backoff == 300.0
+
+    @pytest.mark.asyncio
+    async def test_async_stop_cancels_supervisor(self) -> None:
+        listener = self._make_listener()
+        unsub = MagicMock()
+        listener._fcm_supervisor_unsub = unsub
+        listener._fcm_restart_at = 123.0
+
+        await listener.async_stop()
+
+        unsub.assert_called_once()
+        assert listener._fcm_supervisor_unsub is None
+        assert listener._fcm_restart_at is None
+
+
 class TestAsyncStartFcmRepairs:
     """The FCM listener raises a Repair when registration / push start fails."""
 

--- a/tests/unit/test_notification_fcm_guard.py
+++ b/tests/unit/test_notification_fcm_guard.py
@@ -1,0 +1,140 @@
+"""Tests for the firebase-messaging reconnect-storm logging guard (#285).
+
+The guard defuses the CPU bomb described in #285: firebase-messaging's
+listen loop logging a full, ever-growing traceback on every iteration while
+its stream reader is poisoned. Stripping `exc_info` in a logging.Filter
+(which runs before handlers format the record) keeps the one-line message
+but skips the quadratic traceback formatting on Python 3.14.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from custom_components.aegis_ajax.notification_fcm_guard import (
+    FCM_PUSH_LOGGER_NAME,
+    FcmExceptionLogThrottle,
+    attach_fcm_log_guard,
+)
+
+
+def _make_record(
+    *, with_exc: bool = True, msg: str = "Unexpected exception during read\n"
+) -> logging.LogRecord:
+    exc_info = None
+    if with_exc:
+        try:
+            raise ConnectionResetError("Connection lost")
+        except ConnectionResetError:
+            exc_info = sys.exc_info()
+    return logging.LogRecord(
+        name=FCM_PUSH_LOGGER_NAME,
+        level=logging.ERROR,
+        pathname="fcmpushclient.py",
+        lineno=717,
+        msg=msg,
+        args=(),
+        exc_info=exc_info,
+    )
+
+
+class TestFcmExceptionLogThrottle:
+    def test_under_threshold_keeps_exc_info(self) -> None:
+        throttle = FcmExceptionLogThrottle(max_exceptions=3, window_seconds=60, clock=lambda: 0.0)
+        for _ in range(3):
+            record = _make_record()
+            assert throttle.filter(record) is True
+            assert record.exc_info is not None
+
+    def test_over_threshold_strips_exc_info_but_keeps_record(self) -> None:
+        throttle = FcmExceptionLogThrottle(max_exceptions=3, window_seconds=60, clock=lambda: 0.0)
+        for _ in range(3):
+            throttle.filter(_make_record())
+
+        record = _make_record()
+        # The record must still be emitted (returns True) — only the
+        # traceback is dropped, so operators keep a one-line trace.
+        assert throttle.filter(record) is True
+        assert record.exc_info is None
+        assert record.exc_text is None
+        assert record.stack_info is None
+        assert "traceback suppressed" in record.msg
+
+    def test_window_expiry_restores_exc_info(self) -> None:
+        now = {"t": 0.0}
+        throttle = FcmExceptionLogThrottle(
+            max_exceptions=2, window_seconds=60, clock=lambda: now["t"]
+        )
+        throttle.filter(_make_record())
+        throttle.filter(_make_record())
+        suppressed = _make_record()
+        throttle.filter(suppressed)
+        assert suppressed.exc_info is None
+
+        now["t"] = 61.0
+        record = _make_record()
+        assert throttle.filter(record) is True
+        assert record.exc_info is not None
+
+    def test_records_without_exc_info_pass_untouched_and_uncounted(self) -> None:
+        throttle = FcmExceptionLogThrottle(max_exceptions=1, window_seconds=60, clock=lambda: 0.0)
+        for _ in range(5):
+            record = _make_record(with_exc=False)
+            assert throttle.filter(record) is True
+            assert "traceback suppressed" not in record.msg
+        # The plain records above must not have consumed the budget.
+        record = _make_record()
+        assert throttle.filter(record) is True
+        assert record.exc_info is not None
+
+
+class TestEndToEndSuppression:
+    def test_handler_never_formats_traceback_past_threshold(self) -> None:
+        """Storm simulation through the real logging pipeline.
+
+        Emulates fcmpushclient's `_logger.exception(...)` per-iteration storm
+        and asserts the handler (where traceback formatting — the actual CPU
+        cost — happens) only ever formats the allowed number of tracebacks.
+        """
+        import io
+
+        logger = logging.getLogger(FCM_PUSH_LOGGER_NAME)
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        original_filters = list(logger.filters)
+        original_propagate = logger.propagate
+        logger.addHandler(handler)
+        logger.propagate = False
+        try:
+            attach_fcm_log_guard()
+            for _ in range(20):
+                try:
+                    raise ConnectionResetError("Connection lost")
+                except ConnectionResetError:
+                    logger.exception("Unexpected exception during read\n")
+            output = stream.getvalue()
+            assert output.count("Traceback") == 5
+            assert output.count("traceback suppressed") == 15
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = original_propagate
+            for f in list(logger.filters):
+                if f not in original_filters:
+                    logger.removeFilter(f)
+
+
+class TestAttachFcmLogGuard:
+    def test_attach_is_idempotent(self) -> None:
+        logger = logging.getLogger(FCM_PUSH_LOGGER_NAME)
+        original_filters = list(logger.filters)
+        try:
+            attach_fcm_log_guard()
+            attach_fcm_log_guard()
+            guards = [f for f in logger.filters if isinstance(f, FcmExceptionLogThrottle)]
+            assert len(guards) == 1
+        finally:
+            for f in list(logger.filters):
+                if f not in original_filters:
+                    logger.removeFilter(f)


### PR DESCRIPTION
## Problem

#285: a Google-side MCS condition (connect succeeds, session resets shortly after) drove `firebase-messaging==0.4.5`'s listen loop into logging a full, ever-growing traceback every iteration, inside the HA event loop. On Python 3.14 traceback formatting is quadratic in this scenario (`ast.parse` per frame for caret anchors) → 100% CPU, dead HTTP API, watchdog kill, crash loop.

## Hardening (items 1 + 2 of the issue plan; item 3 tracks upstream)

**1. Exception-log throttle** (`notification_fcm_guard.py`): a `logging.Filter` on `firebase_messaging.fcmpushclient` strips `exc_info`/`exc_text`/`stack_info` past 5 exception records per 60 s window and appends a short "traceback suppressed" suffix. Filters run before handlers format the record, so the CPU bomb is defused even while the upstream loop spins; the one-line message still flows. Records are never dropped. Healthy reconnects (≥3 s apart) never hit the threshold.

**2. Supervised restart with backoff**: the library terminates itself (`do_listen = False`) on sequential-error abort (now pinned explicitly via `FcmPushClientConfig(abort_on_sequential_error_count=3)`) or exhausted reconnects — previously leaving push silently dead until the next HA restart. A 60 s liveness check detects it, logs a WARNING (visible at HA's default log level), and restarts with a doubling backoff: 5 → 10 → 15 min cap, reset after 30 min of healthy run. While down, `is_fcm_connected` is False so hub reachability (#236) reports push as down instead of lying. Restart failures during backoff don't raise the "credentials invalid" Repair — those credentials already worked.

## Testing

- 13 new unit tests, including a storm simulation through the real logging pipeline (20 `logger.exception` calls → handler formats exactly 5 tracebacks) and full supervision lifecycle (schedule, fire-after-backoff, double-and-cap, failed-restart reschedule, healthy-run reset, stop cleanup).
- Full suite: 1698 passed, 89% coverage; lint/format/typecheck/vulture clean.

Refs #285