### PR TITLE
fix(blueprints): guard state triggers against unavailable/unknown transitions

### DIFF
--- a/custom_components/aegis_ajax/blueprints/automation/connectivity_loss_escalation.yaml
+++ b/custom_components/aegis_ajax/blueprints/automation/connectivity_loss_escalation.yaml
@@ -49,12 +49,18 @@ variables:
 triggers:
   - trigger: state
     entity_id: !input connectivity_entity
+    not_from:
+      - "unavailable"
+      - "unknown"
     to: "off"
     for:
       minutes: !input warning_delay
     id: warning
   - trigger: state
     entity_id: !input connectivity_entity
+    not_from:
+      - "unavailable"
+      - "unknown"
     to: "off"
     for:
       minutes: !input critical_delay

--- a/custom_components/aegis_ajax/blueprints/automation/door_opened_while_armed.yaml
+++ b/custom_components/aegis_ajax/blueprints/automation/door_opened_while_armed.yaml
@@ -46,6 +46,9 @@ blueprint:
 triggers:
   - trigger: state
     entity_id: !input door_sensor
+    not_from:
+      - "unavailable"
+      - "unknown"
     to: "on"
 
 conditions:

--- a/custom_components/aegis_ajax/blueprints/automation/nobody_home_remind_arm.yaml
+++ b/custom_components/aegis_ajax/blueprints/automation/nobody_home_remind_arm.yaml
@@ -63,6 +63,9 @@ variables:
 triggers:
   - trigger: state
     entity_id: !input person_entities
+    not_from:
+      - "unavailable"
+      - "unknown"
     to: "not_home"
     for:
       minutes: !input delay_minutes

--- a/custom_components/aegis_ajax/blueprints/automation/remind_arm_with_tts.yaml
+++ b/custom_components/aegis_ajax/blueprints/automation/remind_arm_with_tts.yaml
@@ -75,6 +75,9 @@ variables:
 triggers:
   - trigger: state
     entity_id: !input alarm_entity
+    not_from:
+      - "unavailable"
+      - "unknown"
     to: "disarmed"
     for:
       minutes: !input delay_minutes

--- a/docs/automations.yaml
+++ b/docs/automations.yaml
@@ -27,6 +27,9 @@
   triggers:
     - trigger: state
       entity_id: alarm_control_panel.my_hub
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "triggered"
   actions:
     - action: button.press
@@ -57,6 +60,9 @@
   triggers:
     - trigger: state
       entity_id: alarm_control_panel.my_hub
+      not_from:
+        - "unavailable"
+        - "unknown"
       to:
         - "armed_away"
         - "armed_night"
@@ -87,6 +93,9 @@
   triggers:
     - trigger: state
       entity_id: binary_sensor.my_hub_connectivity
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "off"
       for:
         minutes: 2
@@ -116,6 +125,9 @@
   triggers:
     - trigger: state
       entity_id: binary_sensor.my_hub_connectivity
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "on"
   conditions:
     - condition: template
@@ -183,6 +195,9 @@
   triggers:
     - trigger: state
       entity_id: "{{ label_entities('aegis_door') | list }}"
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "on"
       for:
         minutes: 10
@@ -204,6 +219,9 @@
   triggers:
     - trigger: state
       entity_id: binary_sensor.main_door_door
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "on"
   conditions:
     - condition: state
@@ -240,6 +258,9 @@
   triggers:
     - trigger: state
       entity_id: "{{ label_entities('aegis_tamper') | list }}"
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "on"
   actions:
     - action: notify.mobile_app_user
@@ -266,6 +287,9 @@
   triggers:
     - trigger: state
       entity_id: binary_sensor.my_hub_lid_opened
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "on"
   actions:
     - action: notify.mobile_app_user
@@ -292,6 +316,9 @@
   triggers:
     - trigger: state
       entity_id: binary_sensor.my_hub_cra_connection
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "off"
       for:
         minutes: 1
@@ -321,6 +348,9 @@
   triggers:
     - trigger: state
       entity_id: binary_sensor.my_hub_cra_connection
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "on"
   conditions:
     - condition: template
@@ -342,6 +372,9 @@
   triggers:
     - trigger: state
       entity_id: binary_sensor.my_hub_cellular_connected
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "off"
       for:
         minutes: 5
@@ -434,6 +467,9 @@
   triggers:
     - trigger: state
       entity_id: zone.home
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "0"
       for:
         minutes: 5
@@ -485,6 +521,9 @@
   triggers:
     - trigger: state
       entity_id: "{{ label_entities('aegis_connectivity') | list }}"
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "off"
       for:
         minutes: 10
@@ -516,6 +555,9 @@
         - binary_sensor.dining_problem
         - binary_sensor.keypad_problem
         - binary_sensor.my_hub_problem
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "on"
   actions:
     - action: notify.mobile_app_user
@@ -598,6 +640,9 @@
     - trigger: state
       entity_id: event.my_hub_security_event
       attribute: event_type
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "alarm"
   action:
     - parallel:
@@ -631,6 +676,9 @@
     - trigger: state
       entity_id: event.my_hub_security_event
       attribute: event_type
+      not_from:
+        - "unavailable"
+        - "unknown"
       to: "tamper"
   action:
     - action: notify.mobile_app_user


### PR DESCRIPTION
## Context

A config-entry reload (or HA restart) destroys and re-creates every entity, so its state transitions `unavailable → <real state>`. Blueprint and example automations triggering on bare `to:` treat that as a real state change — verified live: the remind-arm blueprints push a phantom **"alarm disarmed"** notification a few minutes after every integration reload (options save, HACS update, etc.).

## Changes

- Add `not_from: ["unavailable", "unknown"]` to every state trigger that lacked a from-side guard:
  - Blueprints: `remind_arm_with_tts` (the live offender), `nobody_home_remind_arm` (person entities restore through unknown), `connectivity_loss_escalation` (2 triggers), `door_opened_while_armed`.
  - `docs/automations.yaml`: 16 of the 18 example triggers (the other 2 already had a `from:`).
- Untouched: the event-entity blueprints (security event notification, intrusion capture, tamper alert) — already guarded by the `< 10s` freshness condition.

## Notes

Blueprints are templates — users with existing automations need to re-import the blueprint to pick this up (the README already documents that flow). Examples are copy-paste, so new copies get the guard.

All YAML validated; full `make check` green.