### PR TITLE
fix(video): map NVR About.Type variants and expose raw video-channel identity

### DIFF
--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -225,11 +225,20 @@ _STATE_MAP: dict[int, DeviceState] = {
 # so the device still appears as a HA card with the device-agnostic
 # sensors instead of silently disappearing.
 _VIDEO_EDGE_TYPE_MAP: dict[int, str] = {
+    1: "video_edge_nvr",
     2: "video_edge_turret",
     3: "video_edge_bullet",
     4: "video_edge_minidome",
     5: "video_edge_doorbell",  # #119: @Permudious's MotionCam Video Doorbell
     6: "video_edge_indoor",
+    7: "video_edge_nvr",  # NVR_H_AC (#290: brunovdw68's 8-channel recorder)
+    8: "video_edge_nvr",  # NVR_H_DC
+    9: "video_edge_nvr",  # NVR_H_2D_AC
+    11: "video_edge_nvr",  # NVR_H_2D_8P_AC
+    12: "video_edge_nvr",  # NVR_H_2D_16P_AC
+    13: "video_edge_nvr",  # NVR_H_2D_AI_2G_AC
+    15: "video_edge_nvr",  # NVR_H_2D_AI_8P_AC
+    16: "video_edge_nvr",  # NVR_H_2D_AI_16P_AC
     17: "video_edge_turret",  # TURRET_HL
     18: "video_edge_turret",  # TURRET_HL_VF
     19: "video_edge_turret",  # S_TURRET_HL_VF
@@ -660,8 +669,44 @@ def _parse_video_edge_channel(channel: Any) -> Device | None:  # noqa: ANN401
         return None
 
     profile = channel.profile
-    type_value = int(channel.video_edge_channel_properties.video_edge_type)
-    device_type = _VIDEO_EDGE_TYPE_MAP.get(type_value, "video_edge_unknown")
+    properties = channel.video_edge_channel_properties
+    type_value = int(properties.video_edge_type)
+    device_type = _VIDEO_EDGE_TYPE_MAP.get(type_value)
+    if device_type is None:
+        device_type = "video_edge_unknown"
+        _LOGGER.warning(
+            "Unmapped video_edge_type %s on channel %s — surfacing as "
+            "video_edge_unknown; please report the value on "
+            "https://github.com/bvis/aegis-hass/issues/290",
+            type_value,
+            profile.id,
+        )
+
+    statuses = _parse_statuses(profile.statuses)
+    # Raw `About.Type` value + per-channel source list, surfaced through
+    # diagnostics (#282/#290). `source_aliases` says HOW the channel is
+    # reachable — `primary` (the camera itself), `nvr` (bridged through
+    # a recorder), `cloud_archive` — and its ids link a camera channel
+    # to the NVR channel re-publishing it.
+    statuses["video_edge_type"] = type_value
+    if properties.HasField("source_aliases"):
+        sources: list[dict[str, Any]] = []
+        for source in properties.source_aliases.sources:
+            kind = source.WhichOneof("kind")
+            if kind is None:
+                continue
+            sub = getattr(source, kind)
+            sources.append(
+                {
+                    "kind": kind.removesuffix("_source"),
+                    "video_edge_id": sub.video_edge_id,
+                    "channel_id": sub.channel_id,
+                    # CloudArchiveSource carries no `type` field.
+                    "type": int(sub.type) if hasattr(sub, "type") else None,
+                }
+            )
+        if sources:
+            statuses["video_sources"] = sources
 
     # No hub_id on the channel side — Ajax models the video bridge
     # as a sibling of the hub, not a child. Falling back to the
@@ -677,6 +722,6 @@ def _parse_video_edge_channel(channel: Any) -> Device | None:  # noqa: ANN401
         state=_parse_device_state(profile.states),
         malfunctions=profile.malfunctions,
         bypassed=profile.bypassed,
-        statuses=_parse_statuses(profile.statuses),
+        statuses=statuses,
         battery=_parse_battery(profile.statuses),
     )

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -66,6 +66,21 @@ async def async_get_config_entry_diagnostics(
                     {"level": d.battery.level, "low": d.battery.is_low} if d.battery else None
                 ),
                 "statuses": list(d.statuses.keys()),
+                # Raw video-channel identity (#282/#290): the `About.Type`
+                # value behind a `video_edge_*` device_type and the
+                # source list (primary / nvr / cloud_archive + ids) that
+                # links a camera channel to the NVR re-publishing it.
+                # Keys absent on non-video devices.
+                **(
+                    {"video_edge_type": d.statuses["video_edge_type"]}
+                    if "video_edge_type" in d.statuses
+                    else {}
+                ),
+                **(
+                    {"video_sources": d.statuses["video_sources"]}
+                    if "video_sources" in d.statuses
+                    else {}
+                ),
             }
             for did, d in coordinator.devices.items()
         },

--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -20,6 +20,13 @@ if TYPE_CHECKING:
     from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 
 
+# device_type → model display overrides for names `.title()` mangles
+# (acronyms). Everything else keeps the generic title-cased fallback.
+_MODEL_OVERRIDES: dict[str, str] = {
+    "video_edge_nvr": "Video Edge NVR",
+}
+
+
 def build_device_info(
     device: Device,
     rooms: Mapping[str, Room] | None = None,
@@ -35,7 +42,9 @@ def build_device_info(
         identifiers={(DOMAIN, device.id)},
         name=device.name,
         manufacturer=MANUFACTURER,
-        model=device.device_type.replace("_", " ").title(),
+        model=_MODEL_OVERRIDES.get(
+            device.device_type, device.device_type.replace("_", " ").title()
+        ),
         serial_number=device.id,
     )
     if not is_hub:

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -406,12 +406,17 @@ class TestRedactProtoBytesToHex:
         assert device is not None
         assert device.device_type == "video_edge_indoor"
 
-    def test_parse_video_edge_channel_unknown_type(self) -> None:
+    def test_parse_video_edge_channel_unknown_type(self, caplog: pytest.LogCaptureFixture) -> None:
         # `About.Type` is open-ended; new firmwares can introduce
         # values we don't know yet. Emit a generic `video_edge_unknown`
         # so the device still surfaces as a HA card with at least the
         # device-agnostic sensors (battery, signal_strength). Beats
-        # silently dropping the device.
+        # silently dropping the device. The raw enum value is kept in
+        # `statuses` (and surfaced via diagnostics) and a WARNING names
+        # it, so a reporter's default-level log already identifies the
+        # missing mapping without a debug-log round-trip (#290).
+        import logging
+
         from v3.mobilegwsvc.commonmodels.space.device.light import (
             light_device_pb2,
             light_device_profile_pb2,
@@ -433,9 +438,135 @@ class TestRedactProtoBytesToHex:
             )
         )
 
-        device = DevicesApi.parse_device(light_device)
+        with caplog.at_level(logging.WARNING):
+            device = DevicesApi.parse_device(light_device)
         assert device is not None
         assert device.device_type == "video_edge_unknown"
+        assert device.statuses["video_edge_type"] == 999
+        warning = next(
+            (r for r in caplog.records if r.levelno == logging.WARNING and "999" in r.message),
+            None,
+        )
+        assert warning is not None
+        assert "cam-mystery" in warning.message
+
+    def test_parse_video_edge_channel_nvr_types_collapse(self) -> None:
+        # #290: an NVR HAC re-publishes bridged cameras as channels typed
+        # with the NVR's own `About.Type` variant (NVR=1, NVR_H_AC=7,
+        # NVR_H_DC=8, NVR_H_2D_*=9..16). None of those were in
+        # `_VIDEO_EDGE_TYPE_MAP`, so every one fell through to
+        # `video_edge_unknown` — despite the map's comment promising they
+        # collapse to `video_edge_nvr`. Make the comment true.
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        for type_value in (1, 7, 8, 9, 11, 12, 13, 15, 16):
+            light_device = light_device_pb2.LightDevice(
+                video_edge_channel=light_video_edge_pb2.LightVideoEdgeChannel(
+                    profile=light_device_profile_pb2.LightDeviceProfile(
+                        id="nvr-ch", name="NVR Channel"
+                    ),
+                    video_edge_channel_properties=(
+                        light_video_edge_pb2.LightVideoEdgeChannel.VideoEdgeChannelProperties(
+                            video_edge_type=type_value,
+                        )
+                    ),
+                )
+            )
+
+            device = DevicesApi.parse_device(light_device)
+            assert device is not None
+            assert device.device_type == "video_edge_nvr", f"type {type_value}"
+            assert device.statuses["video_edge_type"] == type_value
+
+    def test_parse_video_edge_channel_records_source_aliases(self) -> None:
+        # #282/#290: `source_aliases` says HOW a channel is reachable —
+        # `primary` (the camera itself), `nvr` (bridged through a
+        # recorder), `cloud_archive`. Recording kind + ids in `statuses`
+        # (dumped via diagnostics) is what lets us link a duplicated
+        # doorbell card to the NVR channel re-publishing it, without a
+        # debug capture.
+        from systems.ajax.api.mobile.v2.common.video.videoedge.channel import (
+            channel_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        light_device = light_device_pb2.LightDevice(
+            video_edge_channel=light_video_edge_pb2.LightVideoEdgeChannel(
+                profile=light_device_profile_pb2.LightDeviceProfile(
+                    id="cam-front-door", name="Front Door Doorbell"
+                ),
+                video_edge_channel_properties=(
+                    light_video_edge_pb2.LightVideoEdgeChannel.VideoEdgeChannelProperties(
+                        video_edge_type=5,  # DOORBELL
+                        source_aliases=channel_pb2.SourceAliases(
+                            sources=[
+                                channel_pb2.VideoSource(
+                                    primary_source=channel_pb2.PrimarySource(
+                                        video_edge_id="ve-doorbell",
+                                        channel_id="0",
+                                        type=5,
+                                    )
+                                ),
+                                channel_pb2.VideoSource(
+                                    nvr_source=channel_pb2.NvrSource(
+                                        video_edge_id="ve-nvr",
+                                        channel_id="3",
+                                        type=7,  # NVR_H_AC
+                                    )
+                                ),
+                            ]
+                        ),
+                    )
+                ),
+            )
+        )
+
+        device = DevicesApi.parse_device(light_device)
+        assert device is not None
+        assert device.statuses["video_sources"] == [
+            {"kind": "primary", "video_edge_id": "ve-doorbell", "channel_id": "0", "type": 5},
+            {"kind": "nvr", "video_edge_id": "ve-nvr", "channel_id": "3", "type": 7},
+        ]
+
+    def test_parse_video_edge_channel_no_source_aliases_no_key(self) -> None:
+        # Channels without `source_aliases` (every pre-NVR capture) must
+        # not grow an empty `video_sources` key — absent key means "the
+        # cloud didn't send it", same convention as the rest of statuses.
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        light_device = light_device_pb2.LightDevice(
+            video_edge_channel=light_video_edge_pb2.LightVideoEdgeChannel(
+                profile=light_device_profile_pb2.LightDeviceProfile(id="cam", name="Cam"),
+                video_edge_channel_properties=(
+                    light_video_edge_pb2.LightVideoEdgeChannel.VideoEdgeChannelProperties(
+                        video_edge_type=5,
+                    )
+                ),
+            )
+        )
+
+        device = DevicesApi.parse_device(light_device)
+        assert device is not None
+        assert "video_sources" not in device.statuses
+        assert device.statuses["video_edge_type"] == 5
 
     def test_parse_video_edge_channel_no_properties_returns_none(self) -> None:
         # If the channel comes without `video_edge_channel_properties`,

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -131,6 +131,38 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert bat["low"] is False
 
     @pytest.mark.asyncio
+    async def test_video_device_includes_raw_type_and_sources(self, entry: MagicMock) -> None:
+        # #282/#290: the raw `About.Type` value and the source list are
+        # what diagnostics-driven triage of duplicated / unknown video
+        # devices runs on — they must survive into the dump (the
+        # `statuses` block only lists keys, not values).
+        from dataclasses import replace
+
+        device = replace(
+            _make_device(did="cam-1"),
+            statuses={
+                "video_edge_type": 7,
+                "video_sources": [
+                    {"kind": "nvr", "video_edge_id": "ve-nvr", "channel_id": "3", "type": 7}
+                ],
+            },
+        )
+        entry.runtime_data.devices = {"cam-1": device}
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+        dev_info = result["devices"]["cam-1"]
+        assert dev_info["video_edge_type"] == 7
+        assert dev_info["video_sources"] == [
+            {"kind": "nvr", "video_edge_id": "ve-nvr", "channel_id": "3", "type": 7}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_non_video_device_omits_video_keys(self, entry: MagicMock) -> None:
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+        dev_info = result["devices"]["dev-1"]
+        assert "video_edge_type" not in dev_info
+        assert "video_sources" not in dev_info
+
+    @pytest.mark.asyncio
     async def test_stream_tasks_count(self, entry: MagicMock) -> None:
         result = await async_get_config_entry_diagnostics(MagicMock(), entry)
         assert result["stream_tasks"] == 2


### PR DESCRIPTION
## Context

References #290 and #282.

An NVR republishes bridged cameras as `video_edge` channels typed with the NVR's own `About.Type` variant (`NVR=1`, `NVR_H_AC=7`, `NVR_H_DC=8`, `NVR_H_2D_*=9..16`). None of those were in `_VIDEO_EDGE_TYPE_MAP` — despite the map's comment promising they collapse to `video_edge_nvr` — so every NVR-bridged channel surfaced as a generic **Video Edge Unknown** device card (#290), with no way to tell from diagnostics which raw type produced it.

## Changes

- **Map all NVR `About.Type` variants to `video_edge_nvr`** (model rendered as "Video Edge NVR" via a small acronym override in `build_device_info`).
- **Keep the raw `About.Type` value** in `statuses["video_edge_type"]` and dump it in diagnostics — an unknown variant becomes identifiable from a single diagnostics download.
- **Record `source_aliases` per channel** (kind `primary`/`nvr`/`cloud_archive` + `video_edge_id`/`channel_id`/`type`) in `statuses["video_sources"]` and dump it in diagnostics. This is the linkage that ties a duplicated camera card to the NVR channel republishing it, and the first map of how video devices surface to the integration for the camera-entity exploration (#282).
- **WARNING on unmapped types** (visible at HA's default log level), naming the raw value and channel id, so reporters don't need a debug-logging round-trip.

## What this does NOT do yet

- No dedup of a camera appearing both as its own channel and as an NVR channel — we first need a real diagnostics dump (#290) to see how the duplicate actually arrives before deciding which side wins and how pushes route.
- No `camera` entity / NVR-box (`video_edge` oneof) parsing — same reason (#282).

## Tests

- Real-proto parser tests: NVR variants collapse to `video_edge_nvr`, raw type recorded, `source_aliases` round-trip (primary + nvr kinds), absent aliases ⇒ no `video_sources` key, unmapped type ⇒ WARNING with raw value + channel id.
- Diagnostics tests: video fields present for video devices, absent otherwise.
- Full `make check` in Docker (no volume mount): 1706 passed, coverage 89%.