### PR TITLE
fix(video): attribute motion to NVR-bridged cameras via primary video_edge_id (#290)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -193,9 +193,13 @@ class DevicesApi:
         return devices_parser._dedupe_video_doorbells(devices)[0]
 
     def _dedupe_and_track_aliases(self, devices: list[Device]) -> list[Device]:
-        """Dedupe video-doorbell twins and record the twin→sibling alias map
-        (#173) so doorbell/motion pushes carrying the twin id still resolve."""
+        """Dedupe video-doorbell twins and record the alias maps so
+        doorbell/motion pushes resolve onto the device the user sees:
+        the #173 twin→sibling map, the #290 NVR-republish map, and each
+        video_edge device's primary video_edge_id → channel-id key (#290
+        motion — the id a push actually carries)."""
         deduped, aliases = devices_parser._dedupe_video_doorbells(devices)
+        aliases.update(devices_parser._video_edge_push_aliases(deduped))
         self.doorbell_twin_aliases.update(aliases)
         return deduped
 

--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -636,6 +636,34 @@ def _dedupe_video_doorbells(devices: list[Device]) -> tuple[list[Device], dict[s
     return result, aliases
 
 
+def _video_edge_push_aliases(devices: list[Device]) -> dict[str, str]:
+    """Map each video_edge device's primary `video_edge_id` to its device id.
+
+    A doorbell-ring / motion push carries the source's Jeweller hardware id,
+    which for a video_edge device is its *primary* `video_edge_id` — not the
+    MAC-style `channel_id` the device is keyed on. On an NVR-bridged camera
+    there's no `hub_device` twin, so the #173 twin→sibling alias is never
+    created and the push id resolves to nothing: the ring survives on the
+    single-doorbell fallback, but motion (which has no fallback) is lost.
+    Aliasing the primary `video_edge_id` to the device id fixes both (#290).
+
+    Only the `primary` source is used — the `nvr` source's `video_edge_id` is
+    the recorder's, shared across every channel it republishes, so it can't
+    identify a single camera.
+    """
+    aliases: dict[str, str] = {}
+    for d in devices:
+        if not d.device_type.startswith(_VIDEO_EDGE_PREFIX):
+            continue
+        for source in d.statuses.get("video_sources", []):
+            if source.get("kind") == "primary":
+                ve_id = source.get("video_edge_id")
+                if ve_id and ve_id != d.id:
+                    aliases[ve_id] = d.id
+                break
+    return aliases
+
+
 def _dedupe_nvr_republished_channels(
     devices: list[Device],
 ) -> tuple[list[Device], dict[str, str]]:

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1396,7 +1396,12 @@ class TestDeduplicateNvrRepublishedChannels:
         deduped = api._dedupe_and_track_aliases([primary, nvr_twin])
 
         assert [d.id for d in deduped] == ["9c756e2bca39-0"]
-        assert api.doorbell_twin_aliases == {"gRdWkZna2l-9c756e2bca39-0": "9c756e2bca39-0"}
+        # The dropped NVR channel id aliases to the primary, AND the primary's
+        # own video_edge_id aliases to its channel-id key (#290 motion fix).
+        assert api.doorbell_twin_aliases == {
+            "gRdWkZna2l-9c756e2bca39-0": "9c756e2bca39-0",
+            "310A8DF4": "9c756e2bca39-0",
+        }
 
     def test_keeps_standalone_nvr_channel_not_republishing(self) -> None:
         """A genuine NVR-native channel (no primary lists it as an `nvr`
@@ -1427,6 +1432,94 @@ class TestDeduplicateNvrRepublishedChannels:
         )
         deduped = DevicesApi._dedupe_video_doorbells([door, door_nvr, bullet, bullet_nvr])
         assert {d.id for d in deduped} == {"9c756e2bca39-0", "bullet-0"}
+
+
+class TestVideoEdgePushAliases:
+    """Issue #290 (motion): a doorbell/motion push carries the source's
+    Jeweller hardware id, which for a video_edge device is its *primary*
+    `video_edge_id` — NOT the MAC-style `channel_id` the device is keyed on.
+    On an NVR-bridged camera there's no `hub_device` twin, so the #173 dedup
+    alias never gets created and the push id resolves to nothing. The doorbell
+    ring survives on the single-doorbell fallback, but motion (no fallback)
+    is lost. Alias every video_edge device's primary `video_edge_id` to its
+    device id so both resolve directly."""
+
+    @staticmethod
+    def _make(
+        device_id: str,
+        device_type: str,
+        video_sources: list[dict[str, object]] | None = None,
+    ) -> Device:
+        statuses: dict[str, object] = {}
+        if video_sources is not None:
+            statuses["video_sources"] = video_sources
+        return Device(
+            id=device_id,
+            hub_id="hub-1",
+            name="Deurbel",
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses=statuses,
+            battery=None,
+        )
+
+    def test_primary_video_edge_id_aliased_to_device_id(self) -> None:
+        doorbell = self._make(
+            "9c756e2bca39-0",
+            "video_edge_doorbell",
+            video_sources=[
+                {"kind": "primary", "video_edge_id": "310A8DF4", "channel_id": "9c756e2bca39-0"},
+                {"kind": "nvr", "video_edge_id": "310B121D", "channel_id": "gRdWk-9c756e2bca39-0"},
+            ],
+        )
+        api = DevicesApi(MagicMock())
+
+        api._dedupe_and_track_aliases([doorbell])
+
+        assert api.doorbell_twin_aliases.get("310A8DF4") == "9c756e2bca39-0"
+
+    def test_nvr_source_video_edge_id_not_aliased(self) -> None:
+        """The `nvr` source's video_edge_id is the recorder's, shared across all
+        its republished channels — it must not alias to one camera."""
+        doorbell = self._make(
+            "9c756e2bca39-0",
+            "video_edge_doorbell",
+            video_sources=[
+                {"kind": "primary", "video_edge_id": "310A8DF4", "channel_id": "9c756e2bca39-0"},
+                {"kind": "nvr", "video_edge_id": "310B121D", "channel_id": "gRdWk-9c756e2bca39-0"},
+            ],
+        )
+        api = DevicesApi(MagicMock())
+
+        api._dedupe_and_track_aliases([doorbell])
+
+        assert "310B121D" not in api.doorbell_twin_aliases
+
+    def test_no_alias_when_video_edge_id_equals_device_id(self) -> None:
+        doorbell = self._make(
+            "310A8DF4",
+            "video_edge_doorbell",
+            video_sources=[
+                {"kind": "primary", "video_edge_id": "310A8DF4", "channel_id": "310A8DF4"},
+            ],
+        )
+        api = DevicesApi(MagicMock())
+
+        api._dedupe_and_track_aliases([doorbell])
+
+        assert "310A8DF4" not in api.doorbell_twin_aliases
+
+    def test_non_video_device_gets_no_alias(self) -> None:
+        door_sensor = self._make("dp-1", "door_protect_plus")
+        api = DevicesApi(MagicMock())
+
+        api._dedupe_and_track_aliases([door_sensor])
+
+        assert api.doorbell_twin_aliases == {}
 
 
 class TestVideoEdgeOnvifRtspProbe:


### PR DESCRIPTION
## Summary
Fixes the remaining #290 symptom on brunovdw68's v1.11.5-beta.2: after the dedup, the doorbell appears once and the **ring works, but motion still doesn't**.

## Root cause (confirmed from the beta.2 diagnostics)
A doorbell-ring / motion push carries the source's Jeweller hardware id (`HubNotificationSource.id`). For a video_edge device that id is its **primary `video_edge_id`** (e.g. `310A8DF4`), not the MAC-style `channel_id` the device is keyed on (`9c756e2bca39-0`).

On an NVR-bridged camera there is **no `hub_device` twin**, so the #173 twin→sibling alias is never created and the push id resolves to nothing:
- the **ring** survives on the single-doorbell fallback in `notification.py`;
- **motion**, which deliberately has no fallback (the `motion` type is shared with PIR detectors), is lost.

That's exactly the reported asymmetry.

## Fix
Alias every video_edge device's primary `video_edge_id` → its device id, so both ring and motion resolve directly. Only the `primary` source is used — the `nvr` source's `video_edge_id` is the recorder's, shared across every channel it republishes, so it can't identify one camera. `notification.py` already consults `doorbell_twin_aliases` for both event types, so no change there.

## Tests
- New `TestVideoEdgePushAliases` (primary aliased; nvr source not aliased; no self-alias when id==video_edge_id; non-video untouched).
- Updated the NVR-dedup alias test to assert both aliases.
- Full suite: 1731 passed.

Refs #290