### PR TITLE
feat(sensor): expose LifeQuality temperature, humidity and CO₂ (#302)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ You can type any custom label during setup if yours is not listed.
 | Combi | CombiProtect, CombiProtect S, CombiProtect Fibra | Motion, glass break, tamper, battery |
 | Fire/Smoke | FireProtect, FireProtect Plus, FireProtect 2 (all sub-models — heat-only `*hrb`/`*hsb`, CO-only `*crb`/`*csb`, multi-sensor `*hcrb`/`*hcsb`, AC-powered `*_ac`, UL-listed `*_ul`) | Smoke, steam (FireProtect 2 only — chamber discriminator), CO, high temperature, tamper, battery — sub-models without a given sensor expose only the relevant entity |
 | Water Leak | LeaksProtect | Leak detected, tamper, battery |
+| Air Quality | LifeQuality | Temperature (°C), humidity (%), CO₂ (ppm), battery, signal |
 | Relays/Switches | Relay, WallSwitch, Socket (and outlet variants) | On/off per channel; electrical readings (current, voltage, energy) across the WallSwitch / Socket family. Power is exposed as a direct reading on the Outlet Type E / F family (the firmware reports it natively) and as a derived `current × voltage` reading on the WallSwitch family. |
 | Light switches | LightSwitch (Jeweller / Fibra) | On/off per channel |
 | Lights | LightSwitch Dimmer | Brightness control |

--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -330,21 +330,21 @@ def _parse_statuses(statuses: Any) -> dict[str, Any]:  # noqa: ANN401
         elif which == "temperature":
             result["temperature"] = status.temperature.value
         elif which == "life_quality":
-            # #302 diagnostic: LifeQuality can also report readings here in the
-            # status oneof (as ints), separately from the float values in
+            # #302 LifeQuality: environmental readings can also arrive here in
+            # the status oneof (as ints), separately from the float values in
             # `spread_properties.life_quality_info`. The actual_* fields are
             # `optional` — guard with HasField, NOT hasattr (always true for a
             # defined proto field, which would report a phantom 0 for an unset
-            # measurement). Distinct `lq_status_*` keys + the threshold/fault
-            # enums so a single diagnostics dump reveals which path a real
-            # device uses and in what units, before we commit to sensors.
+            # measurement). Written to the canonical `temperature`/`humidity`/
+            # `co2` keys so the device-agnostic sensors pick them up; the
+            # threshold/fault enums stay diagnostic-only (`lq_*`).
             lq = status.life_quality
             if lq.HasField("actual_temperature"):
-                result["lq_status_temperature"] = lq.actual_temperature
+                result["temperature"] = lq.actual_temperature
             if lq.HasField("actual_humidity"):
-                result["lq_status_humidity"] = lq.actual_humidity
+                result["humidity"] = lq.actual_humidity
             if lq.HasField("actual_co2"):
-                result["lq_status_co2"] = lq.actual_co2
+                result["co2"] = lq.actual_co2
             for key, vals in (
                 ("lq_temperature_statuses", lq.temperature_statuses),
                 ("lq_humidity_statuses", lq.humidity_statuses),
@@ -520,21 +520,21 @@ def _parse_spread_properties(hub_dev: Any) -> dict[str, Any]:  # noqa: ANN401
             if 2 in [int(m) for m in getattr(wsc, "malfunctions", [])]:
                 result[f"valve_ch{channel_id}_stuck"] = True
         elif which == "life_quality_info":
-            # #302 diagnostic probe: LifeQuality's environmental readings ride
-            # here in the lite stream (alongside the switch channels), not in
+            # #302 LifeQuality: environmental readings ride here in the lite
+            # stream (alongside the switch channels), not in
             # `LightDeviceStatus.statuses`. The three measurements are
             # `optional` (explicit presence) — guard each with `HasField` so an
             # unset one leaves its key absent rather than reporting a phantom 0.
-            # Surfaced under diagnostic `lq_*` keys for now; promoted to real
-            # temperature / humidity / CO₂ sensors once the values + units are
-            # confirmed against a real device.
+            # mroleh-confirmed units vs the Ajax app: temperature °C, humidity
+            # %, CO₂ ppm. Written to the canonical `temperature`/`humidity`/
+            # `co2` keys so the device-agnostic sensors create the entities.
             lq = entry.life_quality_info
             if lq.HasField("actual_temperature"):
-                result["lq_temperature"] = lq.actual_temperature
+                result["temperature"] = lq.actual_temperature
             if lq.HasField("actual_humidity"):
-                result["lq_humidity"] = lq.actual_humidity
+                result["humidity"] = lq.actual_humidity
             if lq.HasField("actual_co2"):
-                result["lq_co2"] = lq.actual_co2
+                result["co2"] = lq.actual_co2
     return result
 
 

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -717,11 +717,12 @@ class TestSpreadPropertiesParser:
         assert result == {}
 
     def test_life_quality_info_values_extracted(self) -> None:
-        # #302 diagnostic probe: LifeQuality's environmental readings ride in
-        # spread_properties (same lite stream as the switch channels), under
-        # the `life_quality_info` oneof case. Surface them under diagnostic
-        # `lq_*` keys so a dump confirms the values + units before we commit
-        # to real sensor entities.
+        # #302: LifeQuality's environmental readings ride in spread_properties
+        # (same lite stream as the switch channels), under the
+        # `life_quality_info` oneof case. mroleh-confirmed units against the
+        # Ajax app: temperature °C (float), humidity % (float), CO₂ ppm (int).
+        # Surfaced under the canonical `temperature`/`humidity`/`co2` keys so
+        # the device-agnostic sensors in sensor.py create the entities.
         from v3.mobilegwsvc.commonmodels.hub.device.light import light_hub_device_pb2
         from v3.mobilegwsvc.commonmodels.hub.device.light.properties import (
             life_quality_info_pb2,
@@ -731,14 +732,14 @@ class TestSpreadPropertiesParser:
         spread = hub_dev.spread_properties.add()
         spread.life_quality_info.CopyFrom(
             life_quality_info_pb2.LifeQualityInfo(
-                actual_temperature=21.5,
-                actual_humidity=48.0,
-                actual_co2=620,
+                actual_temperature=23.9,
+                actual_humidity=55.4,
+                actual_co2=2215,
             )
         )
 
         result = DevicesApi._parse_spread_properties(hub_dev)
-        assert result == {"lq_temperature": 21.5, "lq_humidity": 48.0, "lq_co2": 620}
+        assert result == {"temperature": 23.9, "humidity": 55.4, "co2": 2215}
 
     def test_life_quality_info_unset_fields_omitted(self) -> None:
         # The three measurements are `optional` (explicit presence) — an unset
@@ -755,7 +756,7 @@ class TestSpreadPropertiesParser:
         )
 
         result = DevicesApi._parse_spread_properties(hub_dev)
-        assert result == {"lq_temperature": 19.0}
+        assert result == {"temperature": 19.0}
 
     def test_water_stop_channel_state_on_populates_valve_ch1_open(self) -> None:
         # Read-only valve path (#117). `STATE_ON` means the channel is
@@ -998,13 +999,14 @@ class TestStatusParser:
         lds = _LDS()
         status = lds(life_quality=lds.LifeQualityStatus(actual_temperature=21))
         result = DevicesApi._parse_statuses([status])
-        assert result["lq_status_temperature"] == 21
-        assert "lq_status_humidity" not in result
-        assert "lq_status_co2" not in result
+        assert result["temperature"] == 21
+        assert "humidity" not in result
+        assert "co2" not in result
 
     def test_life_quality_status_threshold_enums_captured(self) -> None:
         # Sensor fault / out-of-range threshold flags are diagnostically
-        # useful (e.g. CO₂ lightly polluted, CO₂ sensor malfunction).
+        # useful (e.g. CO₂ lightly polluted, CO₂ sensor malfunction). Kept as
+        # diagnostic-only `lq_*` keys (no sensor entity).
         lds = _LDS()
         status = lds(
             life_quality=lds.LifeQualityStatus(
@@ -1067,9 +1069,9 @@ class TestStatusParser:
             )
         )
         result = DevicesApi._parse_statuses([status])
-        assert result.get("lq_status_temperature") == 21
-        assert result.get("lq_status_humidity") == 55
-        assert result.get("lq_status_co2") == 400
+        assert result.get("temperature") == 21
+        assert result.get("humidity") == 55
+        assert result.get("co2") == 400
 
     def test_none_which_oneof_skipped(self) -> None:
         status = MagicMock()

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -190,20 +190,20 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert sorted(probe["310B121D"]["kinds"]) == ["nvr"]
 
     @pytest.mark.asyncio
-    async def test_life_quality_readings_dumped_with_values(self, entry: MagicMock) -> None:
-        # #302: the lq_* readings must appear with their VALUES in the dump
-        # (the generic `statuses` block only lists keys), so a reporter can
-        # sanity-check temperature/humidity/CO₂ against the Ajax app.
+    async def test_life_quality_threshold_flags_dumped_with_values(self, entry: MagicMock) -> None:
+        # #302: temperature/humidity/CO₂ are real sensors now (canonical keys),
+        # but the diagnostic-only threshold/fault flags (`lq_*`) must still
+        # appear with their VALUES in the dump — the generic `statuses` block
+        # only lists keys, which can't convey a fault/out-of-range state.
         from dataclasses import replace
 
         device = replace(
             _make_device(did="lq-1"),
             statuses={
-                "signal_strength": "High",
-                "lq_temperature": 21.5,
-                "lq_humidity": 48.0,
-                "lq_co2": 620,
+                "temperature": 23.9,
+                "co2": 2215,
                 "lq_co2_statuses": [3],
+                "lq_hardware_malfunctions": [2],
             },
         )
         entry.runtime_data.devices = {"lq-1": device}
@@ -211,10 +211,11 @@ class TestAsyncGetConfigEntryDiagnostics:
         result = await async_get_config_entry_diagnostics(MagicMock(), entry)
 
         dev_info = result["devices"]["lq-1"]
-        assert dev_info["lq_temperature"] == 21.5
-        assert dev_info["lq_humidity"] == 48.0
-        assert dev_info["lq_co2"] == 620
         assert dev_info["lq_co2_statuses"] == [3]
+        assert dev_info["lq_hardware_malfunctions"] == [2]
+        # canonical readings show in the statuses key list (they're sensors now)
+        assert "temperature" in dev_info["statuses"]
+        assert "co2" in dev_info["statuses"]
 
     @pytest.mark.asyncio
     async def test_non_video_device_omits_video_keys(self, entry: MagicMock) -> None:


### PR DESCRIPTION
## Summary
Adds the temperature / humidity / CO₂ sensors for the Ajax LifeQuality (#302). Until now it only exposed battery + signal.

## Confirmed against real hardware
mroleh's [v1.11.5-beta.4](https://github.com/bvis/aegis-hass/releases/tag/v1.11.5-beta.4) diagnostic dump pinned both the data path and the units — the readings arrive in the lite stream's `spread_properties` (`life_quality_info`), and matched the Ajax app at capture time:

| Reading | Ajax app | dump (`lq_*`) |
|---|---|---|
| Temperature | 23.9 °C | 23.9 (float) |
| Humidity | 55.2 % | 55.4 (float) |
| CO₂ | 2194 ppm | 2215 (int) |

(small drift = seconds between the app reading and the dump.)

## Change
Parse the readings into the **canonical** `temperature`/`humidity`/`co2` status keys (both the `spread_properties` path and the status-oneof path, each `HasField`-guarded for explicit presence). The existing device-agnostic sensors in `sensor.py` already map those keys to `SensorDeviceClass.TEMPERATURE` (°C), `HUMIDITY` (%) and `CO2` (ppm) — so no new entity code and no new translations. The status-oneof threshold/fault enums stay as diagnostic-only `lq_*` keys. README Supported Devices gains a LifeQuality row.

## Tests
- `TestSpreadPropertiesParser` / `TestStatusParser`: canonical keys from both paths, unset-omitted (HasField), threshold/fault enums diagnostic-only.
- Diagnostics: threshold flags still dumped with values.
- Full suite: 1736 passed.

Refs #302