### PR TITLE
fix(notification): nudge group/night snapshot re-read on FCM security events

### DIFF
--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -351,6 +351,15 @@ RAW_TAG_TO_GROUP_SECURITY_STATE: dict[str, SecurityState] = {
     "space_group_duress_disarmed": SecurityState.DISARMED,
 }
 
+# HA event types that signal a security-state change. Used by the FCM event
+# path to nudge the snapshot-backed re-read (#284/#287): a push tells (at
+# most) one group's new state, while a scenario / keypad / fob action can
+# flip several groups at once plus `night_mode_enabled` — both only carried
+# by the heavier `get_space_snapshot`.
+SECURITY_STATE_EVENT_TYPES: frozenset[str] = frozenset(
+    {"arm", "disarm", "arm_night", "disarm_night"}
+)
+
 
 # Map HubEventTag oneof field names to simplified HA event types
 HUB_EVENT_TAG_MAP: dict[str, str] = {

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -952,6 +952,29 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             async_dispatcher_send(self.hass, SIGNAL_NEW_DEVICE, device_id_hex)
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
+    def request_security_snapshot_refresh(self) -> None:
+        """Nudge the authoritative security re-read, group states included.
+
+        Forces the next refresh to re-read group security states and
+        `night_mode_enabled` via `get_space_snapshot` (#266) — arming or
+        disarming can flip several groups at once plus the night flag, none
+        of which the lighter `list_spaces` poll carries — and routes the
+        re-read through the dedicated short-cooldown debouncer (#270), NOT
+        the shared 10 s request-refresh debouncer (whose cooldown coalesced a
+        rapid arm→disarm→arm burst into one trailing re-read that lagged the
+        panel ~10 s).
+
+        Called from the HTS 0x08 space-event path and, since #284/#287, from
+        FCM security events: a push tells (at most) one group's new state, so
+        a scenario / keypad / fob action that changes other groups or night
+        mode would otherwise wait for the hourly snapshot (~9 min lag
+        observed live on a scenario-driven group arm).
+
+        Runs on the event loop.
+        """
+        self._force_snapshot_refresh = True
+        self.hass.async_create_task(self._security_refresh_debouncer.async_call())
+
     def _on_hts_space_event(self, hub_id: str, payload_hex: str, candidate: int | None) -> None:
         """React to a hub `type=0x08` space event pushed over HTS in real time.
 
@@ -995,16 +1018,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "none" if candidate is None else f"0x{candidate:02X}",
                 payload_hex,
             )
-            # Force the next refresh to re-read group security states too (#266):
-            # arming/disarming a single group changes only per-group state, which
-            # the lighter `list_spaces` poll doesn't carry. Without this the group
-            # panel would lag until the hourly snapshot when push is off.
-            self._force_snapshot_refresh = True
-            # Route through the dedicated short-cooldown debouncer (#270), NOT the
-            # shared 10 s request-refresh debouncer — the latter coalesced a rapid
-            # arm→disarm→arm burst into one trailing re-read that left the panel on
-            # the stale state for up to ~10 s when FCM push didn't arrive first.
-            self.hass.async_create_task(self._security_refresh_debouncer.async_call())
+            self.request_security_snapshot_refresh()
             return
 
         _LOGGER.debug(

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -20,6 +20,7 @@ from custom_components.aegis_ajax.const import (
     MOTION_EVENT_TYPE,
     RAW_TAG_TO_GROUP_SECURITY_STATE,
     RAW_TAG_TO_SECURITY_STATE,
+    SECURITY_STATE_EVENT_TYPES,
 )
 from custom_components.aegis_ajax.notification_fcm_guard import attach_fcm_log_guard
 from custom_components.aegis_ajax.repairs import (
@@ -820,6 +821,15 @@ class AjaxNotificationListener:
                             self._coordinator.fire_push_event, space_id, event_type, event_data
                         )
                         self._apply_security_state_from_event(space_id, event_data)
+                # A security-state event can change several groups at once
+                # (scenario / keypad / fob) plus `night_mode_enabled` — state
+                # only the heavier snapshot carries. Nudge the same
+                # authoritative re-read the HTS 0x08 path uses (#284/#287):
+                # the push state applied above keeps the space panel instant;
+                # the nudge settles group panels + armed_night ~1 s later
+                # instead of waiting for the hourly snapshot.
+                if event_type in SECURITY_STATE_EVENT_TYPES:
+                    self._dispatch_to_loop(self._coordinator.request_security_snapshot_refresh)
                 # Surface doorbell ring / motion on the source device's own
                 # card, in addition to the hub-level event entity (#173).
                 self._dispatch_event_to_device(event_type, event_data, raw)

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -560,6 +560,25 @@ class TestAsyncUpdateData:
         # `async_request_refresh` whose 10 s cooldown caused the lag.
         coordinator.hass.async_create_task.assert_called_once()
 
+    def test_request_security_snapshot_refresh_public_nudge(self) -> None:
+        """The snapshot nudge must be callable on its own (#284/#287): the FCM
+        event path needs the same forced-snapshot + dedicated-debouncer combo
+        the HTS 0x08 handler uses, without faking an HTS event. A scenario /
+        keypad / fob action can flip several groups at once plus
+        `night_mode_enabled` — state only `get_space_snapshot` carries, which
+        a push event alone never refreshes (wip3out3r's group panel lagged
+        ~9 minutes on a scenario-driven arm).
+        """
+        coordinator = _make_coordinator()
+        coordinator._security_refresh_debouncer = MagicMock()
+        coordinator.hass = MagicMock()
+
+        coordinator.request_security_snapshot_refresh()
+
+        coordinator._security_refresh_debouncer.async_call.assert_called_once()
+        assert coordinator._force_snapshot_refresh is True
+        coordinator.hass.async_create_task.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_update_data_raises_update_failed_on_error(self) -> None:
         from homeassistant.helpers.update_coordinator import UpdateFailed

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -2013,6 +2013,59 @@ class TestParseAndFireEventLogging:
             for r in caplog.records
         )
 
+
+class TestSecurityEventSnapshotNudge:
+    """FCM security events must nudge the snapshot-backed re-read (#284/#287).
+
+    `apply_push_security_state` keeps the space panel instant, but a scenario /
+    keypad / fob action can flip several groups at once plus
+    `night_mode_enabled` — state only `get_space_snapshot` carries. Before this
+    nudge, only the HTS 0x08 path forced the snapshot, so on push-only signals
+    the group panels lagged until the hourly snapshot (~9 min observed on a
+    scenario-driven arm, wip3out3r in #287).
+    """
+
+    def _make_listener(self) -> AjaxNotificationListener:
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.is_running.return_value = True
+        hass.loop.call_soon_threadsafe.side_effect = lambda cb, *a: cb(*a)
+        coordinator = MagicMock()
+        coordinator._space_ids = []
+        return AjaxNotificationListener(hass=hass, coordinator=coordinator, **_FCM_KWARGS)
+
+    def _fire(self, listener: AjaxNotificationListener, event_type: str, raw_tag: str) -> None:
+        encoded = base64.b64encode(b"any-payload").decode()
+        with (
+            patch.object(
+                listener,
+                "_extract_event_from_proto",
+                return_value=(event_type, {"raw_tag": raw_tag}),
+            ),
+            patch.object(listener, "_extract_source_info", return_value={}),
+            patch.object(listener, "_find_space_for_event", return_value="space-1"),
+        ):
+            listener._parse_and_fire_event(encoded)
+
+    def test_arm_event_nudges_snapshot_refresh(self) -> None:
+        listener = self._make_listener()
+        self._fire(listener, "arm", "arm")
+        listener._coordinator.request_security_snapshot_refresh.assert_called_once()
+
+    def test_all_security_event_types_nudge(self) -> None:
+        from custom_components.aegis_ajax.const import SECURITY_STATE_EVENT_TYPES
+
+        assert {"arm", "disarm", "arm_night", "disarm_night"} == SECURITY_STATE_EVENT_TYPES
+        for event_type in sorted(SECURITY_STATE_EVENT_TYPES):
+            listener = self._make_listener()
+            self._fire(listener, event_type, "whatever_tag")
+            listener._coordinator.request_security_snapshot_refresh.assert_called_once()
+
+    def test_non_security_event_does_not_nudge(self) -> None:
+        listener = self._make_listener()
+        self._fire(listener, "doorbell_pressed", "doorbell_press")
+        listener._coordinator.request_security_snapshot_refresh.assert_not_called()
+
     def test_group_event_without_group_id_logs_warning_with_hex(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
## Context

References #284 and #287 (wip3out3r's scenario datapoint). Companion to #294 — together they cover all three confirmed origins of the group-panel lag.

## Root cause

`apply_push_security_state` keeps the space panel instant, but a push tells (at most) one group's new state. A scenario / keypad / fob action can flip several groups at once plus `night_mode_enabled` — state only the heavier `get_space_snapshot` carries. Only the HTS 0x08 event path forced that snapshot read; on push-only signals the group panels lagged until the hourly snapshot (wip3out3r measured ~9 minutes on a scenario-driven group arm).

## Changes

- Extract the HTS handler's forced-snapshot + dedicated-debouncer combo into `coordinator.request_security_snapshot_refresh()` (public, documented).
- Call it from the FCM event path for every security-state `event_type` (`arm`, `disarm`, `arm_night`, `disarm_night` — new `SECURITY_STATE_EVENT_TYPES` in const). Marshaled to the loop like every other FCM-thread dispatch.

Cost: one debounced `get_space_snapshot` per security action (1 s cooldown debouncer, same as the HTS path).

## Verification

- Unit tests: the public nudge sets the one-shot snapshot flag and routes through the dedicated debouncer (not the shared 10 s one); every security event_type nudges; non-security events (doorbell) don't.
- Full `make check` in Docker (no volume mount): all green.
- Live verification: wip3out3r's nightly scenario on the next beta should show the group panel settling in ~1-2 s instead of ~9 min.