### PR TITLE
fix(coordinator): follow keypad full-arm of a group via STATUS_UPDATE arm flag (#284)

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -240,6 +240,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # device + experimental "Active" sensor per entry, added at runtime via
         # the `SIGNAL_NEW_DEVICE` dispatcher as keyfobs are discovered.
         self.keyfobs: dict[str, Keyfob] = {}
+        # Last-seen arm flag (HTS sub-key 0x06) per hub-internal space-security
+        # object (00000001/00000002…). A keypad full-arm of a group reaches us
+        # only as a STATUS_UPDATE flip of this flag — no type=0x08 space event
+        # and no FCM push on no-FCM installs (#284) — so a *change* nudges the
+        # authoritative re-read. Tracking the last value avoids re-nudging on
+        # every 60s STATUS_BODY probe (which re-reports the same flag).
+        self._space_security_arm_flags: dict[str, int] = {}
         # One-shot guard for the #206 Bug-B SmartLock id probe (DEBUG-only).
         self._smart_lock_probe_done = False
         # Per-space monotonic timestamp of when the hub first reported
@@ -845,6 +852,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         device = self.devices.get(device_id_hex)
         if device is None:
+            # A hub-internal space/group security object reporting an arm-flag
+            # transition (#284) — nudge the authoritative re-read. Checked before
+            # the keyfob path because these objects are never keyfobs.
+            if self._maybe_nudge_space_security(hub_id, device_id_hex, kv):
+                return
             # Not a gRPC-modeled device — it may be a SpaceControl keyfob, which
             # only ever appears in the HTS SETTINGS_BODY (never in the gRPC
             # snapshot). Classify and surface it; everything else (users,
@@ -870,6 +882,53 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.device_readings[device_id_hex] = readings
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         _ = hub_id  # currently unused; kept in the signature for symmetry with on_state_update
+
+    def _maybe_nudge_space_security(
+        self, hub_id: str, device_id_hex: str, kv: dict[int, bytes]
+    ) -> bool:
+        """Nudge the authoritative re-read on a space-security arm-flag flip (#284).
+
+        Hub-internal space/group security objects use low reserved ids
+        (00000001..0000000F — six leading zero nibbles, unlike a real Jeweller
+        device's random id or a keyfob's 2A.. id) and report the space/group arm
+        state on HTS sub-key 0x06 (01 armed / 00 disarmed). A keypad full-arm of a
+        group is delivered ONLY as a STATUS_UPDATE flip of this flag: it emits no
+        type=0x08 space event (which app arm and keypad night/disarm do) and no FCM
+        push on no-FCM installs, so without this the central panel sat on its stale
+        state until the 300s poll.
+
+        Returns True when the row is a space-security object — handled here, so the
+        caller skips the keyfob path (these objects are never keyfobs). Only a
+        *change* of the flag nudges; the first sighting (the boot snapshot is
+        already authoritative) and an unchanged flag (re-reported on every 60s
+        STATUS_BODY probe) do not, so the snapshot keeps its hourly cadence. The
+        flag is never decoded into the panel — same rationale as
+        `_on_hts_space_event`: it's a nudge to re-read ground truth, not a state.
+
+        Runs on the event loop (HTS listen task).
+        """
+        if (
+            len(device_id_hex) != 8
+            or not device_id_hex.startswith("000000")
+            or device_id_hex == "00000000"
+            or 0x06 not in kv
+            or not kv[0x06]
+        ):
+            return False
+        arm = kv[0x06][0]
+        previous = self._space_security_arm_flags.get(device_id_hex)
+        self._space_security_arm_flags[device_id_hex] = arm
+        if previous is not None and previous != arm:
+            _LOGGER.debug(
+                "Space security object %s arm flag 0x06 %02X->%02X on hub %s: "
+                "requesting authoritative refresh",
+                device_id_hex,
+                previous,
+                arm,
+                hub_id,
+            )
+            self.request_security_snapshot_refresh()
+        return True
 
     def _maybe_apply_hts_device_temperature(
         self, device_id_hex: str, device: Device, kv: dict[int, bytes]

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2788,6 +2788,74 @@ class TestOnHtsDeviceKvKeyfob:
         mock_send.assert_not_called()
 
 
+class TestOnHtsDeviceKvSpaceSecurity:
+    """#284: keypad full-arm of a group reaches us only as a STATUS_UPDATE arm-flag
+    flip on a hub-internal space-security object (00000001/00000002) — no type=0x08
+    space event, and no FCM push on no-FCM installs. A *change* in the 0x06 arm flag
+    must nudge the authoritative re-read so the central panel follows; an unchanged
+    flag (re-reported on every 60s STATUS_BODY probe) must NOT, or it would force a
+    snapshot every cycle and defeat the hourly cadence.
+    """
+
+    def test_arm_flag_change_nudges_authoritative_refresh(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._security_refresh_debouncer = MagicMock()
+        # Boot/poll already saw the disarmed flag; seed it so the next is a change.
+        coordinator._on_hts_device_kv("002CA005", "00000001", {0x06: b"\x00"})
+        coordinator._force_snapshot_refresh = False
+        # Keypad full-arm: 0x06 flips 0 -> 1 in a lone STATUS_UPDATE delta.
+        coordinator._on_hts_device_kv("002CA005", "00000001", {0x06: b"\x01"})
+        assert coordinator._force_snapshot_refresh is True
+        coordinator._security_refresh_debouncer.async_call.assert_called_once()
+
+    def test_disarm_flag_change_nudges_authoritative_refresh(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._security_refresh_debouncer = MagicMock()
+        coordinator._on_hts_device_kv("002CA005", "00000002", {0x06: b"\x01"})
+        coordinator._force_snapshot_refresh = False
+        coordinator._on_hts_device_kv("002CA005", "00000002", {0x06: b"\x00"})
+        assert coordinator._force_snapshot_refresh is True
+
+    def test_first_sighting_does_not_nudge(self) -> None:
+        # The initial snapshot is already authoritative — the first time we see the
+        # flag (boot STATUS_BODY) must not force a redundant refresh.
+        coordinator = _make_coordinator()
+        coordinator._security_refresh_debouncer = MagicMock()
+        coordinator._on_hts_device_kv("002CA005", "00000001", {0x06: b"\x01"})
+        assert coordinator._force_snapshot_refresh is False
+        coordinator._security_refresh_debouncer.async_call.assert_not_called()
+
+    def test_unchanged_arm_flag_does_not_nudge(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._security_refresh_debouncer = MagicMock()
+        coordinator._on_hts_device_kv("002CA005", "00000001", {0x06: b"\x01"})
+        coordinator._force_snapshot_refresh = False
+        # 60s STATUS_BODY probe re-reports the same flag.
+        coordinator._on_hts_device_kv("002CA005", "00000001", {0x06: b"\x01"})
+        assert coordinator._force_snapshot_refresh is False
+        coordinator._security_refresh_debouncer.async_call.assert_not_called()
+
+    def test_space_security_object_not_treated_as_keyfob(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator._security_refresh_debouncer = MagicMock()
+        coordinator.async_set_updated_data = MagicMock()
+        with patch("custom_components.aegis_ajax.coordinator.async_dispatcher_send") as mock_send:
+            coordinator._on_hts_device_kv("002CA005", "00000001", {0x06: b"\x00"})
+            coordinator._on_hts_device_kv("002CA005", "00000001", {0x06: b"\x01"})
+        assert coordinator.keyfobs == {}
+        mock_send.assert_not_called()
+
+    def test_real_device_arm_like_byte_does_not_nudge(self) -> None:
+        # A real Jeweller device (random 8-hex id, not 6 leading zeros) reporting a
+        # 0x06 value must never be mistaken for a space-security object.
+        coordinator = _make_coordinator()
+        coordinator._security_refresh_debouncer = MagicMock()
+        coordinator._on_hts_device_kv("002CA005", "30E3131A", {0x06: b"\x00"})
+        coordinator._on_hts_device_kv("002CA005", "30E3131A", {0x06: b"\x01"})
+        assert coordinator._force_snapshot_refresh is False
+        coordinator._security_refresh_debouncer.async_call.assert_not_called()
+
+
 class TestHtsDeviceTemperature:
     """HTS 0x02 → temperature for gRPC-temp-less device families (#229)."""
 


### PR DESCRIPTION
## Problem (#284, residual)

After the beta.6 fixes, dheuts90's 2026-06-14 debug log shows every keypad/app action updates the central panel **except one**: *Arm Away / Full Arm* of a group via the **Keypad Plus**.

Root cause from the log: that specific action arrives **only** as an HTS `STATUS_UPDATE` flipping sub-key `0x06` on a hub-internal space-security object (`00000001`/`00000002`, `01`=armed / `00`=disarmed). Unlike:
- an **app arm** → emits a `type=0x08` space event → already nudges the authoritative re-read (#258/#294), and
- a **keypad night/disarm** → also converges,

the keypad full-arm emits **no `0x08` event**, and the reporter runs **without FCM**, so nothing triggered a re-read and the panel sat stale until the 300s poll.

## Fix

A *change* of the `0x06` arm flag on those reserved-id objects (six leading zero nibbles — never a real Jeweller device id or a `2A..` keyfob id) now calls the existing `request_security_snapshot_refresh()`.

- Only a **change** nudges. The first sighting (boot snapshot is already authoritative) and an **unchanged** flag (re-reported on every 60s `STATUS_BODY` probe) do **not** — otherwise the snapshot would fire every cycle and defeat the hourly cadence.
- The flag is **never decoded** into the panel — same nudge-don't-trust rationale as the `0x08` path (`_on_hts_space_event`): re-read ground truth, never sit on a decoded-but-wrong state.
- Checked before the keyfob path (these objects are never keyfobs).

## Tests

New `TestOnHtsDeviceKvSpaceSecurity` (6 cases, TDD): arm flip nudges, disarm flip nudges, first sighting doesn't, unchanged doesn't, object isn't treated as a keyfob, and a real device with a `0x06` byte never nudges. Full suite green (1719 passed, 89.12% cov), lint/format/typecheck/dead-code clean.

Refs #284