### PR TITLE
fix(diagnostics): VideoEdge IPv4 is little-endian, not network byte order (#282)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -147,9 +147,12 @@ def _encode_varint_field(field_number: int, value: int) -> bytes:
 def _video_edge_interfaces(video_edge: Any) -> list[dict[str, Any]]:  # noqa: ANN401
     """Extract `{name, mac, ip}` for each VideoEdge interface with an IPv4 (#282).
 
-    `IpAddressV4.data` is a uint32 in network byte order → dotted quad.
-    MacAddress.data is raw bytes → colon-hex. Interfaces without a configured
-    IPv4 (address unset / 0) are skipped — we only want reachable endpoints.
+    `IpAddressV4.data` is a uint32. NOTE: despite the proto comment claiming
+    "network byte order", real devices store it **little-endian** — byte 0 is
+    the first octet (mroleh #282: 0x6E00A8C0 → 192.168.0.110, not the
+    big-endian 110.0.168.192). MacAddress.data is raw bytes → colon-hex.
+    Interfaces without a configured IPv4 (address unset / 0) are skipped — we
+    only want reachable endpoints.
     """
     interfaces: list[dict[str, Any]] = []
     for ni in getattr(video_edge, "network_interfaces", []):
@@ -158,7 +161,7 @@ def _video_edge_interfaces(video_edge: Any) -> list[dict[str, Any]]:  # noqa: AN
         raw = int(ni.configuration.v4.address.data)
         if not raw:
             continue
-        ip = ".".join(str((raw >> (8 * (3 - i))) & 0xFF) for i in range(4))
+        ip = ".".join(str((raw >> (8 * i)) & 0xFF) for i in range(4))
         mac_bytes = bytes(ni.mac_address.data)
         mac = ":".join(f"{b:02x}" for b in mac_bytes) if mac_bytes else None
         interfaces.append({"name": ni.name, "mac": mac, "ip": ip})

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1626,8 +1626,11 @@ class TestVideoEdgeNetworkProbe:
                         data=bytes([0x9C, 0x75, 0x6E, 0x81, 0x0C, 0x6E])
                     ),
                     configuration=network_interface_pb2.NetworkConfiguration(
+                        # Despite the proto comment ("network byte order"),
+                        # real devices store the int little-endian: 0x6E00A8C0
+                        # = 192.168.0.110 (mroleh #282, not 110.0.168.192).
                         v4=network_interface_pb2.NetworkConfigurationIPv4(
-                            address=types_pb2.IpAddressV4(data=0xC0A80164),  # 192.168.1.100
+                            address=types_pb2.IpAddressV4(data=0x6E00A8C0),
                         )
                     ),
                 )
@@ -1659,7 +1662,7 @@ class TestVideoEdgeNetworkProbe:
         assert captured[0].space_id == "space-1"
         assert captured[0].video_edge_id == "30BE4400"
         assert result == {
-            "interfaces": [{"name": "eth0", "mac": "9c:75:6e:81:0c:6e", "ip": "192.168.1.100"}]
+            "interfaces": [{"name": "eth0", "mac": "9c:75:6e:81:0c:6e", "ip": "192.168.0.110"}]
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
The VideoEdge LAN IP added in the previous beta came out **byte-reversed** in mroleh's diagnostics: `110.0.168.192` for a device that is really `192.168.0.110` (the MAC was correct).

## Cause
`IpAddressV4.data` is a uint32. Its proto doc-comment says *"In network byte order"*, so the probe formatted it big-endian (MSB first). On real devices the int is actually **little-endian** (byte 0 = first octet), so the octets came out reversed. Format LSB-first.

`0x6E00A8C0` → `192.168.0.110` (correct), not `110.0.168.192`.

The diagnostic probe is read-only and ships no camera entity yet — catching this byte-order assumption from a real dump before building anything on it is exactly why it went out as a diagnostic first.

## Tests
- `TestVideoEdgeNetworkProbe::test_success_returns_interface_ip_and_mac` updated to mroleh's real value (little-endian) with a comment on the proto-doc discrepancy.
- Full suite: 1740 passed.

Refs #282