### PR TITLE
feat(diagnostics): probe VideoEdge ONVIF/RTSP settings (#282)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -285,6 +285,59 @@ class DevicesApi:
                 break
         return None
 
+    async def get_video_edge_onvif_rtsp_settings(
+        self, space_id: str, video_edge_id: str
+    ) -> dict[str, Any] | None:
+        """Read a VideoEdge's ONVIF/RTSP settings for diagnostics (#282).
+
+        Wraps `GetVideoEdgeOnvifAndRtspSettingsService.execute`. This is the
+        most realistic first step toward a real `camera` entity: it reports
+        whether ONVIF/RTSP are reachable and on which ports, so a diagnostics
+        dump shows what's available (the stream itself is local RTSP/ONVIF,
+        not carried over gRPC). Returns a flat, **PII-free** dict — ports, the
+        auth flag and the user *count*, never usernames. Never raises: a probe
+        failure (offline VideoEdge, ONVIF disabled, RPC error) is reported as
+        an ``{"error": reason}`` dict so it can't break diagnostics generation.
+        """
+        from v3.mobilegwsvc.service.get_video_edge_onvif_and_rtsp_settings import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.GetVideoEdgeOnvifAndRtspSettingsServiceStub(channel)
+        request = request_pb2.GetVideoEdgeOnvifAndRtspSettingsRequest(
+            space_id=space_id,
+            video_edge_id=video_edge_id,
+        )
+        try:
+            response = await stub.execute(request, metadata=metadata, timeout=15)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "GetVideoEdgeOnvifAndRtspSettings RPC failed for video_edge %s",
+                video_edge_id,
+                exc_info=True,
+            )
+            return {"error": "rpc_error"}
+
+        which = response.WhichOneof("response") if hasattr(response, "WhichOneof") else None
+        if which != "success":
+            reason = response.failure.WhichOneof("error") if which == "failure" else None
+            return {"error": reason or which or "unknown"}
+
+        onvif = response.success.onvif_settings
+        rtsp = response.success.rtsp_settings
+        return {
+            "onvif": {
+                "user_auth_enabled": onvif.user_auth_enabled,
+                "http_port": onvif.http_port,
+                "max_users_number": onvif.max_users_number,
+                "users_count": len(onvif.users),
+            },
+            "rtsp": {"http_port": rtsp.http_port},
+        }
+
     def _handle_update(
         self,
         update: Any,  # noqa: ANN401

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -32,6 +32,33 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data
+
+    # Probe the VideoEdge ONVIF/RTSP settings for each distinct video_edge_id
+    # seen across the devices' source lists (#282). Read-only and best-effort:
+    # it maps what's available towards a real camera entity without affecting
+    # normal operation. Skipped entirely when there are no video devices.
+    video_edge_kinds: dict[str, set[str]] = {}
+    for device in coordinator.devices.values():
+        for source in device.statuses.get("video_sources", []):
+            ve_id = source.get("video_edge_id")
+            if ve_id:
+                video_edge_kinds.setdefault(ve_id, set()).add(source.get("kind"))
+
+    video_edge_probe: dict[str, Any] = {}
+    for ve_id, kinds in video_edge_kinds.items():
+        settings: dict[str, Any] | None = None
+        for space_id in coordinator.spaces:
+            settings = await coordinator.devices_api.get_video_edge_onvif_rtsp_settings(
+                space_id, ve_id
+            )
+            # Stop at the space that actually owns this VideoEdge.
+            if settings is not None and "error" not in settings:
+                break
+        video_edge_probe[ve_id] = {
+            "kinds": sorted(k for k in kinds if k),
+            **(settings or {"error": "not_probed"}),
+        }
+
     return {
         "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
         "spaces": {
@@ -93,6 +120,7 @@ async def async_get_config_entry_diagnostics(
             }
             for kid, k in coordinator.keyfobs.items()
         },
+        "video_edge_onvif_rtsp": video_edge_probe,
         "stream_tasks": len(coordinator._stream_tasks),
         "notification_listener": coordinator.notification_listener is not None,
     }

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1429,6 +1429,118 @@ class TestDeduplicateNvrRepublishedChannels:
         assert {d.id for d in deduped} == {"9c756e2bca39-0", "bullet-0"}
 
 
+class TestVideoEdgeOnvifRtspProbe:
+    """Issue #282: a diagnostic read of the VideoEdge ONVIF/RTSP settings, so
+    we can map what's available towards a real camera entity. Returns a flat,
+    PII-free dict (ports, auth flag, user *count*) for the diagnostics dump —
+    never raises, so a probe failure can't break diagnostics generation."""
+
+    @staticmethod
+    def _make_api() -> DevicesApi:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        return DevicesApi(client)
+
+    @pytest.mark.asyncio
+    async def test_success_returns_flat_settings(self) -> None:
+        from v3.mobilegwsvc.commonmodels.video.videoedge.onvif import (
+            onvif_settings_pb2,
+            onvif_user_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.rtsp import rtsp_settings_pb2
+        from v3.mobilegwsvc.service.get_video_edge_onvif_and_rtsp_settings import (
+            endpoint_pb2_grpc,
+            request_pb2,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        ok = response_pb2.GetVideoEdgeOnvifAndRtspSettingsResponse(
+            success=response_pb2.GetVideoEdgeOnvifAndRtspSettingsResponse.Success(
+                onvif_settings=onvif_settings_pb2.OnvifSettings(
+                    user_auth_enabled=True,
+                    http_port=8000,
+                    max_users_number=8,
+                    users=[onvif_user_pb2.OnvifUser(), onvif_user_pb2.OnvifUser()],
+                ),
+                rtsp_settings=rtsp_settings_pb2.RtspSettings(http_port=554),
+            )
+        )
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                async def _execute(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return ok
+
+                self.execute = AsyncMock(side_effect=_execute)
+
+        with patch.object(
+            endpoint_pb2_grpc, "GetVideoEdgeOnvifAndRtspSettingsServiceStub", _StubFactory
+        ):
+            result = await api.get_video_edge_onvif_rtsp_settings("space-1", "310A8DF4")
+
+        assert isinstance(captured[0], request_pb2.GetVideoEdgeOnvifAndRtspSettingsRequest)
+        assert captured[0].space_id == "space-1"
+        assert captured[0].video_edge_id == "310A8DF4"
+        assert result == {
+            "onvif": {
+                "user_auth_enabled": True,
+                "http_port": 8000,
+                "max_users_number": 8,
+                "users_count": 2,
+            },
+            "rtsp": {"http_port": 554},
+        }
+
+    @pytest.mark.asyncio
+    async def test_failure_response_reports_error_reason(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.get_video_edge_onvif_and_rtsp_settings import (
+            endpoint_pb2_grpc,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        failure = response_pb2.GetVideoEdgeOnvifAndRtspSettingsResponse(
+            failure=response_pb2.GetVideoEdgeOnvifAndRtspSettingsResponse.Failure(
+                video_edge_is_offline=common_response_pb2.Error(),
+            )
+        )
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.execute = AsyncMock(return_value=failure)
+
+        with patch.object(
+            endpoint_pb2_grpc, "GetVideoEdgeOnvifAndRtspSettingsServiceStub", _StubFactory
+        ):
+            result = await api.get_video_edge_onvif_rtsp_settings("space-1", "310B121D")
+
+        assert result == {"error": "video_edge_is_offline"}
+
+    @pytest.mark.asyncio
+    async def test_rpc_exception_reports_error_not_raises(self) -> None:
+        from v3.mobilegwsvc.service.get_video_edge_onvif_and_rtsp_settings import (
+            endpoint_pb2_grpc,
+        )
+
+        api = self._make_api()
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.execute = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch.object(
+            endpoint_pb2_grpc, "GetVideoEdgeOnvifAndRtspSettingsServiceStub", _StubFactory
+        ):
+            result = await api.get_video_edge_onvif_rtsp_settings("space-1", "310A8DF4")
+
+        assert result == {"error": "rpc_error"}
+
+
 class TestDevicesApiInit:
     def test_init(self) -> None:
         client = MagicMock()

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -68,6 +68,9 @@ class TestAsyncGetConfigEntryDiagnostics:
         coord.devices = {"dev-1": _make_device()}
         coord._stream_tasks = [MagicMock(), MagicMock()]
         coord.notification_listener = MagicMock()
+        # The ONVIF/RTSP probe (#282) is only called for video_edge devices;
+        # default it to a no-op so non-video fixtures don't await a MagicMock.
+        coord.devices_api.get_video_edge_onvif_rtsp_settings = AsyncMock(return_value=None)
         return coord
 
     @pytest.fixture
@@ -154,6 +157,37 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert dev_info["video_sources"] == [
             {"kind": "nvr", "video_edge_id": "ve-nvr", "channel_id": "3", "type": 7}
         ]
+
+    @pytest.mark.asyncio
+    async def test_video_edge_onvif_rtsp_probe_included(self, entry: MagicMock) -> None:
+        # #282: diagnostics probes the VideoEdge ONVIF/RTSP settings for each
+        # distinct video_edge_id seen across the devices' source lists, so a
+        # dump shows what's available towards a camera entity. Keyed by
+        # video_edge_id, with the probe result (and the kinds it appears as).
+        from dataclasses import replace
+
+        device = replace(
+            _make_device(did="cam-1"),
+            statuses={
+                "video_sources": [
+                    {"kind": "primary", "video_edge_id": "310A8DF4", "channel_id": "0", "type": 5},
+                    {"kind": "nvr", "video_edge_id": "310B121D", "channel_id": "x-0", "type": 7},
+                ],
+            },
+        )
+        entry.runtime_data.devices = {"cam-1": device}
+        entry.runtime_data.devices_api.get_video_edge_onvif_rtsp_settings = AsyncMock(
+            return_value={"onvif": {"http_port": 8000}, "rtsp": {"http_port": 554}}
+        )
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        probe = result["video_edge_onvif_rtsp"]
+        assert set(probe) == {"310A8DF4", "310B121D"}
+        assert probe["310A8DF4"]["onvif"] == {"http_port": 8000}
+        assert probe["310A8DF4"]["rtsp"] == {"http_port": 554}
+        assert sorted(probe["310A8DF4"]["kinds"]) == ["primary"]
+        assert sorted(probe["310B121D"]["kinds"]) == ["nvr"]
 
     @pytest.mark.asyncio
     async def test_non_video_device_omits_video_keys(self, entry: MagicMock) -> None:


### PR DESCRIPTION
## Summary
First concrete step on the video-support exploration (#282): a diagnostics-only probe that reads each VideoEdge's ONVIF/RTSP settings, so we can map what's actually available towards a real `camera` entity.

The `video_edge_id` the request needs is now known — it's surfaced in the channel source list added in #291 (the same data that fixed the #290 duplicate).

## What it does
- For each distinct `video_edge_id` seen across the devices' `video_sources`, calls `GetVideoEdgeOnvifAndRtspSettingsService` and records the result in diagnostics under `video_edge_onvif_rtsp`, keyed by id.
- Reports **ports, the ONVIF auth flag and the user *count*** — PII-free, never usernames.
- **Never raises**: an offline VideoEdge / disabled ONVIF / RPC error is recorded as `{"error": reason}`, so the probe can't break diagnostics generation.
- Skipped entirely when there are no video devices.

## What it does NOT do
The actual stream is local RTSP/ONVIF (not carried over gRPC), and the response gives ports + auth, not a full URL/credentials/LAN IP. So this maps **feasibility** — it does not create a camera entity. Next step depends on what the dump shows once a reporter enables ONVIF.

## Tests
- `TestVideoEdgeOnvifRtspProbe`: success (flat PII-free dict), failure-response (`{error: reason}`), RPC-exception (no raise).
- `test_video_edge_onvif_rtsp_probe_included` in diagnostics.
- Full suite: 1727 passed.

Refs #282