### PR TITLE
feat(temperature): source MotionProtect Outdoor temperature from HTS 0x02 (#269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - unreleased
+
+### Added
+- **MotionProtect Outdoor now exposes its internal temperature (#269).** The outdoor motion detector doesn't report temperature on the device stream the integration reads for most families, so no temperature sensor was created for it. It is now sourced from the same live internal-temperature value the Ajax app shows (HTS sub-key 0x02, the same path already used for the Curtain Outdoor Plus/Base and the sirens), confirmed against a reporter's capture of a MotionProtect Outdoor Jeweller.
+
 ## [1.12.1] - 2026-06-20
 
 Siren temperature fix. Consolidates the 1.12.1-beta series.

--- a/custom_components/aegis_ajax/api/hts/hub_state.py
+++ b/custom_components/aegis_ajax/api/hts/hub_state.py
@@ -262,6 +262,11 @@ HTS_TEMPERATURE_DEVICE_TYPES: frozenset[str] = frozenset(
     {
         "motion_protect_curtain_outdoor_plus",
         "motion_protect_curtain_outdoor_base",
+        # MotionProtect Outdoor (#269). No temperature on the light stream; a
+        # reporter's STATUS_BODY capture showed 0x02 with plausible ambient
+        # values on every candidate row (26–29 °C in July), matching the
+        # Curtain Outdoor Plus/Base behaviour on the same protocol.
+        "motion_protect_outdoor",
         # Sirens (#312, #269). They also expose a gRPC `device_temperature`, but
         # that is the internal *board* temperature (runs hotter than ambient and
         # only refreshes on the slow per-device snapshot). HTS 0x02 is the value

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -155,10 +155,11 @@ MAX_RETRIES = 3
 RATE_LIMIT_REQUESTS = 60
 RATE_LIMIT_WINDOW = 60  # seconds
 
-# Per-device internal temperature (#220, #229, #312). Some devices report their
-# temperature only in the rich per-device `StreamHubDevice` snapshot, not in the
-# lighter `StreamLightDevices` stream we run continuously: sirens (#220) and
-# outdoor curtain motion detectors (#229). The Curtain Outdoor *Mini* is the
+# Per-device internal temperature (#220, #229, #269, #312). Some devices report
+# their temperature only in the rich per-device `StreamHubDevice` snapshot, not
+# in the lighter `StreamLightDevices` stream we run continuously: sirens (#220),
+# outdoor curtain motion detectors (#229) and the MotionProtect Outdoor (#269).
+# The Curtain Outdoor *Mini* is the
 # only family still pulled over gRPC (a throttled one-shot snapshot — temperature
 # is slow-moving and a persistent per-device stream would contradict how the
 # Ajax app uses that endpoint). Sirens and the Curtain Plus/Base are sourced from
@@ -182,6 +183,7 @@ HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
         "motion_protect_curtain_outdoor_base",
         "motion_protect_curtain_outdoor_mini",
         "motion_protect_curtain_outdoor_plus",
+        "motion_protect_outdoor",
     }
 )
 

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -645,3 +645,35 @@ class TestParseDeviceTemperatureC:
             "home_siren_fibra",
         ):
             assert siren_type in HTS_TEMPERATURE_DEVICE_TYPES
+
+    def test_motion_protect_outdoor_decodes_from_0x02(self) -> None:
+        # #269: MotionProtect Outdoor Jeweller carries no temperature on the
+        # light stream. A reporter's STATUS_BODY capture showed 0x02 on every
+        # candidate row with plausible ambient values (0x1d = 29 °C, 0x1a =
+        # 26 °C in July), so the family is sourced from HTS like the Curtain
+        # Outdoor Plus/Base.
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_outdoor", {DEVICE_KEY_TEMPERATURE_C: b"\x1d"}
+            )
+            == 29.0
+        )
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_outdoor", {DEVICE_KEY_TEMPERATURE_C: b"\x1a"}
+            )
+            == 26.0
+        )
+
+    def test_motion_protect_outdoor_in_gated_set(self) -> None:
+        assert "motion_protect_outdoor" in HTS_TEMPERATURE_DEVICE_TYPES
+
+    def test_hts_set_is_subset_of_carry_forward_set(self) -> None:
+        # Every HTS-sourced family must also be in the coordinator's
+        # carry-forward set, or the merged temperature would be dropped on the
+        # next gRPC device snapshot (see the hub_state / const.py comments).
+        from custom_components.aegis_ajax.const import (
+            HUB_DEVICE_TEMPERATURE_DEVICE_TYPES,
+        )
+
+        assert HTS_TEMPERATURE_DEVICE_TYPES <= HUB_DEVICE_TEMPERATURE_DEVICE_TYPES


### PR DESCRIPTION
## Summary

Adds the internal temperature sensor for the **MotionProtect Outdoor** family, sourced from HTS sub-key `0x02` — the same live path already used for the Curtain Outdoor Plus/Base (#229) and the sirens (#312).

Context: #269. A reporter with a MotionProtect Outdoor Jeweller confirmed the family reports no temperature on the light stream, and shared a `STATUS_BODY` capture where every candidate row carries `0x02` with plausible ambient values (26–29 °C in July).

## Changes

- `api/hts/hub_state.py`: add `motion_protect_outdoor` to `HTS_TEMPERATURE_DEVICE_TYPES`.
- `const.py`: add it to `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES` so the merged value survives gRPC snapshots (being in both sets also excludes it from the per-device gRPC fetch).
- Tests: decode tests with the reporter's real capture values, gating test, and a new invariant test asserting `HTS_TEMPERATURE_DEVICE_TYPES ⊆ HUB_DEVICE_TEMPERATURE_DEVICE_TYPES` (would have caught forgetting the const half).

## Testing

- `make check` green in the CI image (no volume mount): 1751 passed, coverage 89.29%, lint/format/typecheck/dead-code clean.
- TDD: both new tests watched failing before the change; the invariant test watched failing between the two halves of the change.