### PR TITLE
fix(notification): detect zombie FCM client and retry failed initial start

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -378,10 +378,17 @@ class AjaxNotificationListener:
                 "integration README and re-enter them in Options."
             )
 
-        # Start push client (supervised, #285)
+        # Start push client (supervised, #285). The supervisor is installed
+        # even when the first start fails: "push silently dead until the next
+        # HA restart" is exactly the state #285 eliminates, so a failed
+        # initial start seeds a delayed retry with the regular backoff
+        # instead of giving up. (The failure already logged a WARNING and,
+        # on the initial path, raised the credentials Repair.)
         self._fcm_config = fcm_config
-        if await self._async_start_push_client():
-            self._start_push_client_supervisor()
+        started = await self._async_start_push_client()
+        self._start_push_client_supervisor()
+        if not started:
+            self._schedule_fcm_restart(time.monotonic())
 
     async def _async_start_push_client(self, *, register_repair_on_failure: bool = True) -> bool:
         """Create and start the FcmPushClient; True when it started.
@@ -440,32 +447,49 @@ class AjaxNotificationListener:
             self._hass, _tick, timedelta(seconds=FCM_SUPERVISE_INTERVAL_SECONDS)
         )
 
-    async def _async_supervise_push_client(self, now: float | None = None) -> None:
-        """Detect a self-terminated FCM client and restart it with backoff (#285).
+    def _schedule_fcm_restart(self, now: float) -> float:
+        """Arm the next restart attempt and advance the backoff; returns the delay."""
+        delay = self._fcm_restart_backoff
+        self._fcm_restart_at = now + delay
+        self._fcm_restart_backoff = min(
+            self._fcm_restart_backoff * 2, FCM_RESTART_BACKOFF_MAX_SECONDS
+        )
+        return delay
 
-        `do_listen` is the library's own "I gave up" signal — it goes False
-        when `_terminate()` fires (sequential-error abort, exhausted
-        reconnects) and stays True through normal RESETTING cycles, so a
-        routine reconnect never triggers a restart here. Tearing the client
-        down also flips `is_fcm_connected`, so the hub reachability logic
-        (#236) correctly reports push as down during the backoff window.
+    async def _async_supervise_push_client(self, now: float | None = None) -> None:
+        """Detect a dead FCM client and restart it with backoff (#285).
+
+        firebase-messaging 0.4.5 has two distinct death modes:
+
+        - `_terminate()` lowers `do_listen` (sequential-error abort, or
+          reconnect exhaustion inside `_reset()`).
+        - `_listen()` silently returns when the INITIAL `_connect_with_retry`
+          exhausts its tries — `do_listen` stays True and `run_state` parks in
+          STARTING_CONNECTION, where the library's own `_do_monitor` never
+          acts. The only observable signal is the finished listen task in
+          `client.tasks` ([] until `start()` runs, so pre-start ticks don't
+          read as dead).
+
+        Liveness therefore requires `do_listen` AND no finished task. Routine
+        RESETTING cycles keep both, so a normal reconnect never triggers a
+        restart here. Tearing the client down also flips `is_fcm_connected`,
+        so the hub reachability logic (#236) correctly reports push as down
+        during the backoff window.
         """
         if now is None:
             now = time.monotonic()
         client = self._push_client
         if client is not None:
-            if getattr(client, "do_listen", True):
+            tasks = getattr(client, "tasks", None) or []
+            task_finished = any(task.done() for task in tasks)
+            if getattr(client, "do_listen", True) and not task_finished:
                 if (
                     self._fcm_client_started_at is not None
                     and now - self._fcm_client_started_at >= FCM_HEALTHY_RUN_RESET_SECONDS
                 ):
                     self._fcm_restart_backoff = FCM_RESTART_BACKOFF_INITIAL_SECONDS
                 return
-            delay = self._fcm_restart_backoff
-            self._fcm_restart_at = now + delay
-            self._fcm_restart_backoff = min(
-                self._fcm_restart_backoff * 2, FCM_RESTART_BACKOFF_MAX_SECONDS
-            )
+            delay = self._schedule_fcm_restart(now)
             _LOGGER.warning(
                 "FCM push client terminated after repeated connection errors — "
                 "restarting in %.0f minutes. Until then real-time events "
@@ -486,11 +510,7 @@ class AjaxNotificationListener:
         if await self._async_start_push_client(register_repair_on_failure=False):
             _LOGGER.info("FCM push client restarted — push notifications active again")
         else:
-            delay = self._fcm_restart_backoff
-            self._fcm_restart_at = now + delay
-            self._fcm_restart_backoff = min(
-                self._fcm_restart_backoff * 2, FCM_RESTART_BACKOFF_MAX_SECONDS
-            )
+            delay = self._schedule_fcm_restart(now)
             _LOGGER.warning(
                 "FCM push client restart failed — next attempt in %.0f minutes.",
                 delay / 60,

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -496,17 +496,90 @@ class TestFcmPushClientSupervision:
         coordinator = MagicMock()
         return AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
 
+    @staticmethod
+    def _running_task() -> MagicMock:
+        task = MagicMock()
+        task.done.return_value = False
+        return task
+
+    @staticmethod
+    def _finished_task() -> MagicMock:
+        task = MagicMock()
+        task.done.return_value = True
+        return task
+
     @pytest.mark.asyncio
     async def test_alive_client_is_left_alone(self) -> None:
         listener = self._make_listener()
         client = MagicMock()
         client.do_listen = True
+        client.tasks = [self._running_task(), self._running_task()]
         listener._push_client = client
 
         await listener._async_supervise_push_client(now=1000.0)
 
         assert listener._push_client is client
         assert listener._fcm_restart_at is None
+
+    @pytest.mark.asyncio
+    async def test_zombie_client_with_dead_listen_task_schedules_restart(self) -> None:
+        """`_listen()` early-returns when the INITIAL connect exhausts its
+        retries — `do_listen` stays True (only `_terminate()` and the reset
+        path lower it) and `run_state` parks in STARTING_CONNECTION, where
+        the library's own `_do_monitor` never acts. The flag alone would
+        report this zombie as healthy forever; a finished task in
+        `client.tasks` is the tell.
+        """
+        listener = self._make_listener()
+        client = MagicMock()
+        client.do_listen = True
+        client.tasks = [self._finished_task(), self._running_task()]
+        client.stop = AsyncMock()
+        listener._push_client = client
+
+        await listener._async_supervise_push_client(now=1000.0)
+
+        assert listener._push_client is None
+        assert listener._fcm_restart_at == 1000.0 + 300.0
+
+    @pytest.mark.asyncio
+    async def test_client_with_no_tasks_yet_is_not_a_zombie(self) -> None:
+        # `tasks` is [] until start() runs — an empty list must not read as
+        # "listen task finished".
+        listener = self._make_listener()
+        client = MagicMock()
+        client.do_listen = True
+        client.tasks = []
+        listener._push_client = client
+
+        await listener._async_supervise_push_client(now=1000.0)
+
+        assert listener._push_client is client
+        assert listener._fcm_restart_at is None
+
+    @pytest.mark.asyncio
+    async def test_initial_start_failure_still_supervises_and_schedules_retry(self) -> None:
+        """A failed first start must not leave push dead until the next HA
+        restart — the supervisor is installed regardless and a delayed retry
+        is seeded with the same backoff the death path uses.
+        """
+        hass = MagicMock()
+        listener = AjaxNotificationListener(hass=hass, coordinator=MagicMock(), **_FCM_KWARGS)
+        listener._store.async_load = AsyncMock(
+            return_value={"fcm": {"registration": {"token": "tok"}}}
+        )
+        listener._register_push_token = AsyncMock()
+        listener._async_start_push_client = AsyncMock(return_value=False)
+        fake_unsub = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.event.async_track_time_interval",
+            MagicMock(return_value=fake_unsub),
+        ):
+            await listener.async_start()
+
+        assert listener._fcm_supervisor_unsub is fake_unsub
+        assert listener._fcm_restart_at is not None
 
     @pytest.mark.asyncio
     async def test_dead_client_schedules_delayed_restart(self) -> None:
@@ -579,6 +652,7 @@ class TestFcmPushClientSupervision:
         listener = self._make_listener()
         client = MagicMock()
         client.do_listen = True
+        client.tasks = [self._running_task()]
         listener._push_client = client
         listener._fcm_restart_backoff = 900.0
         listener._fcm_client_started_at = 0.0


### PR DESCRIPTION
Follow-up to #288 addressing review findings (refs #285).

## P1 — Zombie client invisible to the supervisor

Liveness was judged solely on `do_listen`, but firebase-messaging 0.4.5 has a death mode that never lowers it: `_listen()` silently returns when the **initial** `_connect_with_retry` exhausts its 5 tries (~90 s), parking `run_state` in `STARTING_CONNECTION` where the library's own `_do_monitor` never acts (it only acts on `STARTED`). During a sustained Google-side outage the first supervised restart hits exactly that path → a zombie the supervisor reported healthy forever, permanently disabling the protection in the very scenario it was built for, with `is_fcm_connected` lying to hub reachability (#236).

Liveness now requires `do_listen` **and** no finished task in `client.tasks` (initialized to `[]` in the library's `__init__`, so pre-start ticks can't false-positive).

## P2 — Failed initial start left no supervisor

`async_start` only installed the supervisor on a successful first start, reproducing "push dead until the next HA restart" for initial failures. The supervisor is now installed unconditionally after the credentials flow, and an initial failure seeds a delayed retry with the regular backoff (failure still logs WARNING and raises the credentials Repair on the initial path only).

## P3 — Docstring correction

"Exhausted reconnects" lowers `do_listen` only on the `_reset()` path; the initial-connect path does not. The supervision docstring now documents both death modes explicitly.

## Testing

4 new unit tests: zombie detection (finished task + `do_listen=True` → teardown + scheduled restart), empty-`tasks` pre-start guard, failed-initial-start supervision seeding, plus updated alive-path tests with realistic running tasks. Full suite: 1701 passed; lint/format/typecheck/vulture clean.

Refs #285