### PR TITLE
feat(diagnostics): read VideoEdge LAN IP via stream_video_edge (#282)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -144,6 +144,27 @@ def _encode_varint_field(field_number: int, value: int) -> bytes:
     return bytes([tag]) + bytes(varint)
 
 
+def _video_edge_interfaces(video_edge: Any) -> list[dict[str, Any]]:  # noqa: ANN401
+    """Extract `{name, mac, ip}` for each VideoEdge interface with an IPv4 (#282).
+
+    `IpAddressV4.data` is a uint32 in network byte order → dotted quad.
+    MacAddress.data is raw bytes → colon-hex. Interfaces without a configured
+    IPv4 (address unset / 0) are skipped — we only want reachable endpoints.
+    """
+    interfaces: list[dict[str, Any]] = []
+    for ni in getattr(video_edge, "network_interfaces", []):
+        if not ni.HasField("configuration") or not ni.configuration.HasField("v4"):
+            continue
+        raw = int(ni.configuration.v4.address.data)
+        if not raw:
+            continue
+        ip = ".".join(str((raw >> (8 * (3 - i))) & 0xFF) for i in range(4))
+        mac_bytes = bytes(ni.mac_address.data)
+        mac = ":".join(f"{b:02x}" for b in mac_bytes) if mac_bytes else None
+        interfaces.append({"name": ni.name, "mac": mac, "ip": ip})
+    return interfaces
+
+
 class DevicesApi:
     """API operations for devices."""
 
@@ -341,6 +362,52 @@ class DevicesApi:
             },
             "rtsp": {"http_port": rtsp.http_port},
         }
+
+    async def get_video_edge_network(
+        self, space_id: str, video_edge_id: str
+    ) -> dict[str, Any] | None:
+        """Read a VideoEdge's LAN network interfaces for diagnostics (#282).
+
+        Wraps the `StreamVideoEdgeService` server stream and reads only the
+        first `initial_state` snapshot. Returns each interface's IPv4 address
+        and MAC — the last piece needed to point Home Assistant's native ONVIF
+        integration at the camera (combined with the ports from
+        `get_video_edge_onvif_rtsp_settings`). `IpAddressV4.data` is an int in
+        network byte order. Never raises: any failure is reported as an
+        ``{"error": reason}`` dict so it can't break diagnostics generation.
+        """
+        from v3.mobilegwsvc.service.stream_video_edge import (  # noqa: PLC0415
+            endpoint_pb2_grpc,
+            request_pb2,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = endpoint_pb2_grpc.StreamVideoEdgeServiceStub(channel)
+        request = request_pb2.StreamVideoEdgeRequest(
+            space_id=space_id,
+            video_edge_id=video_edge_id,
+        )
+        try:
+            # Read only the first message: the stream is long-lived (it keeps
+            # pushing change deltas), but the snapshot we need is the leading
+            # `initial_state`.
+            async for msg in stub.execute(request, metadata=metadata, timeout=15):
+                which = msg.WhichOneof("response") if hasattr(msg, "WhichOneof") else None
+                if which == "failure":
+                    return {"error": msg.failure.WhichOneof("error") or "failure"}
+                if which == "success" and msg.success.WhichOneof("update") == "initial_state":
+                    video_edge = msg.success.initial_state.video_edge
+                    return {"interfaces": _video_edge_interfaces(video_edge)}
+                return {"error": "no_initial_state"}
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "StreamVideoEdge RPC failed for video_edge %s",
+                video_edge_id,
+                exc_info=True,
+            )
+            return {"error": "rpc_error"}
+        return {"error": "empty_stream"}
 
     def _handle_update(
         self,

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -47,16 +47,24 @@ async def async_get_config_entry_diagnostics(
     video_edge_probe: dict[str, Any] = {}
     for ve_id, kinds in video_edge_kinds.items():
         settings: dict[str, Any] | None = None
+        owning_space: str | None = None
         for space_id in coordinator.spaces:
             settings = await coordinator.devices_api.get_video_edge_onvif_rtsp_settings(
                 space_id, ve_id
             )
             # Stop at the space that actually owns this VideoEdge.
             if settings is not None and "error" not in settings:
+                owning_space = space_id
                 break
+        # Read the LAN IP / MAC (#282) so the dump has the full connection info
+        # (IP + ONVIF/RTSP ports) to point HA's native ONVIF integration at.
+        network = await coordinator.devices_api.get_video_edge_network(
+            owning_space or next(iter(coordinator.spaces), ""), ve_id
+        )
         video_edge_probe[ve_id] = {
             "kinds": sorted(k for k in kinds if k),
             **(settings or {"error": "not_probed"}),
+            "network": network,
         }
 
     return {

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1590,6 +1590,159 @@ class TestVideoEdgePushAliases:
         assert api.doorbell_twin_aliases == {}
 
 
+class TestVideoEdgeNetworkProbe:
+    """Issue #282: read a VideoEdge's LAN IP (+ MAC) via stream_video_edge, the
+    last piece needed to point Home Assistant's native ONVIF integration at the
+    camera. `IpAddressV4.data` is an int in network byte order. Never raises —
+    a probe failure is reported as `{"error": …}`."""
+
+    @staticmethod
+    def _make_api() -> DevicesApi:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        return DevicesApi(client)
+
+    @pytest.mark.asyncio
+    async def test_success_returns_interface_ip_and_mac(self) -> None:
+        from systems.ajax.api.mobile.v2.common.video import types_pb2
+        from systems.ajax.api.mobile.v2.common.video.videoedge import video_edge_pb2
+        from systems.ajax.api.mobile.v2.common.video.videoedge.network import (
+            network_interface_pb2,
+        )
+        from v3.mobilegwsvc.service.stream_video_edge import (
+            endpoint_pb2_grpc,
+            request_pb2,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        ve = video_edge_pb2.VideoEdge(
+            network_interfaces=[
+                network_interface_pb2.NetworkInterface(
+                    name="eth0",
+                    mac_address=types_pb2.MacAddress(
+                        data=bytes([0x9C, 0x75, 0x6E, 0x81, 0x0C, 0x6E])
+                    ),
+                    configuration=network_interface_pb2.NetworkConfiguration(
+                        v4=network_interface_pb2.NetworkConfigurationIPv4(
+                            address=types_pb2.IpAddressV4(data=0xC0A80164),  # 192.168.1.100
+                        )
+                    ),
+                )
+            ]
+        )
+        msg = response_pb2.StreamVideoEdgeResponse(
+            success=response_pb2.StreamVideoEdgeResponse.Success(
+                initial_state=response_pb2.StreamVideoEdgeResponse.Success.InitialState(
+                    video_edge=ve
+                )
+            )
+        )
+
+        async def _aiter(*_a: object, **_k: object) -> AsyncGenerator[object, None]:
+            yield msg
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                def _execute(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return _aiter()
+
+                self.execute = _execute
+
+        with patch.object(endpoint_pb2_grpc, "StreamVideoEdgeServiceStub", _StubFactory):
+            result = await api.get_video_edge_network("space-1", "30BE4400")
+
+        assert isinstance(captured[0], request_pb2.StreamVideoEdgeRequest)
+        assert captured[0].space_id == "space-1"
+        assert captured[0].video_edge_id == "30BE4400"
+        assert result == {
+            "interfaces": [{"name": "eth0", "mac": "9c:75:6e:81:0c:6e", "ip": "192.168.1.100"}]
+        }
+
+    @pytest.mark.asyncio
+    async def test_interface_without_ipv4_is_skipped(self) -> None:
+        from systems.ajax.api.mobile.v2.common.video.videoedge import video_edge_pb2
+        from systems.ajax.api.mobile.v2.common.video.videoedge.network import (
+            network_interface_pb2,
+        )
+        from v3.mobilegwsvc.service.stream_video_edge import (
+            endpoint_pb2_grpc,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        ve = video_edge_pb2.VideoEdge(
+            network_interfaces=[network_interface_pb2.NetworkInterface(name="wlan0")]
+        )
+        msg = response_pb2.StreamVideoEdgeResponse(
+            success=response_pb2.StreamVideoEdgeResponse.Success(
+                initial_state=response_pb2.StreamVideoEdgeResponse.Success.InitialState(
+                    video_edge=ve
+                )
+            )
+        )
+
+        async def _aiter(*_a: object, **_k: object) -> AsyncGenerator[object, None]:
+            yield msg
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.execute = lambda *a, **k: _aiter()
+
+        with patch.object(endpoint_pb2_grpc, "StreamVideoEdgeServiceStub", _StubFactory):
+            result = await api.get_video_edge_network("space-1", "30BE4400")
+
+        assert result == {"interfaces": []}
+
+    @pytest.mark.asyncio
+    async def test_failure_response_reports_error(self) -> None:
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.stream_video_edge import (
+            endpoint_pb2_grpc,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        msg = response_pb2.StreamVideoEdgeResponse(
+            failure=response_pb2.StreamVideoEdgeResponse.Failure(
+                video_edge_not_found=common_response_pb2.Error(),
+            )
+        )
+
+        async def _aiter(*_a: object, **_k: object) -> AsyncGenerator[object, None]:
+            yield msg
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.execute = lambda *a, **k: _aiter()
+
+        with patch.object(endpoint_pb2_grpc, "StreamVideoEdgeServiceStub", _StubFactory):
+            result = await api.get_video_edge_network("space-1", "bad")
+
+        assert result == {"error": "video_edge_not_found"}
+
+    @pytest.mark.asyncio
+    async def test_rpc_exception_reports_error(self) -> None:
+        from v3.mobilegwsvc.service.stream_video_edge import endpoint_pb2_grpc
+
+        api = self._make_api()
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                def _execute(*_a: object, **_k: object) -> object:
+                    raise RuntimeError("boom")
+
+                self.execute = _execute
+
+        with patch.object(endpoint_pb2_grpc, "StreamVideoEdgeServiceStub", _StubFactory):
+            result = await api.get_video_edge_network("space-1", "30BE4400")
+
+        assert result == {"error": "rpc_error"}
+
+
 class TestVideoEdgeOnvifRtspProbe:
     """Issue #282: a diagnostic read of the VideoEdge ONVIF/RTSP settings, so
     we can map what's available towards a real camera entity. Returns a flat,

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -68,9 +68,10 @@ class TestAsyncGetConfigEntryDiagnostics:
         coord.devices = {"dev-1": _make_device()}
         coord._stream_tasks = [MagicMock(), MagicMock()]
         coord.notification_listener = MagicMock()
-        # The ONVIF/RTSP probe (#282) is only called for video_edge devices;
-        # default it to a no-op so non-video fixtures don't await a MagicMock.
+        # The VideoEdge probes (#282) are only called for video_edge devices;
+        # default them to no-ops so non-video fixtures don't await a MagicMock.
         coord.devices_api.get_video_edge_onvif_rtsp_settings = AsyncMock(return_value=None)
+        coord.devices_api.get_video_edge_network = AsyncMock(return_value=None)
         return coord
 
     @pytest.fixture
@@ -179,12 +180,16 @@ class TestAsyncGetConfigEntryDiagnostics:
         entry.runtime_data.devices_api.get_video_edge_onvif_rtsp_settings = AsyncMock(
             return_value={"onvif": {"http_port": 8000}, "rtsp": {"http_port": 554}}
         )
+        entry.runtime_data.devices_api.get_video_edge_network = AsyncMock(
+            return_value={"interfaces": [{"name": "eth0", "mac": "aa:bb", "ip": "192.168.1.50"}]}
+        )
 
         result = await async_get_config_entry_diagnostics(MagicMock(), entry)
 
         probe = result["video_edge_onvif_rtsp"]
         assert set(probe) == {"310A8DF4", "310B121D"}
         assert probe["310A8DF4"]["onvif"] == {"http_port": 8000}
+        assert probe["310A8DF4"]["network"]["interfaces"][0]["ip"] == "192.168.1.50"
         assert probe["310A8DF4"]["rtsp"] == {"http_port": 554}
         assert sorted(probe["310A8DF4"]["kinds"]) == ["primary"]
         assert sorted(probe["310B121D"]["kinds"]) == ["nvr"]


### PR DESCRIPTION
## Summary
Adds the camera's **LAN IP** (and MAC) to the diagnostics probe — the last connection detail needed to point Home Assistant's native ONVIF integration at an Ajax camera.

## Why
The ONVIF/RTSP probe (beta.2/.4) confirmed, across two testers, that cameras expose ONVIF on **8080** and RTSP on **8554** — but those are local services; HA needs the device's **LAN IP** to reach them, and that isn't in the ONVIF settings response.

## Change
`get_video_edge_network(space_id, video_edge_id)` reads the first `initial_state` snapshot of the `StreamVideoEdge` server stream and returns each network interface's IPv4 + MAC (`IpAddressV4.data` is a uint32 in network byte order → dotted quad). It's merged into the existing `video_edge_onvif_rtsp` diagnostics entry under `network`. Read-only, first-message-only (the stream is long-lived), never raises (failure → `{error: reason}`).

So a single diagnostics download now carries the full picture per camera: **IP + ONVIF/RTSP ports** (the ONVIF password stays user-set). 

## Not included
Still no `camera` entity — the deliverable remains the documented native-ONVIF path, now with the IP available.

## Tests
- `TestVideoEdgeNetworkProbe`: IP+MAC extraction (network byte order), interface-without-IPv4 skipped, failure-response, RPC-exception.
- Diagnostics test asserts `network` is included per VideoEdge.
- Full suite: 1740 passed.

Refs #282