### PR TITLE
fix(binary_sensor): run keyfob discovery dispatch on the event loop

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.const import EntityCategory
+from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -423,11 +424,20 @@ async def async_setup_entry(
             seen_keyfobs.update(e._keyfob_id for e in new)
             async_add_entities(new)
 
+    # MUST be a @callback: the dispatcher classifies a plain function as
+    # HassJobType.Executor and runs it on a SyncWorker thread, where
+    # async_add_entities' eager task creation raises "loop is not the
+    # running loop" and the entity is silently lost. Boot usually escapes
+    # (platform setup finishes after HTS discovery, so keyfobs go through
+    # the direct call above), but every config-entry RELOAD hit it: keyfob
+    # entities vanished until the next restart. Found via #284's report.
+    @callback
+    def _async_add_discovered_keyfob(device_id: str) -> None:
+        _add_keyfobs([device_id])
+
     _add_keyfobs(list(coordinator.keyfobs))
     entry.async_on_unload(
-        async_dispatcher_connect(
-            hass, SIGNAL_NEW_DEVICE, lambda device_id: _add_keyfobs([device_id])
-        )
+        async_dispatcher_connect(hass, SIGNAL_NEW_DEVICE, _async_add_discovered_keyfob)
     )
 
 

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -1303,6 +1303,16 @@ class TestKeyfobActiveSensor:
         assert not [e for e in added if isinstance(e, AjaxKeyfobActiveSensor)]
         assert captured["signal"].endswith("_new_device")
 
+        # The dispatcher target MUST be a HA @callback: a plain function is
+        # classified as HassJobType.Executor and runs on a SyncWorker thread,
+        # where async_add_entities' eager task creation raises "RuntimeError:
+        # loop is not the running loop" and the entity is silently lost.
+        # Bites on every config-entry reload (boot escapes it only because
+        # platform setup usually finishes after HTS discovery). #284 report.
+        from homeassistant.core import is_callback
+
+        assert is_callback(captured["cb"])
+
         # Keyfob discovered at runtime → dispatcher callback adds exactly one.
         coordinator.keyfobs = {"2ACCB91C": self._keyfob()}
         captured["cb"]("2ACCB91C")


### PR DESCRIPTION
## Context

References #284 (instability follow-up reported by dheuts90). Regression present since 1.10.0 (keyfob feature), surfaced by config-entry reloads.

## Root cause

The `SIGNAL_NEW_DEVICE` dispatcher target was a plain lambda. HA's dispatcher classifies a plain function as `HassJobType.Executor` and runs it on a **SyncWorker thread**. From there, `async_add_entities` → `entry.async_create_task(..., eager_start=True)` → `Task(coro, loop, eager_start=True)` raises `RuntimeError: loop <...> is not the running loop`, and the scheduled `EntityPlatform.async_add_entities` task is destroyed while pending. The keyfob entity is silently lost.

Boot usually escapes by accident: platform setup tends to finish *after* the first HTS `SETTINGS_BODY`, so keyfobs are already known and go through the direct on-loop call. On a **reload**, platforms come up instantly and discovery lands seconds later via the dispatcher — every keyfob entity vanishes until the next restart, with a burst of `RuntimeError` + `Task was destroyed but it is pending` in the log (exactly the signature in dheuts90's report).

## Fix

Decorate the dispatcher target with `@callback` so it runs inline on the event loop. Audited the integration for sibling cases: this is the only `async_dispatcher_connect` call site.

## Verification

- Reproduced live on an install with 6 keyfobs by driving an options-flow save (forced reload): 6× RuntimeError + 6 destroyed tasks, keyfob entities gone.
- Test now asserts the wired dispatcher target satisfies `is_callback` — the exact property that decides loop-vs-executor dispatch.
- Full `make check` in Docker (no volume mount): 1706 passed.

Post-merge, the same live install will be redeployed and the reload re-exercised to confirm clean keyfob re-add.