### PR TITLE
fix(video): dedupe NVR-republished doorbell/camera channels (#290)

### DIFF
--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -263,6 +263,7 @@ _VIDEO_EDGE_TYPE_MAP: dict[int, str] = {
 # `_dedupe_video_doorbells` below.
 _MOTION_CAM_VIDEO_HUB_PREFIX = "motion_cam_video_"
 _VIDEO_EDGE_PREFIX = "video_edge_"
+_VIDEO_EDGE_NVR = "video_edge_nvr"
 
 
 def _parse_device_state(states: Any) -> DeviceState:  # noqa: ANN401
@@ -620,6 +621,56 @@ def _dedupe_video_doorbells(devices: list[Device]) -> tuple[list[Device], dict[s
                 d.id,
                 d.device_type,
                 sibling_id,
+            )
+            continue
+        result.append(d)
+
+    # Second pass (#290): an Ajax NVR re-publishes an existing camera/doorbell
+    # channel as its own `video_edge_nvr` device, so the one physical device
+    # surfaces twice. The republished twin carries no sensors and no doorbell
+    # `event` entity, yet doorbell/motion pushes attribute to it (its id is the
+    # composite NVR channel id the push carries) — so the activity lands on a
+    # bare card. Drop the republish and alias its id to the primary channel.
+    result, nvr_aliases = _dedupe_nvr_republished_channels(result)
+    aliases.update(nvr_aliases)
+    return result, aliases
+
+
+def _dedupe_nvr_republished_channels(
+    devices: list[Device],
+) -> tuple[list[Device], dict[str, str]]:
+    """Drop `video_edge_nvr` devices that merely re-publish a primary channel.
+
+    The linkage is the primary channel's `video_sources` (#291): it lists an
+    `nvr` source whose `channel_id` equals the NVR twin's device id. A genuine
+    NVR-native channel (one no primary references) is left untouched.
+
+    Returns the filtered list plus `{dropped nvr id: primary id}` so the
+    doorbell/motion push that currently lands on the NVR twin resolves onto the
+    primary device that owns the sensors. Only the channel id is aliased — the
+    NVR's `video_edge_id` is shared across all its republished channels, so it
+    can't disambiguate which primary a push belongs to.
+    """
+    nvr_channel_to_primary: dict[str, str] = {}
+    for d in devices:
+        if not d.device_type.startswith(_VIDEO_EDGE_PREFIX) or d.device_type == _VIDEO_EDGE_NVR:
+            continue
+        for source in d.statuses.get("video_sources", []):
+            if source.get("kind") == "nvr" and source.get("channel_id"):
+                nvr_channel_to_primary[source["channel_id"]] = d.id
+
+    result: list[Device] = []
+    aliases: dict[str, str] = {}
+    for d in devices:
+        primary_id = nvr_channel_to_primary.get(d.id)
+        if d.device_type == _VIDEO_EDGE_NVR and primary_id is not None:
+            aliases[d.id] = primary_id
+            _LOGGER.debug(
+                "Dropping NVR-republished video channel %s (%s) — re-publishes "
+                "primary channel %s in this snapshot (#290); aliasing pushes to it",
+                d.id,
+                d.device_type,
+                primary_id,
             )
             continue
         result.append(d)

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1322,6 +1322,113 @@ class TestDeduplicateVideoDoorbells:
         assert api.doorbell_twin_aliases == {}
 
 
+class TestDeduplicateNvrRepublishedChannels:
+    """Issue #290: adding an Ajax NVR makes it re-publish an existing
+    camera/doorbell channel as its own `video_edge_nvr` device, so the one
+    physical device appears twice. The republished `video_edge_nvr` twin
+    carries no sensors and no doorbell `event` entity, yet the doorbell/motion
+    pushes attribute to it — so after the #291 type-mapping the activity
+    vanished entirely (brunovdw68). Drop the NVR republish and alias its id to
+    the primary channel (the one with the sensors) so pushes land there.
+
+    The linkage is the primary channel's `video_sources`: it lists an `nvr`
+    source whose `channel_id` equals the NVR twin's device id."""
+
+    @staticmethod
+    def _make(
+        device_id: str,
+        name: str,
+        device_type: str,
+        *,
+        video_sources: list[dict[str, object]] | None = None,
+    ) -> Device:
+        statuses: dict[str, object] = {}
+        if video_sources is not None:
+            statuses["video_sources"] = video_sources
+        return Device(
+            id=device_id,
+            hub_id="hub-1",
+            name=name,
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses=statuses,
+            battery=None,
+        )
+
+    # The exact shape from brunovdw68's diagnostics (#290): one doorbell, both
+    # the primary channel and the NVR republish carry the same source list.
+    _SOURCES = [
+        {"kind": "primary", "video_edge_id": "310A8DF4", "channel_id": "9c756e2bca39-0", "type": 5},
+        {
+            "kind": "nvr",
+            "video_edge_id": "310B121D",
+            "channel_id": "gRdWkZna2l-9c756e2bca39-0",
+            "type": 7,
+        },
+    ]
+
+    def test_drops_nvr_channel_republishing_a_primary(self) -> None:
+        primary = self._make(
+            "9c756e2bca39-0", "Deurbel", "video_edge_doorbell", video_sources=self._SOURCES
+        )
+        nvr_twin = self._make(
+            "gRdWkZna2l-9c756e2bca39-0", "Deurbel", "video_edge_nvr", video_sources=self._SOURCES
+        )
+        deduped = DevicesApi._dedupe_video_doorbells([primary, nvr_twin])
+        assert [d.id for d in deduped] == ["9c756e2bca39-0"]
+
+    def test_aliases_nvr_channel_id_to_primary(self) -> None:
+        """The dropped NVR twin's id is aliased to the surviving primary so the
+        doorbell/motion push (which lands on the NVR twin id) resolves to the
+        device that actually owns the sensors."""
+        primary = self._make(
+            "9c756e2bca39-0", "Deurbel", "video_edge_doorbell", video_sources=self._SOURCES
+        )
+        nvr_twin = self._make(
+            "gRdWkZna2l-9c756e2bca39-0", "Deurbel", "video_edge_nvr", video_sources=self._SOURCES
+        )
+        api = DevicesApi(MagicMock())
+
+        deduped = api._dedupe_and_track_aliases([primary, nvr_twin])
+
+        assert [d.id for d in deduped] == ["9c756e2bca39-0"]
+        assert api.doorbell_twin_aliases == {"gRdWkZna2l-9c756e2bca39-0": "9c756e2bca39-0"}
+
+    def test_keeps_standalone_nvr_channel_not_republishing(self) -> None:
+        """A genuine NVR-native channel (no primary lists it as an `nvr`
+        source) must be kept — only republished duplicates get dropped."""
+        native = self._make("nvr-cam-7", "Garage Cam", "video_edge_nvr")
+        deduped = DevicesApi._dedupe_video_doorbells([native])
+        assert [d.id for d in deduped] == ["nvr-cam-7"]
+
+    def test_bullet_and_doorbell_both_deduped(self) -> None:
+        """One NVR republishes several channels; each republish is matched to
+        its own primary and dropped."""
+        door_sources = self._SOURCES
+        bullet_sources = [
+            {"kind": "primary", "video_edge_id": "310C0001", "channel_id": "bullet-0", "type": 4},
+            {"kind": "nvr", "video_edge_id": "310B121D", "channel_id": "nvr-bullet-0", "type": 7},
+        ]
+        door = self._make(
+            "9c756e2bca39-0", "Deurbel", "video_edge_doorbell", video_sources=door_sources
+        )
+        door_nvr = self._make(
+            "gRdWkZna2l-9c756e2bca39-0", "Deurbel", "video_edge_nvr", video_sources=door_sources
+        )
+        bullet = self._make(
+            "bullet-0", "BulletCam", "video_edge_bullet", video_sources=bullet_sources
+        )
+        bullet_nvr = self._make(
+            "nvr-bullet-0", "BulletCam", "video_edge_nvr", video_sources=bullet_sources
+        )
+        deduped = DevicesApi._dedupe_video_doorbells([door, door_nvr, bullet, bullet_nvr])
+        assert {d.id for d in deduped} == {"9c756e2bca39-0", "bullet-0"}
+
+
 class TestDevicesApiInit:
     def test_init(self) -> None:
         client = MagicMock()


### PR DESCRIPTION
## Summary
Fixes the duplicate doorbell/camera device that appears after adding an Ajax NVR (#290), and restores the doorbell/motion activity that vanished with it.

## Root cause
An Ajax NVR re-publishes an existing camera/doorbell channel as its own `video_edge_nvr` device, so the one physical device surfaces twice. The republished twin has no sensors and no doorbell `event` entity, yet doorbell/motion pushes attribute to it (its id is the composite NVR channel id the push carries). Before #291 the twin was `video_edge_unknown` (which *is* in the binary-sensor map, so it showed activity); after #291 mapped it to `video_edge_nvr` (not in the map), the activity disappeared entirely while the primary doorbell — which owns the sensors — never received the push.

Confirmed from brunovdw68's v1.11.4 diagnostics: `Deurbel` exists as `video_edge_doorbell` (id `9c756e2bca39-0`) **and** `video_edge_nvr` (id `gRdWkZna2l-9c756e2bca39-0`), both carrying the same `video_sources` list that links them.

## Fix
A second dedup pass keyed on the primary channel's `video_sources` (the linkage added in #291): when an `nvr` source's `channel_id` equals a `video_edge_nvr` device's id, that device is a republish — drop it and alias its id to the primary, so pushes resolve onto the device with the sensors. A genuine NVR-native channel (one no primary references) is left untouched. Only the channel id is aliased; the NVR's `video_edge_id` is shared across all its republished channels and can't disambiguate.

## Tests
- New `TestDeduplicateNvrRepublishedChannels` (drop+alias, standalone-NVR kept, multi-channel NVR) using the exact diagnostics shape.
- Existing `TestDeduplicateVideoDoorbells` (hub_device twin pass) unchanged and green.
- Full suite: 1723 passed.

Refs #290, #282