### PR TITLE
feat(diagnostics): read-only WebRTC live-video feasibility probe (#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - unreleased
+
+### Added
+- **Diagnostics now probe whether Ajax's cloud live-video stream is available to the account (#322).** Groundwork for possible camera support on cloud-hosted Home Assistant (where the local ONVIF/RTSP path isn't reachable): the diagnostics download now includes a read-only, best-effort check of the WebRTC signalling the Ajax app uses for remote live view. It reports only whether the account is authorised to start a session and a summary of the offered connection servers — never any credentials, addresses or video — and negotiates no actual stream. It has no effect on normal operation and is skipped when there are no video devices.
+
 ## [1.13.0] - 2026-07-14
 
 MotionProtect Outdoor internal temperature. Consolidates the 1.13.0-beta series.

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -412,6 +412,72 @@ class DevicesApi:
             return {"error": "rpc_error"}
         return {"error": "empty_stream"}
 
+    async def probe_webrtc_initiate(self, space_id: str, video_edge_id: str) -> dict[str, Any]:
+        """Read-only WebRTC signalling probe for live-video feasibility (#322).
+
+        The Ajax app pulls remote live video **exclusively over WebRTC**: a
+        ``WebrtcService.initiate`` signalling stream that returns ICE/TURN
+        servers and an SDP offer from the camera. Before investing in a real
+        ``camera`` entity we need to know whether a normal account is even
+        authorised to start that session, or whether it is permission-walled
+        server-side the way photo-on-demand v3 was.
+
+        This opens the signalling stream, reads **only the first** server
+        message and closes it — it never sends an SDP offer/answer, so no media
+        is negotiated and no session is actually established (the same benign
+        shape as opening then immediately dismissing a camera in the app).
+        Returns a **PII-free** summary: whether we got past the permission gate,
+        the first signalling message type, and the count/schemes of the offered
+        ICE servers — never their credentials, URLs or any SDP. ``authorized``
+        is ``False`` only on an explicit ``permission_denied``; any other
+        failure (offline/not-found) still means the permission gate was passed,
+        so it reports ``authorized: True`` with the reason. Never raises; any
+        failure → ``{"error": reason}``.
+        """
+        from systems.ajax.api.mobile.v2.common.space import space_locator_pb2  # noqa: PLC0415
+        from systems.ajax.api.mobile.v2.video.webrtc import (  # noqa: PLC0415
+            initiate_request_pb2,
+            webrtc_endpoints_pb2_grpc,
+        )
+
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+        stub = webrtc_endpoints_pb2_grpc.WebrtcServiceStub(channel)
+        request = initiate_request_pb2.InitiateWebRtcRequest(
+            video_edge_id=video_edge_id,
+            space_locator=space_locator_pb2.SpaceLocator(space_id=space_id),
+        )
+        try:
+            # First message only: the stream would carry the full SDP handshake,
+            # but we deliberately stop before answering so nothing is negotiated.
+            async for msg in stub.initiate(request, metadata=metadata, timeout=15):
+                which = msg.WhichOneof("response") if hasattr(msg, "WhichOneof") else None
+                if which == "failure":
+                    reason = msg.failure.WhichOneof("error") or "failure"
+                    return {"authorized": reason != "permission_denied", "error": reason}
+                if which == "success":
+                    sig = msg.success.WhichOneof("signaling_message")
+                    result: dict[str, Any] = {"authorized": True, "first_message": sig}
+                    if sig == "init":
+                        init = msg.success.init
+                        schemes: set[str] = set()
+                        for server in init.ice_servers:
+                            for url in server.urls:
+                                schemes.add(url.split(":", 1)[0].lower())
+                        result["ice_servers_count"] = len(init.ice_servers)
+                        result["ice_schemes"] = sorted(schemes)
+                        result["streams_count"] = len(init.streams)
+                    return result
+                return {"error": "unexpected_message"}
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "WebRtc initiate probe failed for video_edge %s",
+                video_edge_id,
+                exc_info=True,
+            )
+            return {"error": "rpc_error"}
+        return {"error": "empty_stream"}
+
     def _handle_update(
         self,
         update: Any,  # noqa: ANN401

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -61,10 +61,18 @@ async def async_get_config_entry_diagnostics(
         network = await coordinator.devices_api.get_video_edge_network(
             owning_space or next(iter(coordinator.spaces), ""), ve_id
         )
+        # Read-only WebRTC feasibility probe (#322): does the account get past
+        # the permission gate to start the app-style remote live stream? PII-free
+        # (no credentials/URLs/SDP); no media is negotiated. This is the go/no-go
+        # signal for a future camera entity for cloud-only (VPS) Home Assistant.
+        webrtc = await coordinator.devices_api.probe_webrtc_initiate(
+            owning_space or next(iter(coordinator.spaces), ""), ve_id
+        )
         video_edge_probe[ve_id] = {
             "kinds": sorted(k for k in kinds if k),
             **(settings or {"error": "not_probed"}),
             "network": network,
+            "webrtc": webrtc,
         }
 
     return {

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.13.0"
+    "version": "1.14.0-beta.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aegis-ajax-hass"
 # Mirror of manifest.json's version (the source of truth HA reads). Kept in
 # sync by tests/unit/test_version_consistency.py — bump both when releasing.
-version = "1.13.0"
+version = "1.14.0-beta.1"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1858,6 +1858,174 @@ class TestVideoEdgeOnvifRtspProbe:
         assert result == {"error": "rpc_error"}
 
 
+class TestWebRtcInitiateProbe:
+    """Issue #322: a read-only WebRTC signalling probe. The Ajax app pulls
+    remote live video only over WebRTC, so before building a camera entity we
+    need to know whether a normal account is authorised to start that session
+    or whether it is permission-walled server-side (like photo v3). The probe
+    reads only the first `initiate` message and never sends an SDP offer, so no
+    media is negotiated. Returns a PII-free summary — never credentials, URLs
+    or SDP — and never raises."""
+
+    @staticmethod
+    def _make_api() -> DevicesApi:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        return DevicesApi(client)
+
+    @pytest.mark.asyncio
+    async def test_success_init_reports_authorized_and_ice_summary(self) -> None:
+        from systems.ajax.api.mobile.v2.common.video.webrtc import (
+            ice_server_pb2,
+            stream_pb2,
+        )
+        from systems.ajax.api.mobile.v2.video.webrtc import (
+            initiate_request_pb2,
+            webrtc_endpoints_pb2_grpc,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        init = initiate_request_pb2.InitiateWebRtcResponse.Success.WebRtcInit(
+            session_id="sess-1",
+            ice_servers=[
+                ice_server_pb2.IceServer(urls=["stun:stun.example:3478"]),
+                ice_server_pb2.IceServer(
+                    urls=["turn:turn.example:3478"],
+                    username="secret-user",
+                    credential="secret-cred",
+                ),
+            ],
+            streams=[stream_pb2.Stream(id="s1"), stream_pb2.Stream(id="s2")],
+        )
+        msg = initiate_request_pb2.InitiateWebRtcResponse(
+            success=initiate_request_pb2.InitiateWebRtcResponse.Success(init=init)
+        )
+
+        async def _aiter(*_a: object, **_k: object) -> AsyncGenerator[object, None]:
+            yield msg
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                def _initiate(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return _aiter()
+
+                self.initiate = _initiate
+
+        with patch.object(webrtc_endpoints_pb2_grpc, "WebrtcServiceStub", _StubFactory):
+            result = await api.probe_webrtc_initiate("space-1", "30BE4400")
+
+        assert isinstance(captured[0], initiate_request_pb2.InitiateWebRtcRequest)
+        assert captured[0].video_edge_id == "30BE4400"
+        assert captured[0].space_locator.space_id == "space-1"
+        assert result == {
+            "authorized": True,
+            "first_message": "init",
+            "ice_servers_count": 2,
+            "ice_schemes": ["stun", "turn"],
+            "streams_count": 2,
+        }
+        # PII guard: TURN credentials must never reach the diagnostics dump.
+        assert "secret-user" not in str(result)
+        assert "secret-cred" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_permission_denied_reports_unauthorized(self) -> None:
+        from systems.ajax.api.mobile.v2.common.response import response_pb2 as webrtc_err_pb2
+        from systems.ajax.api.mobile.v2.video.webrtc import (
+            initiate_request_pb2,
+            webrtc_endpoints_pb2_grpc,
+        )
+
+        api = self._make_api()
+        msg = initiate_request_pb2.InitiateWebRtcResponse(
+            failure=initiate_request_pb2.InitiateWebRtcResponse.Failure(
+                permission_denied=webrtc_err_pb2.DefaultError(),
+            )
+        )
+
+        async def _aiter(*_a: object, **_k: object) -> AsyncGenerator[object, None]:
+            yield msg
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.initiate = lambda *a, **k: _aiter()
+
+        with patch.object(webrtc_endpoints_pb2_grpc, "WebrtcServiceStub", _StubFactory):
+            result = await api.probe_webrtc_initiate("space-1", "30BE4400")
+
+        assert result == {"authorized": False, "error": "permission_denied"}
+
+    @pytest.mark.asyncio
+    async def test_offline_edge_is_authorized_but_reports_error(self) -> None:
+        # A non-permission failure means we passed the permission gate; the
+        # camera is just unreachable right now. authorized stays True so the
+        # go/no-go signal isn't a false negative.
+        from systems.ajax.api.mobile.v2.common.response import response_pb2 as webrtc_err_pb2
+        from systems.ajax.api.mobile.v2.video.webrtc import (
+            initiate_request_pb2,
+            webrtc_endpoints_pb2_grpc,
+        )
+
+        api = self._make_api()
+        msg = initiate_request_pb2.InitiateWebRtcResponse(
+            failure=initiate_request_pb2.InitiateWebRtcResponse.Failure(
+                video_edge_is_offline=webrtc_err_pb2.DefaultError(),
+            )
+        )
+
+        async def _aiter(*_a: object, **_k: object) -> AsyncGenerator[object, None]:
+            yield msg
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.initiate = lambda *a, **k: _aiter()
+
+        with patch.object(webrtc_endpoints_pb2_grpc, "WebrtcServiceStub", _StubFactory):
+            result = await api.probe_webrtc_initiate("space-1", "30BE4400")
+
+        assert result == {"authorized": True, "error": "video_edge_is_offline"}
+
+    @pytest.mark.asyncio
+    async def test_rpc_exception_reports_error(self) -> None:
+        from systems.ajax.api.mobile.v2.video.webrtc import webrtc_endpoints_pb2_grpc
+
+        api = self._make_api()
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                def _initiate(*_a: object, **_k: object) -> object:
+                    raise RuntimeError("boom")
+
+                self.initiate = _initiate
+
+        with patch.object(webrtc_endpoints_pb2_grpc, "WebrtcServiceStub", _StubFactory):
+            result = await api.probe_webrtc_initiate("space-1", "30BE4400")
+
+        assert result == {"error": "rpc_error"}
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_reports_error(self) -> None:
+        from systems.ajax.api.mobile.v2.video.webrtc import webrtc_endpoints_pb2_grpc
+
+        api = self._make_api()
+
+        async def _aiter(*_a: object, **_k: object) -> AsyncGenerator[object, None]:
+            return
+            yield  # pragma: no cover
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                self.initiate = lambda *a, **k: _aiter()
+
+        with patch.object(webrtc_endpoints_pb2_grpc, "WebrtcServiceStub", _StubFactory):
+            result = await api.probe_webrtc_initiate("space-1", "30BE4400")
+
+        assert result == {"error": "empty_stream"}
+
+
 class TestDevicesApiInit:
     def test_init(self) -> None:
         client = MagicMock()

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -72,6 +72,7 @@ class TestAsyncGetConfigEntryDiagnostics:
         # default them to no-ops so non-video fixtures don't await a MagicMock.
         coord.devices_api.get_video_edge_onvif_rtsp_settings = AsyncMock(return_value=None)
         coord.devices_api.get_video_edge_network = AsyncMock(return_value=None)
+        coord.devices_api.probe_webrtc_initiate = AsyncMock(return_value=None)
         return coord
 
     @pytest.fixture
@@ -183,6 +184,15 @@ class TestAsyncGetConfigEntryDiagnostics:
         entry.runtime_data.devices_api.get_video_edge_network = AsyncMock(
             return_value={"interfaces": [{"name": "eth0", "mac": "aa:bb", "ip": "192.168.1.50"}]}
         )
+        entry.runtime_data.devices_api.probe_webrtc_initiate = AsyncMock(
+            return_value={
+                "authorized": True,
+                "first_message": "init",
+                "ice_servers_count": 2,
+                "ice_schemes": ["stun", "turn"],
+                "streams_count": 1,
+            }
+        )
 
         result = await async_get_config_entry_diagnostics(MagicMock(), entry)
 
@@ -193,6 +203,10 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert probe["310A8DF4"]["rtsp"] == {"http_port": 554}
         assert sorted(probe["310A8DF4"]["kinds"]) == ["primary"]
         assert sorted(probe["310B121D"]["kinds"]) == ["nvr"]
+        # #322: the WebRTC live-video feasibility probe rides alongside the
+        # ONVIF/network probe, keyed under the same video_edge_id.
+        assert probe["310A8DF4"]["webrtc"]["authorized"] is True
+        assert probe["310A8DF4"]["webrtc"]["ice_schemes"] == ["stun", "turn"]
 
     @pytest.mark.asyncio
     async def test_life_quality_threshold_flags_dumped_with_values(self, entry: MagicMock) -> None:


### PR DESCRIPTION
## Summary

Phase-1 static proto analysis for #322 established that Ajax's app pulls **remote live video exclusively over WebRTC** (a `WebrtcService.initiate` signalling stream returning ICE/TURN servers + an SDP offer from the camera). There is **no cloud RTSP/HLS URL** to hand Home Assistant, and every WebRTC response carries a `permission_denied` failure case — so the account may be permission-walled server-side, the same way photo-on-demand v3 was.

This PR ships the **go/no-go probe** for that open question, read-only, so we can settle it against a reporter's real camera (ott-play, TurretCam) **without asking them to run an emulator/Frida/mitmproxy capture**.

## What it does

- `DevicesApi.probe_webrtc_initiate(space_id, video_edge_id)`: opens the `initiate` signalling stream, reads **only the first** server message, then closes it **without sending any SDP offer/answer** — no media is negotiated, no session is established (same benign shape as opening then immediately dismissing a camera in the app).
- Returns a **PII-free** summary: `authorized` (False only on explicit `permission_denied`; any other failure still means the gate was passed), the first signalling message type, and the ICE server **count + schemes** (e.g. `["stun", "turn"]`) — **never** credentials, URLs or SDP.
- Wired into diagnostics under the existing `video_edge_onvif_rtsp` probe, keyed per `video_edge_id`. Best-effort, never raises, skipped when there are no video devices.

## Why a diagnostic first

Building the real feature means a full WebRTC peer (aiortc: ICE against Ajax's TURN, DTLS-SRTP, media relay to HA) — a large, high-maintenance lift for a small audience. That's only worth scoping if the account is actually authorised. This probe answers that with zero friction for the tester. See [`feedback_diagnostic_probe_before_feature`] pattern (#282/#302).

## Testing

- TDD: `TestWebRtcInitiateProbe` (5 cases: authorized+init ICE summary, permission_denied → unauthorized, offline → authorized+error, RPC exception, empty stream) — all watched failing before implementation. Includes a PII guard asserting TURN credentials never reach the result.
- Diagnostics integration test asserts the `webrtc` block rides alongside the ONVIF/network probe.
- `make check` green in the CI image (no volume mount): 1756 passed, coverage 89.32%, lint/format/typecheck/dead-code clean.

Shipped as **1.14.0-beta.1** (new diagnostics functionality → MINOR).