### PR TITLE
fix(temperature): source siren temperature from HTS 0x02 and stop it freezing (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - unreleased
+
+### Fixed
+- **Siren temperature is no longer stuck and now matches the Ajax app (#312).** The HomeSiren/StreetSiren temperature was read once at startup and then frozen for the lifetime of the integration (both the per-device gRPC refresh and the HTS path skipped any device that already had a value), and the gRPC source was the internal board sensor, which reads a few degrees high on a sun-exposed StreetSiren. Sirens are now sourced from the same live internal-temperature value the Ajax app shows (HTS sub-key 0x02), so the reading matches the app and updates over the push channel. The freeze is fixed for every per-device temperature source, so the Curtain Outdoor family also updates live now.
+
 ## [1.12.0] - 2026-06-19
 
 WaterStop valve open/close control. Consolidates the 1.12.0-beta series.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ You can type any custom label during setup if yours is not listed.
 | Range extenders | ReX, ReX 2, ReX 2 Fire | Battery, signal |
 | Wired-Input Modules | MultiTransmitter, MultiTransmitter Fibra, Hub Hybrid wired inputs | Tamper of the module itself; each registered wired sensor appears as its own device with an alert binary sensor and an `alarm_type` attribute (intrusion / fire / glass_break / vibration / …) |
 
-> **Siren temperature is the internal (board) temperature**, not room ambient — it's the only temperature the siren reports over the protocol. On an **indoor HomeSiren** the board sits close to ambient, so it tracks the value shown in the Ajax app. On an **outdoor StreetSiren** the enclosure heats up in the sun, so the board can read several degrees above shade-ambient — a genuine reading of the device, not a calibration bug. The value moves in ~2 °C steps and updates slowly (matching the app), refreshed on a 15-minute cycle.
+> **Siren temperature matches the value shown in the Ajax app** and updates live over the hub's push channel (it moves in ~1 °C steps, as in the app). Earlier versions sourced it from the siren's internal board sensor, which read a few degrees high on a sun-exposed StreetSiren and refreshed only every 15 minutes; since `1.12.1` it reads the same internal-temperature value the app shows (#312).
 
 ## Photo on Demand
 

--- a/custom_components/aegis_ajax/api/hts/hub_state.py
+++ b/custom_components/aegis_ajax/api/hts/hub_state.py
@@ -262,6 +262,18 @@ HTS_TEMPERATURE_DEVICE_TYPES: frozenset[str] = frozenset(
     {
         "motion_protect_curtain_outdoor_plus",
         "motion_protect_curtain_outdoor_base",
+        # Sirens (#312, #269). They also expose a gRPC `device_temperature`, but
+        # that is the internal *board* temperature (runs hotter than ambient and
+        # only refreshes on the slow per-device snapshot). HTS 0x02 is the value
+        # the Ajax app shows and updates live, confirmed for both the indoor
+        # HomeSiren and the outdoor StreetSiren, so sirens are sourced from 0x02
+        # and excluded from the gRPC fetch.
+        "street_siren",
+        "street_siren_plus_g3",
+        "home_siren",
+        "home_siren_g3",
+        "home_siren_s",
+        "home_siren_fibra",
     }
 )
 

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -155,16 +155,22 @@ MAX_RETRIES = 3
 RATE_LIMIT_REQUESTS = 60
 RATE_LIMIT_WINDOW = 60  # seconds
 
-# Per-device internal temperature (#220, #229). Some devices report their
-# temperature only in the rich per-device `StreamHubDevice` snapshot, not in
-# the lighter `StreamLightDevices` stream we run continuously: sirens (#220)
-# and outdoor curtain motion detectors (#229). We pull it with a throttled
-# one-shot snapshot per device — temperature is slow-moving and a persistent
-# per-device stream would contradict how the Ajax app uses that endpoint.
+# Per-device internal temperature (#220, #229, #312). Some devices report their
+# temperature only in the rich per-device `StreamHubDevice` snapshot, not in the
+# lighter `StreamLightDevices` stream we run continuously: sirens (#220) and
+# outdoor curtain motion detectors (#229). The Curtain Outdoor *Mini* is the
+# only family still pulled over gRPC (a throttled one-shot snapshot — temperature
+# is slow-moving and a persistent per-device stream would contradict how the
+# Ajax app uses that endpoint). Sirens and the Curtain Plus/Base are sourced from
+# HTS sub-key 0x02 instead (see api/hts/hub_state.HTS_TEMPERATURE_DEVICE_TYPES),
+# which matches the Ajax app and updates live.
 HUB_DEVICE_TEMP_REFRESH_INTERVAL = 900  # seconds (15 min)
-# Device types whose `HubDevice` oneof case carries a `device_temperature`
-# that the `StreamLightDevices` stream omits. Indoor motion/door sensors are
-# NOT here — they already carry `temperature` in the light stream.
+# Device types whose temperature comes from a per-device source (gRPC or HTS)
+# rather than the `StreamLightDevices` stream. Used as the carry-forward set so
+# the merged value survives a fresh stream snapshot that lacks it. The gRPC fetch
+# only runs for the members NOT in `HTS_TEMPERATURE_DEVICE_TYPES` (i.e. the Mini).
+# Indoor motion/door sensors are NOT here — they carry `temperature` in the
+# light stream.
 HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
     {
         "street_siren",
@@ -173,12 +179,6 @@ HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
         "home_siren_g3",
         "home_siren_s",
         "home_siren_fibra",
-        # Outdoor curtain PIRs (#229). Only the *Mini* carries
-        # `device_temperature` in its gRPC `HubDevice` message; the Plus/Base
-        # messages are stubs with no temperature field, so their temperature is
-        # sourced from HTS sub-key 0x02 instead (see
-        # api/hts/hub_state.HTS_TEMPERATURE_DEVICE_TYPES). All three stay in
-        # this set so the merged temperature carries across gRPC snapshots.
         "motion_protect_curtain_outdoor_base",
         "motion_protect_curtain_outdoor_mini",
         "motion_protect_curtain_outdoor_plus",

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -592,11 +592,18 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         from dataclasses import replace as dc_replace  # noqa: PLC0415
 
+        from custom_components.aegis_ajax.api.hts.hub_state import (  # noqa: PLC0415
+            HTS_TEMPERATURE_DEVICE_TYPES,
+        )
+
         changed = False
         for device_id, device in list(self.devices.items()):
+            # Families sourced from HTS 0x02 (sirens #312, Curtain Plus/Base
+            # #229) are authoritative there — don't fetch their gRPC board
+            # temperature, which is wrong (runs hotter) and a wasted RPC.
             if (
                 device.device_type not in HUB_DEVICE_TEMPERATURE_DEVICE_TYPES
-                or "temperature" in device.statuses
+                or device.device_type in HTS_TEMPERATURE_DEVICE_TYPES
             ):
                 continue
             try:
@@ -610,6 +617,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 continue
             current = self.devices.get(device_id)
             if current is None:
+                continue
+            # Refresh on change, not once: the temperature must not freeze at the
+            # first reading (#312). An unchanged value is skipped to avoid
+            # churning listeners every interval.
+            if current.statuses.get("temperature") == temperature:
                 continue
             self.devices[device_id] = dc_replace(
                 current, statuses={**current.statuses, "temperature": temperature}
@@ -943,9 +955,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         merge in `_async_refresh_hub_device_temperatures`; the carry-forward in
         the device-snapshot path keeps it across gRPC refreshes.
 
-        Additive and safe: skips devices that already carry a temperature (gRPC
-        wins) and devices not in `HTS_TEMPERATURE_DEVICE_TYPES`. Returns True
-        when a value was applied. Runs on the loop (HTS listen task).
+        Safe and live: only applies to families in `HTS_TEMPERATURE_DEVICE_TYPES`
+        (0x02 is authoritative for them) and refreshes on change so the reading
+        tracks the device rather than freezing at the first value (#312). An
+        unchanged 0x02 (re-reported on every STATUS_BODY probe) is a no-op.
+        Returns True when a value was applied. Runs on the loop (HTS listen task).
         """
         from dataclasses import replace as dc_replace  # noqa: PLC0415
 
@@ -955,8 +969,6 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
         if device.device_type not in HTS_TEMPERATURE_DEVICE_TYPES:
-            return False
-        if "temperature" in device.statuses:
             return False
         temperature = parse_device_temperature_c(device.device_type, kv)
         if temperature is None:
@@ -968,6 +980,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 device.device_type,
                 sorted(kv),
             )
+            return False
+        if device.statuses.get("temperature") == temperature:
+            # Unchanged value re-reported on a routine probe — no listener churn.
             return False
         self.devices[device_id_hex] = dc_replace(
             device, statuses={**device.statuses, "temperature": temperature}

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -621,4 +621,27 @@ class TestParseDeviceTemperatureC:
     def test_gated_types_present(self) -> None:
         assert "motion_protect_curtain_outdoor_plus" in HTS_TEMPERATURE_DEVICE_TYPES
         assert "motion_protect_curtain_outdoor_base" in HTS_TEMPERATURE_DEVICE_TYPES
+        # Mini stays gRPC-only — it carries device_temperature in its HubDevice
+        # message and has no confirmed HTS 0x02 sample.
         assert "motion_protect_curtain_outdoor_mini" not in HTS_TEMPERATURE_DEVICE_TYPES
+
+    def test_sirens_decode_from_0x02(self) -> None:
+        # #312/#269: sirens carry their internal temperature on HTS 0x02 (the
+        # value the Ajax app shows), confirmed for both the indoor HomeSiren and
+        # the outdoor StreetSiren. They are sourced from 0x02, not the gRPC
+        # board temperature, so the reading matches the app and updates live.
+        assert (
+            parse_device_temperature_c("street_siren", {DEVICE_KEY_TEMPERATURE_C: b"\x19"}) == 25.0
+        )
+        assert parse_device_temperature_c("home_siren", {DEVICE_KEY_TEMPERATURE_C: b"\x17"}) == 23.0
+
+    def test_siren_types_in_gated_set(self) -> None:
+        for siren_type in (
+            "street_siren",
+            "street_siren_plus_g3",
+            "home_siren",
+            "home_siren_g3",
+            "home_siren_s",
+            "home_siren_fibra",
+        ):
+            assert siren_type in HTS_TEMPERATURE_DEVICE_TYPES

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2228,27 +2228,13 @@ def _make_siren(
 
 class TestHubDeviceTemperatureRefresh:
     @pytest.mark.asyncio
-    async def test_merges_temperature_into_siren_statuses(self) -> None:
-        coordinator = _make_coordinator(["s1"])
-        coordinator.devices = {"s1d": _make_siren("s1d")}
-        coordinator.async_set_updated_data = MagicMock()
-        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
-
-        await coordinator._async_refresh_hub_device_temperatures()
-
-        assert coordinator.devices["s1d"].statuses["temperature"] == 21.0
-        coordinator._devices_api.get_hub_device_temperature.assert_awaited_once_with("hub-1", "s1d")
-        # The merge must be pushed to listeners or the sensor never materialises.
-        coordinator.async_set_updated_data.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_merges_temperature_into_curtain_outdoor_statuses(self) -> None:
-        # #229: outdoor curtain PIRs are gated for the StreamHubDevice
-        # temperature fetch just like sirens — the light stream omits their
-        # temperature, so the sensor only materialises via this path.
+    async def test_merges_temperature_into_curtain_mini_statuses(self) -> None:
+        # The Curtain Outdoor Mini is the only family still sourced over gRPC
+        # (it carries device_temperature and has no confirmed HTS 0x02). The
+        # light stream omits its temperature, so the sensor materialises here.
         coordinator = _make_coordinator(["s1"])
         coordinator.devices = {
-            "c1d": _make_siren("c1d", device_type="motion_protect_curtain_outdoor_plus")
+            "c1d": _make_siren("c1d", device_type="motion_protect_curtain_outdoor_mini")
         }
         coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=17.0)
@@ -2260,7 +2246,28 @@ class TestHubDeviceTemperatureRefresh:
         coordinator.async_set_updated_data.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_skips_non_siren_devices(self) -> None:
+    async def test_skips_grpc_fetch_for_hts_sourced_families(self) -> None:
+        # #312/#269: sirens (and Curtain Plus/Base) are sourced from HTS 0x02,
+        # which is authoritative and matches the Ajax app. They must NOT be
+        # fetched over the gRPC StreamHubDevice path (that returns the board
+        # temperature and wastes an RPC).
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {
+            "s1d": _make_siren("s1d"),
+            "cpd": _make_siren("cpd", device_type="motion_protect_curtain_outdoor_plus"),
+        }
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=99.0)
+
+        await coordinator._async_refresh_hub_device_temperatures()
+
+        coordinator._devices_api.get_hub_device_temperature.assert_not_called()
+        assert "temperature" not in coordinator.devices["s1d"].statuses
+        assert "temperature" not in coordinator.devices["cpd"].statuses
+        coordinator.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_non_temperature_devices(self) -> None:
         coordinator = _make_coordinator(["s1"])
         coordinator.devices = {"d1": _make_device("d1")}  # door_protect
         coordinator.async_set_updated_data = MagicMock()
@@ -2273,34 +2280,64 @@ class TestHubDeviceTemperatureRefresh:
         coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_skips_siren_that_already_has_temperature(self) -> None:
+    async def test_changed_grpc_temperature_updates(self) -> None:
+        # #312: a gRPC-sourced reading must not freeze after the first fetch —
+        # a different value updates the stored temperature and notifies.
         coordinator = _make_coordinator(["s1"])
-        coordinator.devices = {"s1d": _make_siren("s1d", statuses={"temperature": 18.0})}
+        coordinator.devices = {
+            "c1d": _make_siren(
+                "c1d",
+                device_type="motion_protect_curtain_outdoor_mini",
+                statuses={"temperature": 18.0},
+            )
+        }
         coordinator.async_set_updated_data = MagicMock()
-        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=99.0)
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
 
         await coordinator._async_refresh_hub_device_temperatures()
 
-        coordinator._devices_api.get_hub_device_temperature.assert_not_called()
-        assert coordinator.devices["s1d"].statuses["temperature"] == 18.0
+        assert coordinator.devices["c1d"].statuses["temperature"] == 21.0
+        coordinator.async_set_updated_data.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unchanged_grpc_temperature_is_noop(self) -> None:
+        coordinator = _make_coordinator(["s1"])
+        coordinator.devices = {
+            "c1d": _make_siren(
+                "c1d",
+                device_type="motion_protect_curtain_outdoor_mini",
+                statuses={"temperature": 21.0},
+            )
+        }
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=21.0)
+
+        await coordinator._async_refresh_hub_device_temperatures()
+
+        assert coordinator.devices["c1d"].statuses["temperature"] == 21.0
         coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_none_result_leaves_statuses_untouched(self) -> None:
         coordinator = _make_coordinator(["s1"])
-        coordinator.devices = {"s1d": _make_siren("s1d")}
+        coordinator.devices = {
+            "c1d": _make_siren("c1d", device_type="motion_protect_curtain_outdoor_mini")
+        }
         coordinator.async_set_updated_data = MagicMock()
         coordinator._devices_api.get_hub_device_temperature = AsyncMock(return_value=None)
 
         await coordinator._async_refresh_hub_device_temperatures()
 
-        assert "temperature" not in coordinator.devices["s1d"].statuses
+        assert "temperature" not in coordinator.devices["c1d"].statuses
         coordinator.async_set_updated_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_one_device_error_does_not_abort_others(self) -> None:
         coordinator = _make_coordinator(["s1"])
-        coordinator.devices = {"bad": _make_siren("bad"), "good": _make_siren("good")}
+        coordinator.devices = {
+            "bad": _make_siren("bad", device_type="motion_protect_curtain_outdoor_mini"),
+            "good": _make_siren("good", device_type="motion_protect_curtain_outdoor_mini"),
+        }
         coordinator.async_set_updated_data = MagicMock()
 
         async def _temp(hub_id: str, device_id: str) -> float:
@@ -2326,7 +2363,9 @@ class TestHubDeviceTemperatureRefresh:
         coordinator = _make_coordinator()
         coordinator._client.session.is_authenticated = True
         coordinator._streams_started = True
-        coordinator.devices = {"s1d": _make_siren("s1d")}
+        coordinator.devices = {
+            "c1d": _make_siren("c1d", device_type="motion_protect_curtain_outdoor_mini")
+        }
         coordinator._stream_tasks = [MagicMock(done=MagicMock(return_value=False))]
         coordinator._hts_client = MagicMock()
         coordinator._hts_task = MagicMock(done=MagicMock(return_value=False))
@@ -2875,13 +2914,28 @@ class TestHtsDeviceTemperature:
         assert coordinator.devices["d1"].statuses["temperature"] == 27.0
         coordinator.async_set_updated_data.assert_called_once()
 
-    def test_existing_grpc_temperature_not_overwritten(self) -> None:
-        # gRPC wins: an already-present temperature is left untouched.
-        coordinator = self._coordinator_with_device(
-            "motion_protect_curtain_outdoor_plus", statuses={"temperature": 21.0}
-        )
-        coordinator._on_hts_device_kv("hub-1", "d1", {0x02: b"\x1b"})
-        assert coordinator.devices["d1"].statuses["temperature"] == 21.0
+    def test_siren_temperature_merged_from_0x02(self) -> None:
+        # #312/#269: sirens are sourced from HTS 0x02 (matches the Ajax app),
+        # not the gRPC board temperature.
+        coordinator = self._coordinator_with_device("street_siren")
+        coordinator._on_hts_device_kv("hub-1", "d1", {0x02: b"\x19"})
+        assert coordinator.devices["d1"].statuses["temperature"] == 25.0
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_changed_0x02_updates_existing_temperature(self) -> None:
+        # #312: the reading must not freeze after the first value. A different
+        # 0x02 updates the stored temperature and notifies listeners.
+        coordinator = self._coordinator_with_device("street_siren", statuses={"temperature": 28.0})
+        coordinator._on_hts_device_kv("hub-1", "d1", {0x02: b"\x1a"})
+        assert coordinator.devices["d1"].statuses["temperature"] == 26.0
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_unchanged_0x02_is_noop(self) -> None:
+        # An identical 0x02 (re-reported on every STATUS_BODY probe) must not
+        # churn listeners.
+        coordinator = self._coordinator_with_device("street_siren", statuses={"temperature": 25.0})
+        coordinator._on_hts_device_kv("hub-1", "d1", {0x02: b"\x19"})
+        assert coordinator.devices["d1"].statuses["temperature"] == 25.0
         coordinator.async_set_updated_data.assert_not_called()
 
     def test_non_gated_device_not_given_hts_temperature(self) -> None:


### PR DESCRIPTION
## Problem (#312)

A StreetSiren reported a fixed 28 °C in Home Assistant while the Ajax app showed 25–27 °C, "stuck no matter what" (reload, etc.).

Two root causes:

1. **Frozen reading.** The per-device temperature was read once and then never updated. Both updaters skip a device that already has a value — the 15-min gRPC refresh (`coordinator.py`: `or "temperature" in device.statuses: continue`) and the HTS 0x02 path (`if "temperature" in device.statuses: return False`) — and the snapshot carry-forward never clears it. So the first reading lived forever.
2. **Wrong source.** Sirens were sourced from the gRPC `StreamHubDevice` `device_temperature`, which is the internal **board** sensor — it reads a few degrees above ambient on a sun-exposed StreetSiren.

## Fix

- **Sirens are now sourced from HTS sub-key 0x02** — the same live internal-temperature value the Ajax app shows. Confirmed for both HomeSiren and StreetSiren in #269 (bogar + wip3out3r). They are added to `HTS_TEMPERATURE_DEVICE_TYPES` and **excluded from the gRPC board-temperature fetch** (no wrong value, no wasted RPC).
- **The freeze is fixed for every per-device source.** Both the gRPC refresh and the HTS path now update when the value *changes* (and no-op when it doesn't), instead of skipping once a value exists. The Curtain Outdoor Plus/Base also update live now.
- **Curtain Outdoor Mini is untouched** — it's the only family still sourced over gRPC (carries `device_temperature`, no confirmed HTS 0x02 sample). It stays the lone blocker for the full #269 unification.

`HUB_DEVICE_TEMPERATURE_DEVICE_TYPES` now serves as the carry-forward set (so the merged value survives a fresh stream snapshot); the gRPC fetch runs only for its members **not** in `HTS_TEMPERATURE_DEVICE_TYPES`.

## Tests (TDD)

Red-first, then green. Added/updated coverage in `test_hub_state.py` (sirens decode 0x02 + are in the gated set) and `test_coordinator.py`:
- siren temperature merged from 0x02
- a changed 0x02 / gRPC value updates (no freeze); an unchanged one is a no-op
- HTS-sourced families are skipped by the gRPC fetch
- Curtain Mini still fetched over gRPC

Full suite: **1748 passed, 1 skipped**.

## Validation

bvis-home has no siren, so this is validated by the reporter (@adamspir, StreetSiren + FCM). Ships as a beta first.

Refs #312, #269.
