### PR TITLE
fix(hts): recognise peripheral-originated 0x08 space events

### DIFF
--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -81,19 +81,31 @@ MAX_FRAME_BUFFER_BYTES = 256 * 1024
 # Chime frame by signature and use it only as a trigger to re-read the
 # authoritative gRPC chime_status.
 _MSG_TYPE_EVENT = 0x08
-# A `type=0x08` space event (chime toggle #239, arm/disarm #258) starts with
-# params[0]=0x02, params[1]=0x22, then params[2]=the 4-byte SOURCE id that
-# triggered it (the keypad/keyfob/app device — VARIES per hub and per trigger,
-# NOT a fixed signature). params[3] is the 1-byte state discriminator (chime
-# 0x38/0x39; security 0x00 disarm / 0x01 arm / 0x02 night). The coordinator
-# decodes params[3]; here we only gate the forward.
+# A `type=0x08` space event (chime toggle #239, arm/disarm #258/#284) starts
+# with params[0]=0x02, params[1]=<event family>, then params[2]=the 4-byte
+# SOURCE id that triggered it (the keypad/keyfob/app device — VARIES per hub
+# and per trigger, NOT a fixed signature). params[3] is the 1-byte state
+# discriminator (family 0x22: chime 0x38/0x39, security 0x00 disarm / 0x01
+# arm / 0x02 night; family 0x30: 0x22 arm / 0x28 disarm observed). The
+# coordinator decodes params[3]; here we only gate the forward.
 #
-# NOTE: an earlier version hardcoded params[2]==0x33 80 41 a4 (BadFlo's source
-# id from the #239 capture), so the matcher only fired on his hub — chime AND
-# the #258 arm/disarm decode silently no-op'd everywhere else. Match the
-# constant 2-byte prefix + a 4-byte source id instead (#258, bvis-home capture
-# showed source id 0x77 dd 6a 14).
-_SPACE_EVENT_PREFIX: tuple[bytes, bytes] = (b"\x02", b"\x22")
+# NOTE: this matcher has been too narrow TWICE. First it hardcoded
+# params[2]==0x33 80 41 a4 (BadFlo's source id from the #239 capture), so it
+# only fired on his hub (#258 fixed that: any 4-byte source id). Then it
+# required params[1]==0x22, which silently dropped the whole
+# peripheral-originated family (#284 keypad capture). Prefer matching on
+# structure (params[0] + known family + 4-byte id + state byte) over exact
+# values from a single capture.
+_SPACE_EVENT_PREFIX: bytes = b"\x02"
+# params[1] is the event FAMILY. 0x22 = hub/app-originated (chime #239,
+# arm/disarm #258). 0x30 = peripheral-originated: dheuts90's #284 capture
+# showed [0x02, 0x30, <keypad id>, 0x22/0x28] for a Keypad Plus night
+# arm/disarm that produced NO FCM push at all — gating on 0x22 alone dropped
+# the family and the authoritative re-read never fired, so the panel lagged
+# until the next poll. SpaceControl fobs (#287) most likely use it too.
+# The same capture also held an [0x0b, 0x21, …] frame (≈30 s after the arm,
+# plausibly exit-delay completion) — left unmapped until more samples.
+_SPACE_EVENT_FAMILIES: frozenset[int] = frozenset({0x22, 0x30})
 
 
 def _redact_payload_hex(data: bytes) -> str:
@@ -890,7 +902,14 @@ class HtsClient:
         hub_id = self._hub_id_from_message(msg)
         if not hub_id:
             return
-        candidate = params[3][0] if len(params) >= 4 and params[3] else None
+        # The state-byte vocabulary is per-family: chime 0x38/0x39 only exists
+        # in the 0x22 family. Forward the byte only there, so a peripheral
+        # (0x30) event whose byte happens to collide can never be mis-decoded
+        # as a chime toggle — it falls through to the authoritative-refresh
+        # nudge instead (the full payload is already DEBUG-logged above).
+        candidate = (
+            params[3][0] if len(params) >= 4 and params[3] and params[1] == b"\x22" else None
+        )
         try:
             self._on_chime_event(hub_id, redacted, candidate)
         except Exception:  # noqa: BLE001
@@ -900,13 +919,17 @@ class HtsClient:
     def _is_space_event(params: list[bytes]) -> bool:
         """Recognise a `type=0x08` space event (chime #239 / arm-disarm #258).
 
-        Matches the constant 2-byte prefix (0x02, 0x22) plus a 4-byte source id
-        at params[2] — deliberately NOT a fixed params[2] value, which varies by
-        hub/trigger (#258). params[3] (the state byte) is left for the coordinator.
+        Matches params[0]=0x02 + a known event family at params[1] (0x22
+        hub/app-originated, 0x30 peripheral-originated — keypads #284, likely
+        fobs #287) plus a 4-byte source id at params[2] — deliberately NOT a
+        fixed params[2] value, which varies by hub/trigger (#258). params[3]
+        (the state byte) is left for the coordinator.
         """
         return (
             len(params) >= 4
-            and tuple(params[:2]) == _SPACE_EVENT_PREFIX
+            and params[0] == _SPACE_EVENT_PREFIX
+            and len(params[1]) == 1
+            and params[1][0] in _SPACE_EVENT_FAMILIES
             and len(params[2]) == 4
             and len(params[3]) >= 1
         )

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -1438,10 +1438,66 @@ class TestChimeEvent:
         )
         assert HtsClient._is_space_event(params) is True
 
+    def test_is_space_event_true_for_peripheral_family(self) -> None:
+        # #284 follow-up: arm/disarm performed ON a peripheral (Keypad Plus
+        # user code; likely SpaceControl fobs too, #287) emits params[1]=0x30
+        # with the PERIPHERAL's id as source — dheuts90's capture showed
+        # [0x02, 0x30, <keypad id>, 0x22] on night arm and [..., 0x28] on
+        # disarm. The old 0x22-only gate dropped the whole family, so the
+        # authoritative re-read never fired and the panel lagged until the
+        # next poll/snapshot. Both observed state bytes must pass the gate
+        # (the coordinator treats any non-chime byte as a nudge, never as a
+        # decoded state).
+        from custom_components.aegis_ajax.api.hts.messages import tlv_decode
+
+        for state_byte in (b"\x22", b"\x28"):
+            params = tlv_decode(
+                tlv_encode(
+                    [b"\x02", b"\x30", b"\x30\x9f\x84\xe5", state_byte, b"\xfd\xfd\x1a", b"\x00"]
+                )
+            )
+            assert HtsClient._is_space_event(params) is True, state_byte.hex()
+
     def test_is_space_event_false_for_other_event(self) -> None:
         from custom_components.aegis_ajax.api.hts.messages import tlv_decode
 
         params = tlv_decode(tlv_encode([b"\x02", b"\x99", b"\x00"]))
+        assert HtsClient._is_space_event(params) is False
+
+    def test_peripheral_family_forwards_none_candidate(self) -> None:
+        # The state-byte vocabulary is per-family (chime 0x38/0x39 lives in
+        # 0x22 only). A 0x30-family event must reach the callback as a
+        # candidate-less nudge, so a colliding byte can never flip
+        # chime_status — route by shape before content.
+        client = _make_client()
+        client._hubs = [MagicMock(hub_id="12345678")]
+        cb = MagicMock()
+        client._on_chime_event = cb
+        msg = HtsMessage(
+            sender=0x12345678,
+            receiver=client._sender_id,
+            seq_num=1,
+            link=10,
+            flags=0,
+            msg_type=0x08,
+            payload=tlv_encode(
+                [b"\x02", b"\x30", b"\x30\x9f\x84\xe5", b"\x38", b"\xfd\xfd\x1a", b"\x00"]
+            ),
+        )
+
+        client._handle_event_message(msg)
+
+        cb.assert_called_once()
+        hub_id, _payload_hex, candidate = cb.call_args[0]
+        assert hub_id == "12345678"
+        assert candidate is None
+
+    def test_is_space_event_false_for_unknown_first_param(self) -> None:
+        # The 17:21:55 frame in the same capture opened with params[0]=0x0b —
+        # a different (still unmapped) family. Stay out until more samples.
+        from custom_components.aegis_ajax.api.hts.messages import tlv_decode
+
+        params = tlv_decode(tlv_encode([b"\x0b", b"\x21", b"\x00\x2c\xa0\x06", b"\x68"]))
         assert HtsClient._is_space_event(params) is False
 
     def test_is_space_event_false_for_non_4byte_source(self) -> None:


### PR DESCRIPTION
## Context

References #284 (dheuts90's keypad finding) and #287 (fob/scenario group lag).

## Root cause

dheuts90's debug capture showed that a night arm/disarm done with a **user code on the Keypad Plus** produces **no FCM push at all** — only a hub `type=0x08` HTS event with `params[1]=0x30` and the keypad's id as source (`[0x02, 0x30, <keypad id>, 0x22]` arm / `[..., 0x28]` disarm). The space-event gate (`_is_space_event`) required `params[1]==0x22`, so the whole peripheral-originated family was dropped: neither the debounced authoritative re-read (#258/#270) nor the forced group/snapshot read (#266) ever fired, and the panel lagged until the next poll or hourly snapshot. In group mode + night that is exactly "disarm from Keypad Plus leaves HA stuck on `armed_night`".

This matcher has now been too narrow twice (the first time it was hardcoded to one user's source id, fixed in #258) — the code comment now documents the lesson: match structure, not exact values from a single capture.

## Changes

- Accept event families `{0x22, 0x30}` (`params[0]=0x02` + 4-byte source id + state byte still required).
- The state-byte vocabulary is per-family, so the candidate byte is only forwarded for the `0x22` family — a colliding `0x30` byte can never be mis-decoded as a chime toggle. Peripheral events always take the nudge path (re-read, never trust the byte).
- The `[0x0b, 0x21, …]` frame in the same capture (plausibly exit-delay completion) stays unmapped until more samples.

## Why this is safe

The nudge path was designed fail-safe (#258): it never decodes state from the event, it only triggers the authoritative gRPC re-read through the 1 s debouncer, with the forced snapshot read refreshing groups + `night_mode_enabled`. Worst case of an over-broad match is an extra debounced re-read.

## Verification

- Real-shape tests from the capture (both observed state bytes), candidate-gating test, unknown-family regression test.
- Full `make check` in Docker (no volume mount): all green.
- Functional verification needs a keypad/fob + group-mode install — that's dheuts90/ArshSoni on the next beta (bvis-home has neither).