### PR TITLE
feat(valve): open/close for Ajax WaterStop (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - unreleased
+
+### Added
+- **WaterStop valves can now be opened and closed from Home Assistant (#308).** The Ajax WaterStop (and WaterStop Fibra) valve entity was read-only; it now supports open and close, so you can shut off or restore the water supply from the dashboard or an automation. State, transition and the `stuck` attribute keep working as before.
+
 ## [1.11.5] - 2026-06-18
 
 LifeQuality air-quality sensors, NVR-bridged camera fixes, and groundwork for camera support. Consolidates the 1.11.5-beta series.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 - **Lights**: Dimmers with absolute brightness control via `DeviceCommandBrightness`
 - **Locks**: Ajax SmartLock and LockBridge (Yale) — lock and unlock. Hub-attached Jeweller locks (e.g. installer-added Yale modules) are commanded over the generic device on/off path. Unlatch (`lock.open`) isn't exposed: it requires Ajax's cloud SmartLock service, which the hub-attached locks seen so far aren't registered with — the Ajax app can't unlatch them either
 - **Hub Chime switch**: a per-hub `Chime` switch toggles the hub-wide chime — the tone the hub plays when a monitored door/window opens while disarmed (the Ajax app's bottom-left toggle). Only created for hubs that expose the feature, and requires the account's chime-edit permission. Changes made from the Ajax app are reflected in Home Assistant immediately.
-- **Valves** (read-only): Ajax WaterStop and WaterStop Fibra surface as native `valve.*` entities reflecting `WaterStopChannel.state` (open / closed), `is_transitioning`, and a `stuck` attribute pulled from the channel-level `MALFUNCTION_IS_STUCK`. Bidirectional control isn't wired yet — open an issue if you have a WaterStop and we'll work with you to add the open / close path
+- **Valves**: Ajax WaterStop and WaterStop Fibra surface as native `valve.*` entities reflecting `WaterStopChannel.state` (open / closed), `is_transitioning`, and a `stuck` attribute pulled from the channel-level `MALFUNCTION_IS_STUCK`. **Open and close are supported** — the valve can be controlled from Home Assistant and automations
 - **Hub firmware update** (read-only): each hub exposes an `update.<hub>_firmware` entity that shows whether Ajax has queued a firmware update for the hub, with download progress when the cloud is pushing bytes. No install button is exposed on purpose — firmware updates remain Ajax-scheduled and the entity is informational. Click the entity for a short explainer of what "Up-to-date" actually means here.
 - **Cameras**: MotionCam Photo on Demand — capture photos and view them in HA (PhOD models only)
 - **Photo Storage**: Captured photos saved to `/media/ajax_photos/` with timestamp overlay, configurable retention
@@ -426,7 +426,7 @@ If a specific group of sensors stops working:
 ## Roadmap
 
 - [x] Video stream support (VideoEdge / NVR) — cameras bridged through an Ajax NVR expose a local ONVIF/RTSP service; the integration surfaces their IP + ports so you can use Home Assistant's native ONVIF integration for live view. See [Video cameras (ONVIF / RTSP)](#video-cameras-onvif--rtsp). Native/proxied streaming and the radio MotionCam Video family (not behind an NVR) are still open
-- [ ] Valve platform — bidirectional control. Read-only `valve` entity ships in `1.3.0`; full open / close still waits on capturing the official app's command-side calls (no `SwitchWaterStopService` in the v3 protos)
+- [x] Valve platform — bidirectional control. Read-only `valve` entity shipped in `1.3.0`; open / close added in `1.12.0` over the generic device on/off command path
 - [ ] Per-device firmware update entities. Hub-level entity ships in `1.4.0` via `streamHubObject` field 201; field 200 (`device_firmware_updates`) carries the same shape per device for the per-device entities, same read-only-by-design pattern
 - [ ] Number/Select platforms for device settings (sensitivity, brightness)
 - [x] SpaceControl (keyfob) detection — keyfobs surface as a **Keyfobs** device with an experimental per-keyfob active sensor (`1.10.0`); the active/inactive value still awaits confirmation from a deactivated-keyfob log. (Who armed/disarmed via a keyfob was already attributed in the logbook.)
@@ -438,7 +438,6 @@ This integration covers the hardware I personally own and can validate against a
 Areas where the integration could grow with community input:
 
 - **Video streaming** — cameras behind an Ajax **NVR** already have a live-view path via Home Assistant's native ONVIF integration ([guide](#video-cameras-onvif--rtsp)). Still open: the radio **MotionCam Video** family that isn't bridged through an NVR, and any in-integration (proxied) streaming.
-- **Bidirectional WaterStop control** — read-only valve entity ships since `1.3.0`; full open / close is still pending.
 - **A deactivated SpaceControl keyfob** — keyfobs now appear as a *Keyfobs* device with an experimental per-keyfob **Active** sensor (`1.10.0`), but the active/inactive value is unconfirmed because every keyfob seen so far is active. If yours has one deactivated by your installer/CRA, a diagnostics dump + debug log would let us finalize the indicator.
 - **Per-device firmware updates**, **device settings** (sensitivity, brightness, alert thresholds).
 - **Co-branded apps** the integration doesn't yet recognise in the `App Label` dropdown.

--- a/custom_components/aegis_ajax/valve.py
+++ b/custom_components/aegis_ajax/valve.py
@@ -1,16 +1,13 @@
-"""Valve entities for Ajax WaterStop devices (read-only — #117).
+"""Valve entities for Ajax WaterStop devices (#117, open/close #308).
 
-Read-only on purpose: the v3 protos we have don't expose a
-`SwitchWaterStopService`, so the integration cannot toggle the valve
-from HA. Surfacing OPEN / CLOSE features would just attach buttons that
-silently fail. The entity therefore declares `supported_features = 0`
-and `reports_position = False`; automations can still react to the
-valve closing (leak event) via the standard `valve.closed` state
-trigger.
+State comes from `WaterStopChannel.state`. Open/close ride the generic
+device on/off command path the integration already uses for relays and
+sockets — there's no dedicated WaterStop command service. The valve is a
+single-channel device, so commands target channel 1: opening the valve
+sends device-on, closing sends device-off (the same polarity as the
+`valve_ch1` state read, where a truthy channel means the valve is open).
 
-When someone with a WaterStop captures the wire calls the official
-mobile app makes when toggling, extending this entity with an
-`async_open_valve` / `async_close_valve` pair is straightforward.
+`reports_position` stays False — the WaterStop is binary, not positional.
 """
 
 from __future__ import annotations
@@ -25,8 +22,9 @@ from homeassistant.components.valve import (
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
-from custom_components.aegis_ajax.entity import build_device_info
+from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -41,6 +39,9 @@ _LOGGER = logging.getLogger(__name__)
 # default wireless variant) and `water_stop_base` (Fibra, wired). Same
 # `WaterStopChannel` payload, same parser path, same entity surface.
 VALVE_DEVICE_TYPES: frozenset[str] = frozenset({"water_stop", "water_stop_base"})
+
+# The WaterStop exposes a single valve channel; on/off commands target it.
+_VALVE_CHANNEL = 1
 
 
 async def async_setup_entry(
@@ -60,7 +61,7 @@ class AjaxValve(CoordinatorEntity[AjaxCobrandedCoordinator], ValveEntity):
     _attr_has_entity_name = True
     _attr_name = None
     _attr_device_class = ValveDeviceClass.WATER
-    _attr_supported_features = ValveEntityFeature(0)
+    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
     _attr_reports_position = False
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
@@ -117,3 +118,22 @@ class AjaxValve(CoordinatorEntity[AjaxCobrandedCoordinator], ValveEntity):
         if device is None:
             return {}
         return {"stuck": bool(device.statuses.get("valve_ch1_stuck"))}
+
+    async def async_open_valve(self, **kwargs: object) -> None:
+        await self._send("on")
+
+    async def async_close_valve(self, **kwargs: object) -> None:
+        await self._send("off")
+
+    async def _send(self, action: str) -> None:
+        device = self._device
+        if device is None:
+            return
+        factory = DeviceCommand.on if action == "on" else DeviceCommand.off
+        cmd = factory(
+            hub_id=device.hub_id,
+            device_id=self._device_id,
+            device_type=device.device_type,
+            channels=[_VALVE_CHANNEL],
+        )
+        await async_send_device_command(self.coordinator, cmd)

--- a/tests/unit/test_valve.py
+++ b/tests/unit/test_valve.py
@@ -165,13 +165,15 @@ class TestAjaxValveAvailability:
 
 
 class TestAjaxValveSupportedFeatures:
-    def test_no_supported_features(self) -> None:
-        # Read-only path: no `SwitchWaterStopService` in v3 protos, so
-        # exposing OPEN/CLOSE features would surface controls that fail
-        # silently. Keep features at 0 until the command path is captured.
+    def test_open_and_close_features_supported(self) -> None:
+        # Open/close ride the generic device on/off command path (#308),
+        # so the entity advertises OPEN | CLOSE.
+        from homeassistant.components.valve import ValveEntityFeature
+
         device = _make_device(valve_ch1=True)
         valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
-        assert int(valve.supported_features) == 0
+        assert valve.supported_features & ValveEntityFeature.OPEN
+        assert valve.supported_features & ValveEntityFeature.CLOSE
 
     def test_reports_position_disabled(self) -> None:
         # WaterStop is binary, not positional. HA renders a position bar
@@ -179,6 +181,71 @@ class TestAjaxValveSupportedFeatures:
         device = _make_device(valve_ch1=True)
         valve = AjaxValve(coordinator=_make_coordinator(device), device_id=device.id)
         assert valve.reports_position is False
+
+
+class TestAjaxValveCommands:
+    """Open/close go through the generic device on/off command (#308):
+    open = device-on, close = device-off, on the WaterStop's single
+    channel (1). Polarity matches the state read (`valve_ch1` truthy =
+    open). No new RPC — reuses the relay/socket switch path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_open_valve_sends_device_on_channel_1(self) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        device = _make_device(valve_ch1=False)
+        coordinator = _make_coordinator(device)
+        valve = AjaxValve(coordinator=coordinator, device_id=device.id)
+        with patch(
+            "custom_components.aegis_ajax.valve.async_send_device_command",
+            new=AsyncMock(),
+        ) as send:
+            await valve.async_open_valve()
+        send.assert_awaited_once()
+        sent_coordinator, cmd = send.await_args.args
+        assert sent_coordinator is coordinator
+        assert cmd.action == "on"
+        assert cmd.hub_id == "hub-1"
+        assert cmd.device_id == "valve-1"
+        assert cmd.device_type == "water_stop"
+        assert cmd.channels == [1]
+
+    @pytest.mark.asyncio
+    async def test_async_close_valve_sends_device_off_channel_1(self) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        device = _make_device(valve_ch1=True)
+        coordinator = _make_coordinator(device)
+        valve = AjaxValve(coordinator=coordinator, device_id=device.id)
+        with patch(
+            "custom_components.aegis_ajax.valve.async_send_device_command",
+            new=AsyncMock(),
+        ) as send:
+            await valve.async_close_valve()
+        send.assert_awaited_once()
+        _, cmd = send.await_args.args
+        assert cmd.action == "off"
+        assert cmd.channels == [1]
+        assert cmd.device_type == "water_stop"
+
+    @pytest.mark.asyncio
+    async def test_commands_noop_when_device_missing(self) -> None:
+        # Device dropped from the snapshot between polls: don't raise,
+        # don't fire a command with empty hub/device ids.
+        from unittest.mock import AsyncMock, patch
+
+        device = _make_device(valve_ch1=True)
+        coordinator = _make_coordinator(device)
+        valve = AjaxValve(coordinator=coordinator, device_id=device.id)
+        coordinator.devices = {}
+        with patch(
+            "custom_components.aegis_ajax.valve.async_send_device_command",
+            new=AsyncMock(),
+        ) as send:
+            await valve.async_open_valve()
+            await valve.async_close_valve()
+        send.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds open/close control to the Ajax WaterStop valve entity, which was read-only since 1.3.0.

## What
- `valve.py`: advertise `ValveEntityFeature.OPEN | CLOSE`; implement `async_open_valve` / `async_close_valve`.
- Open and close reuse the **generic device on/off command** the integration already uses for relays and sockets (`DeviceCommandDeviceOn/OffService`), targeting the WaterStop's single channel (1): open → device-on, close → device-off.
- Polarity matches the existing state read (a truthy `valve_ch1` means the valve is open). Commands no-op when the device is missing from the snapshot.
- **No new proto/RPC.** State, transition and the `stuck` attribute are unchanged.

## Tests (TDD)
- Open sends device-on on channel 1; close sends device-off on channel 1; missing-device is a no-op; entity advertises OPEN|CLOSE.
- Full suite green (1743 passed, 89% cov), lint/format/typecheck/dead-code clean.

## Validation
No WaterStop on my installs, so this needs real-hardware confirmation before stable — @alexllax (#308) offered to test. Plan: ship a beta, have them verify open/close and polarity on their valve, then promote.

Refs #308