### PR TITLE
feat(diagnostics): probe LifeQuality environmental readings (#302)

### DIFF
--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -330,13 +330,30 @@ def _parse_statuses(statuses: Any) -> dict[str, Any]:  # noqa: ANN401
         elif which == "temperature":
             result["temperature"] = status.temperature.value
         elif which == "life_quality":
+            # #302 diagnostic: LifeQuality can also report readings here in the
+            # status oneof (as ints), separately from the float values in
+            # `spread_properties.life_quality_info`. The actual_* fields are
+            # `optional` — guard with HasField, NOT hasattr (always true for a
+            # defined proto field, which would report a phantom 0 for an unset
+            # measurement). Distinct `lq_status_*` keys + the threshold/fault
+            # enums so a single diagnostics dump reveals which path a real
+            # device uses and in what units, before we commit to sensors.
             lq = status.life_quality
-            if hasattr(lq, "actual_temperature"):
-                result["temperature"] = lq.actual_temperature
-            if hasattr(lq, "actual_humidity"):
-                result["humidity"] = lq.actual_humidity
-            if hasattr(lq, "actual_co2"):
-                result["co2"] = lq.actual_co2
+            if lq.HasField("actual_temperature"):
+                result["lq_status_temperature"] = lq.actual_temperature
+            if lq.HasField("actual_humidity"):
+                result["lq_status_humidity"] = lq.actual_humidity
+            if lq.HasField("actual_co2"):
+                result["lq_status_co2"] = lq.actual_co2
+            for key, vals in (
+                ("lq_temperature_statuses", lq.temperature_statuses),
+                ("lq_humidity_statuses", lq.humidity_statuses),
+                ("lq_co2_statuses", lq.co2_statuses),
+                ("lq_hardware_malfunctions", lq.hardware_malfunctions),
+            ):
+                ints = [int(v) for v in vals]
+                if ints:
+                    result[key] = ints
         elif which == "signal_strength":
             signal_int = int(status.signal_strength.device_signal_level)
             result["signal_strength"] = _SIGNAL_LEVEL_MAP.get(signal_int, f"Unknown ({signal_int})")
@@ -502,6 +519,22 @@ def _parse_spread_properties(hub_dev: Any) -> dict[str, Any]:  # noqa: ANN401
             # parsed off `LightDeviceStatus.statuses`).
             if 2 in [int(m) for m in getattr(wsc, "malfunctions", [])]:
                 result[f"valve_ch{channel_id}_stuck"] = True
+        elif which == "life_quality_info":
+            # #302 diagnostic probe: LifeQuality's environmental readings ride
+            # here in the lite stream (alongside the switch channels), not in
+            # `LightDeviceStatus.statuses`. The three measurements are
+            # `optional` (explicit presence) — guard each with `HasField` so an
+            # unset one leaves its key absent rather than reporting a phantom 0.
+            # Surfaced under diagnostic `lq_*` keys for now; promoted to real
+            # temperature / humidity / CO₂ sensors once the values + units are
+            # confirmed against a real device.
+            lq = entry.life_quality_info
+            if lq.HasField("actual_temperature"):
+                result["lq_temperature"] = lq.actual_temperature
+            if lq.HasField("actual_humidity"):
+                result["lq_humidity"] = lq.actual_humidity
+            if lq.HasField("actual_co2"):
+                result["lq_co2"] = lq.actual_co2
     return result
 
 

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -108,6 +108,11 @@ async def async_get_config_entry_diagnostics(
                     if "video_sources" in d.statuses
                     else {}
                 ),
+                # LifeQuality environmental readings (#302): dump the actual
+                # `lq_*` values (temperature / humidity / CO₂ + threshold/fault
+                # enums) so a diagnostics download confirms which data path a
+                # real device uses and in what units, before sensors are added.
+                **{k: v for k, v in d.statuses.items() if k.startswith("lq_")},
             }
             for did, d in coordinator.devices.items()
         },

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -716,6 +716,47 @@ class TestSpreadPropertiesParser:
         result = DevicesApi._parse_spread_properties(hub_dev)
         assert result == {}
 
+    def test_life_quality_info_values_extracted(self) -> None:
+        # #302 diagnostic probe: LifeQuality's environmental readings ride in
+        # spread_properties (same lite stream as the switch channels), under
+        # the `life_quality_info` oneof case. Surface them under diagnostic
+        # `lq_*` keys so a dump confirms the values + units before we commit
+        # to real sensor entities.
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            life_quality_info_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.life_quality_info.CopyFrom(
+            life_quality_info_pb2.LifeQualityInfo(
+                actual_temperature=21.5,
+                actual_humidity=48.0,
+                actual_co2=620,
+            )
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"lq_temperature": 21.5, "lq_humidity": 48.0, "lq_co2": 620}
+
+    def test_life_quality_info_unset_fields_omitted(self) -> None:
+        # The three measurements are `optional` (explicit presence) — an unset
+        # one must leave its key absent, never report a phantom 0.
+        from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
+        from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
+            life_quality_info_pb2,
+        )
+
+        hub_dev = light_hub_device_pb2.LightHubDevice()
+        spread = hub_dev.spread_properties.add()
+        spread.life_quality_info.CopyFrom(
+            life_quality_info_pb2.LifeQualityInfo(actual_temperature=19.0)
+        )
+
+        result = DevicesApi._parse_spread_properties(hub_dev)
+        assert result == {"lq_temperature": 19.0}
+
     def test_water_stop_channel_state_on_populates_valve_ch1_open(self) -> None:
         # Read-only valve path (#117). `STATE_ON` means the channel is
         # energised — water flowing — so the entity should report `open`.
@@ -950,6 +991,31 @@ class TestStatusParser:
         result = DevicesApi._parse_statuses([status])
         assert result.get("high_temperature") is True
 
+    def test_life_quality_status_unset_field_omitted(self) -> None:
+        # The actual_* fields are `optional` ints — an unset one must be
+        # omitted, not reported as a phantom 0 (the prior `hasattr` guard,
+        # always true for a defined proto field, did exactly that).
+        lds = _LDS()
+        status = lds(life_quality=lds.LifeQualityStatus(actual_temperature=21))
+        result = DevicesApi._parse_statuses([status])
+        assert result["lq_status_temperature"] == 21
+        assert "lq_status_humidity" not in result
+        assert "lq_status_co2" not in result
+
+    def test_life_quality_status_threshold_enums_captured(self) -> None:
+        # Sensor fault / out-of-range threshold flags are diagnostically
+        # useful (e.g. CO₂ lightly polluted, CO₂ sensor malfunction).
+        lds = _LDS()
+        status = lds(
+            life_quality=lds.LifeQualityStatus(
+                co2_statuses=[3],  # CO2_STATUS_LIGHTLY_POLLUTED
+                hardware_malfunctions=[2],  # HARDWARE_MALFUNCTION_CO2_SENSOR
+            )
+        )
+        result = DevicesApi._parse_statuses([status])
+        assert result["lq_co2_statuses"] == [3]
+        assert result["lq_hardware_malfunctions"] == [2]
+
     @pytest.mark.parametrize(
         "value,expected",
         [(0, "unknown"), (1, "unlocked"), (2, "locked"), (3, "unlatched")],
@@ -1001,9 +1067,9 @@ class TestStatusParser:
             )
         )
         result = DevicesApi._parse_statuses([status])
-        assert result.get("temperature") == 21
-        assert result.get("humidity") == 55
-        assert result.get("co2") == 400
+        assert result.get("lq_status_temperature") == 21
+        assert result.get("lq_status_humidity") == 55
+        assert result.get("lq_status_co2") == 400
 
     def test_none_which_oneof_skipped(self) -> None:
         status = MagicMock()

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -190,6 +190,33 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert sorted(probe["310B121D"]["kinds"]) == ["nvr"]
 
     @pytest.mark.asyncio
+    async def test_life_quality_readings_dumped_with_values(self, entry: MagicMock) -> None:
+        # #302: the lq_* readings must appear with their VALUES in the dump
+        # (the generic `statuses` block only lists keys), so a reporter can
+        # sanity-check temperature/humidity/CO₂ against the Ajax app.
+        from dataclasses import replace
+
+        device = replace(
+            _make_device(did="lq-1"),
+            statuses={
+                "signal_strength": "High",
+                "lq_temperature": 21.5,
+                "lq_humidity": 48.0,
+                "lq_co2": 620,
+                "lq_co2_statuses": [3],
+            },
+        )
+        entry.runtime_data.devices = {"lq-1": device}
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        dev_info = result["devices"]["lq-1"]
+        assert dev_info["lq_temperature"] == 21.5
+        assert dev_info["lq_humidity"] == 48.0
+        assert dev_info["lq_co2"] == 620
+        assert dev_info["lq_co2_statuses"] == [3]
+
+    @pytest.mark.asyncio
     async def test_non_video_device_omits_video_keys(self, entry: MagicMock) -> None:
         result = await async_get_config_entry_diagnostics(MagicMock(), entry)
         dev_info = result["devices"]["dev-1"]


### PR DESCRIPTION
## Summary
Diagnostic step for #302 (LifeQuality temperature / humidity / CO₂). Today the device only exposes battery + signal_strength.

## Why a diagnostic first
The readings are defined in **two** places in our protos and we don't know which a real LifeQuality populates, nor the units:
- the lite stream's `spread_properties` → `LifeQualityInfo` (float values), and
- the status oneof → `LightDeviceStatus.LifeQualityStatus` (int values), plus threshold/fault enums.

So this captures **both** into distinct diagnostic keys and dumps their values, letting the reporter sanity-check against the Ajax app before we commit sensor entities (and their device_classes/units):
- `spread_properties.life_quality_info` → `lq_temperature` / `lq_humidity` / `lq_co2`
- status oneof → `lq_status_temperature` / `lq_status_humidity` / `lq_status_co2` + `lq_temperature_statuses` / `lq_humidity_statuses` / `lq_co2_statuses` / `lq_hardware_malfunctions`

## Latent bug fixed
The existing status-oneof branch guarded the `actual_*` reads with `hasattr()`, which is always true for a defined proto field — so an unset `optional` measurement was emitted as a phantom `0`. Now guarded with `HasField`.

## Not included
No sensor entities yet — added once a real dump confirms the data path and units.

## Tests
- `TestSpreadPropertiesParser`: life_quality_info values + unset-omitted.
- `TestStatusParser`: status-oneof values, unset-omitted (the HasField fix), threshold/fault enums.
- `test_life_quality_readings_dumped_with_values` in diagnostics.
- Full suite: 1736 passed.

Refs #302