### PR TITLE
feat(update): per-device firmware update entities (2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.14.0] - unreleased
 
 ### Added
+- **Per-device firmware update entities (2.1).** The hub-level firmware update entity (1.4.0-beta.5) now has a per-device counterpart: each non-hub device gets an `update.<device>_firmware` entity sourced from the same read-only `streamHubObject` snapshot (field 200, `device_firmware_updates`). It surfaces the pending target version, download progress (during the download phase) and a security-critical flag, and renders "Up to date" when Ajax has no update queued for that device. Like the hub entity it is informational only — no install button and the integration never calls the install RPC. Entities are **disabled by default** (a typical install has 10-30 devices); enable the ones you want to watch.
 - **Diagnostics now probe whether Ajax's cloud live-video stream is available to the account (#322).** Groundwork for possible camera support on cloud-hosted Home Assistant (where the local ONVIF/RTSP path isn't reachable): the diagnostics download now includes a read-only, best-effort check of the WebRTC signalling the Ajax app uses for remote live view. It reports only whether the account is authorised to start a session and a summary of the offered connection servers — never any credentials, addresses or video — and negotiates no actual stream. It has no effect on normal operation and is skipped when there are no video devices.
 
 ## [1.13.0] - 2026-07-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - unreleased
+
+### Added
+- **Per-device firmware update entities (2.1).** The hub-level firmware update entity (1.4.0-beta.5) now has a per-device counterpart: each non-hub device gets an `update.<device>_firmware` entity sourced from the same read-only `streamHubObject` snapshot (field 200, `device_firmware_updates`). It surfaces the pending target version, download progress (during the download phase) and a security-critical flag, and renders "Up to date" when Ajax has no update queued for that device. A failed install attempt is called out in the entity's summary, and both firmware maps are included in the diagnostics download. Like the hub entity it is informational only — no install button and the integration never calls the install RPC. Entities are **disabled by default** (a typical install has 10-30 devices); enable the ones you want to watch.
+
+### Fixed
+- **Hub firmware update entity now reports download progress.** The `PROGRESS` feature flag was missing, so Home Assistant silently ignored the entity's in-progress signal while the hub was downloading a queued firmware update.
+
 ## [1.14.0] - 2026-07-18
 
 Cloud live-video feasibility probe in diagnostics and mains-power flapping fixes. Consolidates the 1.14.0-beta series.
 
 ### Added
-- **Per-device firmware update entities (2.1).** The hub-level firmware update entity (1.4.0-beta.5) now has a per-device counterpart: each non-hub device gets an `update.<device>_firmware` entity sourced from the same read-only `streamHubObject` snapshot (field 200, `device_firmware_updates`). It surfaces the pending target version, download progress (during the download phase) and a security-critical flag, and renders "Up to date" when Ajax has no update queued for that device. Like the hub entity it is informational only — no install button and the integration never calls the install RPC. Entities are **disabled by default** (a typical install has 10-30 devices); enable the ones you want to watch.
 - **Diagnostics now probe whether Ajax's cloud live-video stream is available to the account (#322).** Groundwork for possible camera support on cloud-hosted Home Assistant (where the local ONVIF/RTSP path isn't reachable): the diagnostics download now includes a read-only, best-effort check of the WebRTC signalling the Ajax app uses for remote live view. It reports only whether the account is authorised to start a session and a summary of the offered connection servers — never any credentials, addresses or video — and negotiates no actual stream. It has no effect on normal operation and is skipped when there are no video devices.
 
 ### Fixed

--- a/custom_components/aegis_ajax/api/hub_object.py
+++ b/custom_components/aegis_ajax/api/hub_object.py
@@ -55,6 +55,44 @@ class HubFirmwareUpdateInfo:
     state: str
 
 
+# Phase of an Ajax-side per-device firmware update. Mirrors the
+# `DeviceFirmwareUpdate.Status` oneof (field 200 of the hub object):
+# not_started → downloading(%) → downloaded → installing → completed
+# (or → failed). Unlike the hub `system_firmware_update`, this list is
+# populated whenever the Ajax cloud has queued an update for a specific
+# device, so absence of a device's entry means "device is up to date".
+DEVICE_FW_STATE_NONE = "none"  # no pending update (device absent from list)
+DEVICE_FW_STATE_NOT_STARTED = "not_started"  # queued, not begun
+DEVICE_FW_STATE_DOWNLOADING = "downloading"  # server pushing bytes (has %)
+DEVICE_FW_STATE_DOWNLOADED = "downloaded"  # bytes on device, not installing yet
+DEVICE_FW_STATE_INSTALLING = "installing"  # device flashing new firmware
+DEVICE_FW_STATE_COMPLETED = "completed"  # finished (transient, then entry drops)
+DEVICE_FW_STATE_FAILED = "failed"  # last attempt failed
+
+
+@dataclass(frozen=True)
+class DeviceFirmwareUpdateInfo:
+    """Pending firmware update for a single Ajax device.
+
+    Reported by `streamHubObject` (field 200, `device_firmware_updates`).
+    `device_id` is the Ajax hex hardware id (matching `Device.id`);
+    `target_version` is the version the device will move to; `state` is
+    one of the `DEVICE_FW_STATE_*` constants; `progress` is the 0-99
+    download percentage while `state == DEVICE_FW_STATE_DOWNLOADING`
+    (``None`` otherwise); `is_critical` flags a security-critical update.
+
+    As with the hub, Ajax does not expose the currently-installed
+    version in this stream and this integration never triggers the
+    install RPC — the entity is informational only.
+    """
+
+    device_id: str
+    target_version: str
+    state: str
+    progress: int | None = None
+    is_critical: bool = False
+
+
 class HubObjectApi:
     """API for hub-level data via streamHubObject."""
 
@@ -167,6 +205,93 @@ class HubObjectApi:
             target_version=sfu.firmware_version or "",
             state=state,
         )
+
+    async def get_device_firmware_updates(self, hub_id: str) -> list[DeviceFirmwareUpdateInfo]:
+        """Get pending per-device firmware updates from streamHubObject (field 200).
+
+        Returns an empty list when no device on the hub has a queued
+        update, when the stream errors, or when the payload omits the
+        field. Ajax only lists a device here while an update is queued
+        or in flight, so a device's absence from the list means it is
+        up to date from the cloud's perspective.
+        """
+        channel = self._client._get_channel()
+        metadata = self._client._session.get_call_metadata()
+
+        tag = (1 << 3) | 2
+        encoded = hub_id.encode("utf-8")
+        request_bytes = bytes([tag, len(encoded)]) + encoded
+
+        method = channel.unary_stream(
+            "/systems.ajax.api.mobile.v2.hubobject.HubObjectService/streamHubObject",
+            request_serializer=lambda x: x,
+            response_deserializer=lambda x: x,
+        )
+
+        try:
+            stream = method(request_bytes, metadata=metadata, timeout=15)
+            async for raw_msg in stream:
+                return self._parse_device_firmware_from_hub_object(raw_msg)
+        except Exception:
+            _LOGGER.debug("Failed to get device firmware updates for %s", hub_id)
+
+        return []
+
+    @staticmethod
+    def _parse_device_firmware_from_hub_object(
+        raw_msg: bytes,
+    ) -> list[DeviceFirmwareUpdateInfo]:
+        """Parse the per-device firmware update list from a StreamHubObject frame.
+
+        Uses the generated proto class (same rationale as the hub
+        firmware path — the list hangs off field 200, a multi-byte tag
+        `FromString` handles for us).
+        """
+        from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+            StreamHubObject,
+        )
+
+        try:
+            response = StreamHubObject.FromString(raw_msg)
+        except Exception:
+            return []
+
+        # Only the snapshot (first stream message) carries the full
+        # firmware list; deltas omit unchanged fields.
+        if response.WhichOneof("item") != "snapshot":
+            return []
+        hub_object = response.snapshot
+
+        if not hub_object.HasField("device_firmware_updates"):
+            return []
+
+        updates: list[DeviceFirmwareUpdateInfo] = []
+        for dfu in hub_object.device_firmware_updates.device_firmware_update:
+            device_id = dfu.device_id
+            if not device_id:
+                continue
+            status_name = dfu.status.WhichOneof("status")
+            progress = (
+                dfu.status.downloading if status_name == DEVICE_FW_STATE_DOWNLOADING else None
+            )
+            # Unknown/future status names fall through as their raw label
+            # (or "none" when the oneof is unset) — the entity stays
+            # informational regardless.
+            state = status_name or DEVICE_FW_STATE_NONE
+            target_version = ""
+            if dfu.HasField("resource_id") and dfu.resource_id.HasField("firmware_id"):
+                target_version = dfu.resource_id.firmware_id.firmware_version or ""
+            is_critical = dfu.HasField("is_critical") and dfu.is_critical.value
+            updates.append(
+                DeviceFirmwareUpdateInfo(
+                    device_id=device_id,
+                    target_version=target_version,
+                    state=state,
+                    progress=progress,
+                    is_critical=is_critical,
+                )
+            )
+        return updates
 
     @staticmethod
     def _parse_sim_from_hub_object(raw_msg: bytes) -> SimCardInfo | None:

--- a/custom_components/aegis_ajax/api/hub_object.py
+++ b/custom_components/aegis_ajax/api/hub_object.py
@@ -233,7 +233,7 @@ class HubObjectApi:
             async for raw_msg in stream:
                 return self._parse_device_firmware_from_hub_object(raw_msg)
         except Exception:
-            _LOGGER.debug("Failed to get device firmware updates for %s", hub_id)
+            _LOGGER.debug("Failed to get device firmware updates for %s", hub_id, exc_info=True)
 
         return []
 

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -22,6 +22,7 @@ from custom_components.aegis_ajax.api import devices_parser
 from custom_components.aegis_ajax.api.devices import DevicesApi
 from custom_components.aegis_ajax.api.hts.client import HtsClient
 from custom_components.aegis_ajax.api.hub_object import (
+    DeviceFirmwareUpdateInfo,
     HubFirmwareUpdateInfo,
     HubObjectApi,
     SimCardInfo,
@@ -171,6 +172,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # as `sim_info`. Read-only; the integration never calls the
         # install RPC even though the proto exposes one.
         self.hub_firmware_updates: dict[str, HubFirmwareUpdateInfo] = {}
+        # Pending per-device firmware updates keyed by device_id (2.1).
+        # Absent entry = the device reports no pending update. Rides the
+        # same hourly `streamHubObject` cycle as `hub_firmware_updates`.
+        # Read-only, disabled-by-default entities; the integration never
+        # triggers the install RPC.
+        self.device_firmware_updates: dict[str, DeviceFirmwareUpdateInfo] = {}
         self._notification_listener: AjaxNotificationListener | None = None
         self._stream_tasks: list[asyncio.Task[None]] = []
         self._streams_started: bool = False
@@ -498,6 +505,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         sim_refresh_interval = 3600.0
         if now - self._sim_info_last_fetch <= sim_refresh_interval:
             return
+        # Rebuild the per-device firmware map from scratch each cycle so a
+        # completed/cleared update (Ajax-scheduled installs finish between
+        # cycles) drops out instead of lingering.
+        device_updates: dict[str, DeviceFirmwareUpdateInfo] = {}
         for space in self.spaces.values():
             if not space.hub_id:
                 continue
@@ -510,6 +521,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.hub_firmware_updates.pop(space.hub_id, None)
             else:
                 self.hub_firmware_updates[space.hub_id] = fw
+            for dfu in await self._hub_object_api.get_device_firmware_updates(space.hub_id):
+                device_updates[dfu.device_id] = dfu
+        self.device_firmware_updates = device_updates
         self._sim_info_last_fetch = now
 
     async def _maybe_refresh_rooms(self, now: float) -> None:

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -509,9 +509,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # completed/cleared update (Ajax-scheduled installs finish between
         # cycles) drops out instead of lingering.
         device_updates: dict[str, DeviceFirmwareUpdateInfo] = {}
+        # Multiple spaces can share one hub (group mode); dedupe so the
+        # per-hub `streamHubObject` snapshot is fetched once per cycle.
+        seen_hubs: set[str] = set()
         for space in self.spaces.values():
-            if not space.hub_id:
+            if not space.hub_id or space.hub_id in seen_hubs:
                 continue
+            seen_hubs.add(space.hub_id)
             if space.hub_id not in self.sim_info:
                 sim = await self._hub_object_api.get_sim_info(space.hub_id)
                 if sim:

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -526,7 +526,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else:
                 self.hub_firmware_updates[space.hub_id] = fw
             for dfu in await self._hub_object_api.get_device_firmware_updates(space.hub_id):
-                device_updates[dfu.device_id] = dfu
+                # `.upper()` on write (and on the entity's read): the hex
+                # device id here comes from `streamHubObject` while the
+                # entities key off `Device.id` from the devices snapshot —
+                # two services whose id casing is not guaranteed to match.
+                device_updates[dfu.device_id.upper()] = dfu
         self.device_firmware_updates = device_updates
         self._sim_info_last_fetch = now
 

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -142,6 +142,23 @@ async def async_get_config_entry_diagnostics(
             for kid, k in coordinator.keyfobs.items()
         },
         "video_edge_onvif_rtsp": video_edge_probe,
+        # Firmware update state feeding the `update.*` entities (project
+        # rule: every entity-driving field is dumped here). Both maps are
+        # empty most of the time — Ajax only lists a hub/device while an
+        # update is queued or in flight.
+        "hub_firmware_updates": {
+            hid: {"target_version": fw.target_version, "state": fw.state}
+            for hid, fw in coordinator.hub_firmware_updates.items()
+        },
+        "device_firmware_updates": {
+            did: {
+                "target_version": dfu.target_version,
+                "state": dfu.state,
+                "progress": dfu.progress,
+                "is_critical": dfu.is_critical,
+            }
+            for did, dfu in coordinator.device_firmware_updates.items()
+        },
         "stream_tasks": len(coordinator._stream_tasks),
         "notification_listener": coordinator.notification_listener is not None,
     }

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Microprogramari"
+            },
+            "device_firmware": {
+                "name": "Microprogramari"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -447,6 +447,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -447,6 +447,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Micrologiciel"
+            },
+            "device_firmware": {
+                "name": "Micrologiciel"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Oprogramowanie"
+            },
+            "device_firmware": {
+                "name": "Oprogramowanie"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Firmware"
+            },
+            "device_firmware": {
+                "name": "Firmware"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Donanım yazılımı"
+            },
+            "device_firmware": {
+                "name": "Donanım yazılımı"
             }
         }
     },

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -431,6 +431,9 @@
         "update": {
             "hub_firmware": {
                 "name": "Прошивка"
+            },
+            "device_firmware": {
+                "name": "Прошивка"
             }
         }
     },

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -194,7 +194,7 @@ class AjaxDeviceFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], Upda
         if info is None or not info.target_version:
             # No pending update — mirror installed_version so HA renders
             # "Up to date" (STATE_OFF) rather than "unknown".
-            return _INSTALLED_VERSION_PLACEHOLDER
+            return self.installed_version
         return info.target_version
 
     @property

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -29,7 +29,10 @@ from homeassistant.components.update import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.hub_object import (
+    DEVICE_FW_STATE_DOWNLOADING,
+    DEVICE_FW_STATE_INSTALLING,
     HUB_FW_STATE_DOWNLOADING,
+    DeviceFirmwareUpdateInfo,
     HubFirmwareUpdateInfo,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
@@ -59,7 +62,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
-    entities: list[AjaxHubFirmwareUpdate] = []
+    entities: list[UpdateEntity] = []
     seen: set[str] = set()
     for space in coordinator.spaces.values():
         hub_id = space.hub_id
@@ -70,6 +73,14 @@ async def async_setup_entry(
         if coordinator.devices.get(hub_id):
             entities.append(AjaxHubFirmwareUpdate(coordinator, hub_id))
             seen.add(hub_id)
+
+    # Per-device firmware update entities (2.1). One per non-hub device,
+    # disabled-by-default: a typical install has 10-30 devices and most
+    # users only care when a specific device is stuck on old firmware.
+    for device_id, device in coordinator.devices.items():
+        if device.device_type.startswith("hub"):
+            continue
+        entities.append(AjaxDeviceFirmwareUpdate(coordinator, device_id))
     async_add_entities(entities)
 
 
@@ -137,4 +148,86 @@ class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateE
             f"Ajax has queued firmware {info.target_version} for this hub. "
             "The hub will install it on its own; this entity is "
             "informational and cannot trigger or skip the update."
+        )
+
+
+class AjaxDeviceFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateEntity):
+    """Read-only firmware update entity for a single Ajax device (2.1).
+
+    Same design as `AjaxHubFirmwareUpdate`: informational only (no
+    `INSTALL` feature, no `async_install`), and Ajax does not expose the
+    currently-installed version, so `installed_version` is a constant
+    placeholder. Disabled by default — a typical install has many
+    devices and most users only enable this when chasing a stuck update.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "device_firmware"
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = UpdateEntityFeature(0)
+    # Disabled-by-default: opt-in per device to avoid 10-30 entities most
+    # users don't want.
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: AjaxCobrandedCoordinator, device_id: str) -> None:
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._attr_unique_id = f"aegis_ajax_{device_id}_firmware"
+        device = coordinator.devices.get(device_id)
+        if device:
+            self._attr_device_info = build_device_info(device, coordinator.rooms)
+
+    @property
+    def _info(self) -> DeviceFirmwareUpdateInfo | None:
+        return self.coordinator.device_firmware_updates.get(self._device_id)
+
+    @property
+    def installed_version(self) -> str | None:
+        # See `_INSTALLED_VERSION_PLACEHOLDER`: Ajax doesn't expose the
+        # device's current version, so a constant is used to let HA
+        # differentiate "up to date" from "unknown".
+        return _INSTALLED_VERSION_PLACEHOLDER
+
+    @property
+    def latest_version(self) -> str | None:
+        info = self._info
+        if info is None or not info.target_version:
+            # No pending update — mirror installed_version so HA renders
+            # "Up to date" (STATE_OFF) rather than "unknown".
+            return _INSTALLED_VERSION_PLACEHOLDER
+        return info.target_version
+
+    @property
+    def in_progress(self) -> bool:
+        info = self._info
+        return info is not None and info.state in (
+            DEVICE_FW_STATE_DOWNLOADING,
+            DEVICE_FW_STATE_INSTALLING,
+        )
+
+    @property
+    def update_percentage(self) -> int | None:
+        # Only the download phase carries a 0-99 percentage; the install
+        # phase has no progress signal, so HA shows an indeterminate bar.
+        info = self._info
+        if info is not None and info.state == DEVICE_FW_STATE_DOWNLOADING:
+            return info.progress
+        return None
+
+    @property
+    def release_summary(self) -> str | None:
+        info = self._info
+        if info is None:
+            return (
+                "Ajax has not queued a firmware update for this device. "
+                "The actual installed firmware version is not exposed by "
+                "Ajax to the integration, so 'Up-to-date' reflects only "
+                "the absence of a queued update."
+            )
+        critical = " (security-critical)" if info.is_critical else ""
+        return (
+            f"Ajax has queued firmware {info.target_version} for this "
+            f"device{critical}. The device will install it on its own; "
+            "this entity is informational and cannot trigger or skip the "
+            "update."
         )

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -29,7 +29,9 @@ from homeassistant.components.update import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.hub_object import (
+    DEVICE_FW_STATE_COMPLETED,
     DEVICE_FW_STATE_DOWNLOADING,
+    DEVICE_FW_STATE_FAILED,
     DEVICE_FW_STATE_INSTALLING,
     HUB_FW_STATE_DOWNLOADING,
     DeviceFirmwareUpdateInfo,
@@ -77,8 +79,12 @@ async def async_setup_entry(
     # Per-device firmware update entities (2.1). One per non-hub device,
     # disabled-by-default: a typical install has 10-30 devices and most
     # users only care when a specific device is stuck on old firmware.
+    # `device_id in seen` also guards a hub model newer than the vendored
+    # proto: it parses as device_type "unknown", escapes the name filter,
+    # and would otherwise get a second entity with the hub entity's
+    # unique_id (HA then drops one of the two).
     for device_id, device in coordinator.devices.items():
-        if device.device_type.startswith("hub"):
+        if device_id in seen or device.device_type.startswith("hub"):
             continue
         entities.append(AjaxDeviceFirmwareUpdate(coordinator, device_id))
     async_add_entities(entities)
@@ -90,8 +96,11 @@ class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateE
     _attr_has_entity_name = True
     _attr_translation_key = "hub_firmware"
     _attr_device_class = UpdateDeviceClass.FIRMWARE
-    # No `INSTALL` feature — the entity is informational only.
-    _attr_supported_features = UpdateEntityFeature(0)
+    # No `INSTALL` feature — the entity is informational only. `PROGRESS`
+    # is required for HA to honor the `in_progress` property at all:
+    # without it, `UpdateEntity.state_attributes` ignores the property
+    # and reports the internal install flag (always False here).
+    _attr_supported_features = UpdateEntityFeature.PROGRESS
 
     def __init__(self, coordinator: AjaxCobrandedCoordinator, hub_id: str) -> None:
         super().__init__(coordinator)
@@ -164,7 +173,10 @@ class AjaxDeviceFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], Upda
     _attr_has_entity_name = True
     _attr_translation_key = "device_firmware"
     _attr_device_class = UpdateDeviceClass.FIRMWARE
-    _attr_supported_features = UpdateEntityFeature(0)
+    # No `INSTALL` (informational only); `PROGRESS` so HA honors the
+    # `in_progress`/`update_percentage` properties — without the flag
+    # `UpdateEntity.state_attributes` ignores both.
+    _attr_supported_features = UpdateEntityFeature.PROGRESS
     # Disabled-by-default: opt-in per device to avoid 10-30 entities most
     # users don't want.
     _attr_entity_registry_enabled_default = False
@@ -178,8 +190,20 @@ class AjaxDeviceFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], Upda
             self._attr_device_info = build_device_info(device, coordinator.rooms)
 
     @property
+    def available(self) -> bool:
+        # A device deleted from the hub drops out of `coordinator.devices`
+        # but its (opt-in) entity stays in the registry — HA never evicts
+        # orphans on its own. Without this gate the orphan would keep
+        # reporting a confident "Up to date" forever.
+        return super().available and self._device_id in self.coordinator.devices
+
+    @property
     def _info(self) -> DeviceFirmwareUpdateInfo | None:
-        return self.coordinator.device_firmware_updates.get(self._device_id)
+        # `.upper()` on both sides (see coordinator write): the update map
+        # comes from `streamHubObject` while `Device.id` comes from the
+        # devices snapshot — two services whose hex-id casing is not
+        # guaranteed to match.
+        return self.coordinator.device_firmware_updates.get(self._device_id.upper())
 
     @property
     def installed_version(self) -> str | None:
@@ -191,9 +215,11 @@ class AjaxDeviceFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], Upda
     @property
     def latest_version(self) -> str | None:
         info = self._info
-        if info is None or not info.target_version:
-            # No pending update — mirror installed_version so HA renders
-            # "Up to date" (STATE_OFF) rather than "unknown".
+        if info is None or not info.target_version or info.state == DEVICE_FW_STATE_COMPLETED:
+            # No pending update (or the install just finished and the
+            # entry hasn't dropped from the snapshot yet) — mirror
+            # installed_version so HA renders "Up to date" (STATE_OFF)
+            # rather than "unknown" or a stale "update available".
             return self.installed_version
         return info.target_version
 
@@ -225,6 +251,18 @@ class AjaxDeviceFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], Upda
                 "the absence of a queued update."
             )
         critical = " (security-critical)" if info.is_critical else ""
+        if info.state == DEVICE_FW_STATE_COMPLETED:
+            return (
+                f"Firmware {info.target_version} was just installed on "
+                "this device; Ajax will clear the entry shortly."
+            )
+        if info.state == DEVICE_FW_STATE_FAILED:
+            return (
+                f"The last attempt to install firmware {info.target_version}"
+                f"{critical} on this device FAILED. Ajax retries on its "
+                "own schedule; if it stays failed, check the device in "
+                "the Ajax app."
+            )
         return (
             f"Ajax has queued firmware {info.target_version} for this "
             f"device{critical}. The device will install it on its own; "

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1773,6 +1773,7 @@ class TestCachedSnapshotStart:
         coordinator._hub_object_api = MagicMock()
         coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
         coordinator._hub_object_api.get_firmware_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_device_firmware_updates = AsyncMock(return_value=[])
         coordinator._start_device_streams = AsyncMock()
         coordinator._start_hts = AsyncMock()
         return coordinator
@@ -1883,6 +1884,7 @@ class TestHubFirmwareRefresh:
                 target_version="2.17.0", state=HUB_FW_STATE_DOWNLOADING
             )
         )
+        coordinator._hub_object_api.get_device_firmware_updates = AsyncMock(return_value=[])
 
         await coordinator._async_update_data()
 
@@ -1915,10 +1917,60 @@ class TestHubFirmwareRefresh:
         coordinator._hub_object_api = MagicMock()
         coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
         coordinator._hub_object_api.get_firmware_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_device_firmware_updates = AsyncMock(return_value=[])
 
         await coordinator._async_update_data()
 
         assert "hub-1" not in coordinator.hub_firmware_updates
+
+    @pytest.mark.asyncio
+    async def test_device_firmware_updates_stored_and_cleared(self) -> None:
+        """Per-device firmware updates are rebuilt each cycle (2.1):
+
+        a returned update is stored keyed by device_id; a previously
+        cached entry that Ajax no longer reports is dropped.
+        """
+        from custom_components.aegis_ajax.api.hub_object import (
+            DEVICE_FW_STATE_DOWNLOADING,
+            DeviceFirmwareUpdateInfo,
+        )
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._sim_info_last_fetch = -10_000.0
+        # Stale entry from a prior cycle that Ajax no longer reports.
+        coordinator.device_firmware_updates["OLD99"] = DeviceFirmwareUpdateInfo(
+            device_id="OLD99", target_version="1.0.0", state=DEVICE_FW_STATE_DOWNLOADING
+        )
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+        coordinator._hub_object_api = MagicMock()
+        coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_firmware_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_device_firmware_updates = AsyncMock(
+            return_value=[
+                DeviceFirmwareUpdateInfo(
+                    device_id="AA11BB22",
+                    target_version="6.62.3",
+                    state=DEVICE_FW_STATE_DOWNLOADING,
+                    progress=30,
+                    is_critical=True,
+                )
+            ]
+        )
+
+        await coordinator._async_update_data()
+
+        assert "OLD99" not in coordinator.device_firmware_updates
+        assert "AA11BB22" in coordinator.device_firmware_updates
+        stored = coordinator.device_firmware_updates["AA11BB22"]
+        assert stored.target_version == "6.62.3"
+        assert stored.progress == 30
+        assert stored.is_critical is True
 
 
 class TestOnHtsDeviceKv:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1972,6 +1972,46 @@ class TestHubFirmwareRefresh:
         assert stored.progress == 30
         assert stored.is_critical is True
 
+    @pytest.mark.asyncio
+    async def test_device_firmware_updates_keyed_uppercase(self) -> None:
+        """Regression: the map key is normalized to uppercase because the
+
+        `streamHubObject` hex id casing is not guaranteed to match the
+        devices-snapshot `Device.id` the entities key off (the entity
+        lookup uppercases too).
+        """
+        from custom_components.aegis_ajax.api.hub_object import (
+            DEVICE_FW_STATE_NOT_STARTED,
+            DeviceFirmwareUpdateInfo,
+        )
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._sim_info_last_fetch = -10_000.0
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(return_value=[_make_space("s1")])
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+        coordinator._hub_object_api = MagicMock()
+        coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_firmware_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_device_firmware_updates = AsyncMock(
+            return_value=[
+                DeviceFirmwareUpdateInfo(
+                    device_id="aa11bb22",
+                    target_version="6.62.3",
+                    state=DEVICE_FW_STATE_NOT_STARTED,
+                )
+            ]
+        )
+
+        await coordinator._async_update_data()
+
+        assert "AA11BB22" in coordinator.device_firmware_updates
+        assert "aa11bb22" not in coordinator.device_firmware_updates
+
     async def test_sim_and_firmware_refresh_dedupes_shared_hub(self) -> None:
         """Multiple spaces backed by one hub (group mode) trigger only a
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1972,6 +1972,33 @@ class TestHubFirmwareRefresh:
         assert stored.progress == 30
         assert stored.is_critical is True
 
+    async def test_sim_and_firmware_refresh_dedupes_shared_hub(self) -> None:
+        """Multiple spaces backed by one hub (group mode) trigger only a
+
+        single per-hub `streamHubObject` fetch per cycle (2.1 review).
+        """
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+        coordinator._streams_started = True
+        coordinator._sim_info_last_fetch = -10_000.0
+        # Two spaces sharing the default hub_id "hub-1".
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(
+            return_value=[_make_space("s1"), _make_space("s2")]
+        )
+        coordinator._spaces_api.get_space_snapshot = AsyncMock(return_value=SpaceSnapshot())
+        coordinator._devices_api = MagicMock()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[])
+        coordinator._hub_object_api = MagicMock()
+        coordinator._hub_object_api.get_sim_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_firmware_info = AsyncMock(return_value=None)
+        coordinator._hub_object_api.get_device_firmware_updates = AsyncMock(return_value=[])
+
+        await coordinator._async_update_data()
+
+        coordinator._hub_object_api.get_firmware_info.assert_awaited_once_with("hub-1")
+        coordinator._hub_object_api.get_device_firmware_updates.assert_awaited_once_with("hub-1")
+
 
 class TestOnHtsDeviceKv:
     """Coordinator translates HTS per-device kv into DeviceReadings."""

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -126,6 +126,43 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert "door_opened" in dev_info["statuses"]
 
     @pytest.mark.asyncio
+    async def test_firmware_update_maps_included(self, entry: MagicMock) -> None:
+        # 2.1 / project rule (#148): every entity-driving field must land
+        # in the diagnostics dump — both `update.*` sources included.
+        from custom_components.aegis_ajax.api.hub_object import (
+            DEVICE_FW_STATE_DOWNLOADING,
+            HUB_FW_STATE_NOT_STARTED,
+            DeviceFirmwareUpdateInfo,
+            HubFirmwareUpdateInfo,
+        )
+
+        entry.runtime_data.hub_firmware_updates = {
+            "002B1A51": HubFirmwareUpdateInfo(
+                target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED
+            )
+        }
+        entry.runtime_data.device_firmware_updates = {
+            "AA11BB22": DeviceFirmwareUpdateInfo(
+                device_id="AA11BB22",
+                target_version="6.62.3",
+                state=DEVICE_FW_STATE_DOWNLOADING,
+                progress=42,
+                is_critical=True,
+            )
+        }
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+        assert result["hub_firmware_updates"]["002B1A51"] == {
+            "target_version": "2.17.0",
+            "state": HUB_FW_STATE_NOT_STARTED,
+        }
+        assert result["device_firmware_updates"]["AA11BB22"] == {
+            "target_version": "6.62.3",
+            "state": DEVICE_FW_STATE_DOWNLOADING,
+            "progress": 42,
+            "is_critical": True,
+        }
+
+    @pytest.mark.asyncio
     async def test_device_with_battery(self, entry: MagicMock) -> None:
         battery = BatteryInfo(level=85, is_low=False)
         entry.runtime_data.devices = {"dev-1": _make_device(battery=battery)}

--- a/tests/unit/test_hub_object.py
+++ b/tests/unit/test_hub_object.py
@@ -8,8 +8,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.aegis_ajax.api.hub_object import (
+    DEVICE_FW_STATE_DOWNLOADING,
+    DEVICE_FW_STATE_INSTALLING,
+    DEVICE_FW_STATE_NONE,
+    DEVICE_FW_STATE_NOT_STARTED,
     HUB_FW_STATE_DOWNLOADING,
     HUB_FW_STATE_NOT_STARTED,
+    DeviceFirmwareUpdateInfo,
     HubFirmwareUpdateInfo,
     HubObjectApi,
     SimCardInfo,
@@ -386,3 +391,207 @@ class TestGetFirmwareInfo:
 
         result = await api.get_firmware_info("ABCD")
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Per-device firmware update parser (2.1 — read-only, disabled-by-default)
+# ---------------------------------------------------------------------------
+
+
+def _build_device_firmware_snapshot(
+    updates: list[tuple[str, str, str, int | None, bool]],
+) -> bytes:
+    """Build a StreamHubObject snapshot carrying per-device firmware updates.
+
+    Each tuple is (device_id, version, status_name, download_pct, is_critical).
+    ``download_pct`` is only meaningful when status_name == "downloading".
+    """
+    from google.protobuf.empty_pb2 import Empty  # noqa: PLC0415
+    from google.protobuf.wrappers_pb2 import BoolValue  # noqa: PLC0415
+    from systems.ajax.api.mobile.v2.common.resource_id_pb2 import ResourceId  # noqa: PLC0415
+    from systems.ajax.api.mobile.v2.hubobject.model.firmware.device_firmware_update_pb2 import (  # noqa: PLC0415
+        DeviceFirmwareUpdate,
+    )
+    from systems.ajax.api.mobile.v2.hubobject.model.hub_object_pb2 import (  # noqa: PLC0415
+        HubObject,
+    )
+    from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+        StreamHubObject,
+    )
+
+    dfus = []
+    for device_id, version, status_name, pct, is_critical in updates:
+        if status_name == "downloading":
+            status = DeviceFirmwareUpdate.Status(downloading=pct or 0)
+        else:
+            status = DeviceFirmwareUpdate.Status(**{status_name: Empty()})
+        dfu = DeviceFirmwareUpdate(
+            device_id=device_id,
+            resource_id=ResourceId(firmware_id=ResourceId.FirmwareId(firmware_version=version)),
+            status=status,
+            is_critical=BoolValue(value=is_critical),
+        )
+        dfus.append(dfu)
+    hub_obj = HubObject(
+        hex_id="ABCD1234",
+        device_firmware_updates=HubObject.DeviceFirmwareUpdates(device_firmware_update=dfus),
+    )
+    return StreamHubObject(snapshot=hub_obj).SerializeToString()
+
+
+class TestParseDeviceFirmwareFromHubObject:
+    def test_parses_multiple_updates(self) -> None:
+        raw = _build_device_firmware_snapshot(
+            [
+                ("AA11BB22", "6.62.3", "not_started", None, False),
+                ("CC33DD44", "6.62.3", "downloading", 42, True),
+            ]
+        )
+        result = HubObjectApi._parse_device_firmware_from_hub_object(raw)
+        assert result == [
+            DeviceFirmwareUpdateInfo(
+                device_id="AA11BB22",
+                target_version="6.62.3",
+                state=DEVICE_FW_STATE_NOT_STARTED,
+                progress=None,
+                is_critical=False,
+            ),
+            DeviceFirmwareUpdateInfo(
+                device_id="CC33DD44",
+                target_version="6.62.3",
+                state=DEVICE_FW_STATE_DOWNLOADING,
+                progress=42,
+                is_critical=True,
+            ),
+        ]
+
+    def test_installing_state_has_no_progress(self) -> None:
+        raw = _build_device_firmware_snapshot([("AA11BB22", "6.62.3", "installing", None, False)])
+        result = HubObjectApi._parse_device_firmware_from_hub_object(raw)
+        assert len(result) == 1
+        assert result[0].state == DEVICE_FW_STATE_INSTALLING
+        assert result[0].progress is None
+
+    def test_skips_entry_without_device_id(self) -> None:
+        raw = _build_device_firmware_snapshot([("", "6.62.3", "not_started", None, False)])
+        assert HubObjectApi._parse_device_firmware_from_hub_object(raw) == []
+
+    def test_snapshot_without_device_updates_returns_empty(self) -> None:
+        from systems.ajax.api.mobile.v2.hubobject.model.hub_object_pb2 import (  # noqa: PLC0415
+            HubObject,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+            StreamHubObject,
+        )
+
+        raw = StreamHubObject(snapshot=HubObject(hex_id="ABCD")).SerializeToString()
+        assert HubObjectApi._parse_device_firmware_from_hub_object(raw) == []
+
+    def test_delta_frame_returns_empty(self) -> None:
+        from systems.ajax.api.mobile.v2.hubobject.model.firmware.device_firmware_update_pb2 import (  # noqa: PLC0415
+            DeviceFirmwareUpdate,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.model.hub_object_pb2 import (  # noqa: PLC0415
+            HubObject,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+            StreamHubObject,
+        )
+
+        hub_obj = HubObject(
+            hex_id="ABCD",
+            device_firmware_updates=HubObject.DeviceFirmwareUpdates(
+                device_firmware_update=[DeviceFirmwareUpdate(device_id="AA11")]
+            ),
+        )
+        raw = StreamHubObject(update=hub_obj).SerializeToString()
+        assert HubObjectApi._parse_device_firmware_from_hub_object(raw) == []
+
+    def test_garbage_bytes_returns_empty(self) -> None:
+        assert HubObjectApi._parse_device_firmware_from_hub_object(b"\xff\xff\xff") == []
+
+    def test_missing_firmware_version_defaults_empty(self) -> None:
+        from systems.ajax.api.mobile.v2.hubobject.model.firmware.device_firmware_update_pb2 import (  # noqa: PLC0415
+            DeviceFirmwareUpdate,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.model.hub_object_pb2 import (  # noqa: PLC0415
+            HubObject,
+        )
+        from systems.ajax.api.mobile.v2.hubobject.stream_hub_object_request_pb2 import (  # noqa: PLC0415
+            StreamHubObject,
+        )
+
+        hub_obj = HubObject(
+            hex_id="ABCD",
+            device_firmware_updates=HubObject.DeviceFirmwareUpdates(
+                device_firmware_update=[DeviceFirmwareUpdate(device_id="AA11")]
+            ),
+        )
+        raw = StreamHubObject(snapshot=hub_obj).SerializeToString()
+        result = HubObjectApi._parse_device_firmware_from_hub_object(raw)
+        assert result == [
+            DeviceFirmwareUpdateInfo(
+                device_id="AA11",
+                target_version="",
+                state=DEVICE_FW_STATE_NONE,
+                progress=None,
+                is_critical=False,
+            )
+        ]
+
+
+class TestGetDeviceFirmwareUpdates:
+    def _make_api(self) -> HubObjectApi:
+        client = MagicMock()
+        return HubObjectApi(client)
+
+    @pytest.mark.asyncio
+    async def test_returns_updates_from_snapshot(self) -> None:
+        api = self._make_api()
+        raw = _build_device_firmware_snapshot([("AA11BB22", "6.62.3", "downloading", 15, True)])
+
+        async def _fake_stream() -> AsyncGenerator[bytes, None]:
+            yield raw
+
+        mock_method = MagicMock(return_value=_fake_stream())
+        api._client._get_channel().unary_stream.return_value = mock_method
+        api._client._session.get_call_metadata.return_value = []
+
+        result = await api.get_device_firmware_updates("ABCD1234")
+        assert result == [
+            DeviceFirmwareUpdateInfo(
+                device_id="AA11BB22",
+                target_version="6.62.3",
+                state=DEVICE_FW_STATE_DOWNLOADING,
+                progress=15,
+                is_critical=True,
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_stream_exception(self) -> None:
+        api = self._make_api()
+
+        async def _raising_stream() -> AsyncGenerator[bytes, None]:
+            raise RuntimeError("stream error")
+            yield
+
+        mock_method = MagicMock(return_value=_raising_stream())
+        api._client._get_channel().unary_stream.return_value = mock_method
+        api._client._session.get_call_metadata.return_value = []
+
+        assert await api.get_device_firmware_updates("ABCD") == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_stream_empty(self) -> None:
+        api = self._make_api()
+
+        async def _empty_stream() -> AsyncGenerator[bytes, None]:
+            return
+            yield
+
+        mock_method = MagicMock(return_value=_empty_stream())
+        api._client._get_channel().unary_stream.return_value = mock_method
+        api._client._session.get_call_metadata.return_value = []
+
+        assert await api.get_device_firmware_updates("ABCD") == []

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
 from custom_components.aegis_ajax.api.hub_object import (
+    DEVICE_FW_STATE_DOWNLOADED,
+    DEVICE_FW_STATE_DOWNLOADING,
+    DEVICE_FW_STATE_INSTALLING,
+    DEVICE_FW_STATE_NOT_STARTED,
     HUB_FW_STATE_DOWNLOADING,
     HUB_FW_STATE_NOT_STARTED,
+    DeviceFirmwareUpdateInfo,
     HubFirmwareUpdateInfo,
 )
-from custom_components.aegis_ajax.update import AjaxHubFirmwareUpdate
+from custom_components.aegis_ajax.update import AjaxDeviceFirmwareUpdate, AjaxHubFirmwareUpdate
+
+if TYPE_CHECKING:
+    from custom_components.aegis_ajax.api.models import Device
 
 
 class TestAjaxHubFirmwareUpdate:
@@ -220,3 +229,217 @@ class TestAsyncSetupEntry:
         await async_setup_entry(MagicMock(), entry, async_add_entities)
         entities = async_add_entities.call_args[0][0]
         assert entities == []
+
+
+def _make_device(
+    device_id: str, device_type: str = "door_protect", name: str = "Front Door"
+) -> Device:
+    from custom_components.aegis_ajax.api.models import Device
+    from custom_components.aegis_ajax.const import DeviceState
+
+    return Device(
+        id=device_id,
+        hub_id="002B1A51",
+        name=name,
+        device_type=device_type,
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses={},
+        battery=None,
+    )
+
+
+class TestAjaxDeviceFirmwareUpdate:
+    @staticmethod
+    def _make_coordinator(
+        info: DeviceFirmwareUpdateInfo | None,
+        device_id: str = "AA11BB22",
+    ) -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        coordinator.devices = {device_id: _make_device(device_id)}
+        coordinator.device_firmware_updates = {device_id: info} if info else {}
+        return coordinator
+
+    def test_unique_id_namespaced_by_device(self) -> None:
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity._attr_unique_id == "aegis_ajax_AA11BB22_firmware"
+
+    def test_disabled_by_default(self) -> None:
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.entity_registry_enabled_default is False
+
+    def test_installed_version_is_constant_placeholder(self) -> None:
+        from custom_components.aegis_ajax.update import _INSTALLED_VERSION_PLACEHOLDER
+
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.installed_version == _INSTALLED_VERSION_PLACEHOLDER
+
+    def test_latest_version_reflects_pending_update(self) -> None:
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22", target_version="6.62.3", state=DEVICE_FW_STATE_NOT_STARTED
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.latest_version == "6.62.3"
+
+    def test_latest_version_matches_installed_when_no_pending_update(self) -> None:
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.latest_version == entity.installed_version
+        assert entity.in_progress is False
+
+    def test_latest_version_falls_back_on_empty_target(self) -> None:
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22", target_version="", state=DEVICE_FW_STATE_NOT_STARTED
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.latest_version == entity.installed_version
+
+    def test_in_progress_true_when_downloading(self) -> None:
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22",
+            target_version="6.62.3",
+            state=DEVICE_FW_STATE_DOWNLOADING,
+            progress=42,
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.in_progress is True
+        assert entity.update_percentage == 42
+
+    def test_in_progress_true_when_installing_without_percentage(self) -> None:
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22", target_version="6.62.3", state=DEVICE_FW_STATE_INSTALLING
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.in_progress is True
+        # No progress signal during install → indeterminate bar.
+        assert entity.update_percentage is None
+
+    def test_in_progress_false_when_downloaded(self) -> None:
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22", target_version="6.62.3", state=DEVICE_FW_STATE_DOWNLOADED
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.in_progress is False
+        assert entity.update_percentage is None
+
+    def test_supported_features_excludes_install(self) -> None:
+        from homeassistant.components.update import UpdateEntityFeature
+
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert not (entity.supported_features & UpdateEntityFeature.INSTALL)
+        assert entity.supported_features == UpdateEntityFeature(0)
+
+    def test_device_class_firmware(self) -> None:
+        from homeassistant.components.update import UpdateDeviceClass
+
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.device_class is UpdateDeviceClass.FIRMWARE
+
+    def test_state_off_when_no_pending_update(self) -> None:
+        from homeassistant.const import STATE_OFF
+
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.state == STATE_OFF
+
+    def test_state_on_when_pending_update(self) -> None:
+        from homeassistant.const import STATE_ON
+
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22", target_version="6.62.3", state=DEVICE_FW_STATE_NOT_STARTED
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.state == STATE_ON
+
+    def test_release_summary_explains_up_to_date(self) -> None:
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        summary = entity.release_summary
+        assert summary is not None
+        assert "not queued" in summary.lower()
+        assert "device" in summary.lower()
+
+    def test_release_summary_flags_critical_update(self) -> None:
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22",
+            target_version="6.62.3",
+            state=DEVICE_FW_STATE_NOT_STARTED,
+            is_critical=True,
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        summary = entity.release_summary
+        assert summary is not None
+        assert "6.62.3" in summary
+        assert "critical" in summary.lower()
+
+
+class TestAsyncSetupEntryDeviceFirmware:
+    @pytest.mark.asyncio
+    async def test_setup_creates_disabled_entity_per_non_hub_device(self) -> None:
+        from custom_components.aegis_ajax.api.models import Device, Space
+        from custom_components.aegis_ajax.const import (
+            ConnectionStatus,
+            DeviceState,
+            SecurityState,
+        )
+        from custom_components.aegis_ajax.update import async_setup_entry
+
+        hub_id = "002B1A51"
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        coordinator.spaces = {
+            "s1": Space(
+                id="s1",
+                hub_id=hub_id,
+                name="Home",
+                security_state=SecurityState.DISARMED,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+            )
+        }
+        coordinator.devices = {
+            hub_id: Device(
+                id=hub_id,
+                hub_id=hub_id,
+                name="Hub",
+                device_type="hub",
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            ),
+            "AA11BB22": _make_device("AA11BB22"),
+            "CC33DD44": _make_device("CC33DD44", name="Kitchen Motion"),
+        }
+        coordinator.hub_firmware_updates = {}
+        coordinator.device_firmware_updates = {}
+        entry = MagicMock(runtime_data=coordinator)
+        async_add_entities = MagicMock()
+
+        await async_setup_entry(MagicMock(), entry, async_add_entities)
+        entities = async_add_entities.call_args[0][0]
+        hub_entities = [e for e in entities if isinstance(e, AjaxHubFirmwareUpdate)]
+        device_entities = [e for e in entities if isinstance(e, AjaxDeviceFirmwareUpdate)]
+        assert len(hub_entities) == 1
+        # One per non-hub device; the hub device is excluded.
+        assert len(device_entities) == 2
+        assert all(e.entity_registry_enabled_default is False for e in device_entities)

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -8,8 +8,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.aegis_ajax.api.hub_object import (
+    DEVICE_FW_STATE_COMPLETED,
     DEVICE_FW_STATE_DOWNLOADED,
     DEVICE_FW_STATE_DOWNLOADING,
+    DEVICE_FW_STATE_FAILED,
     DEVICE_FW_STATE_INSTALLING,
     DEVICE_FW_STATE_NOT_STARTED,
     HUB_FW_STATE_DOWNLOADING,
@@ -100,14 +102,28 @@ class TestAjaxHubFirmwareUpdate:
         assert entity.in_progress is False
 
     def test_supported_features_excludes_install(self) -> None:
-        """The entity is read-only by design — no INSTALL feature exposed."""
+        """Read-only by design — no INSTALL feature; PROGRESS so HA honors in_progress."""
         from homeassistant.components.update import UpdateEntityFeature
 
         info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
         coordinator = self._make_coordinator(info)
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
         assert not (entity.supported_features & UpdateEntityFeature.INSTALL)
-        assert entity.supported_features == UpdateEntityFeature(0)
+        assert entity.supported_features == UpdateEntityFeature.PROGRESS
+
+    def test_state_attributes_report_in_progress_while_downloading(self) -> None:
+        """Regression: without the PROGRESS feature flag, HA's
+
+        `UpdateEntity.state_attributes` IGNORES the `in_progress`
+        property and reports the internal install flag (always False
+        here) — the property tests above can't catch that.
+        """
+        from homeassistant.components.update import ATTR_IN_PROGRESS
+
+        info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_DOWNLOADING)
+        coordinator = self._make_coordinator(info)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.state_attributes[ATTR_IN_PROGRESS] is True
 
     def test_device_class_firmware(self) -> None:
         from homeassistant.components.update import UpdateDeviceClass
@@ -340,7 +356,103 @@ class TestAjaxDeviceFirmwareUpdate:
         coordinator = self._make_coordinator(None)
         entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
         assert not (entity.supported_features & UpdateEntityFeature.INSTALL)
-        assert entity.supported_features == UpdateEntityFeature(0)
+        assert entity.supported_features == UpdateEntityFeature.PROGRESS
+
+    def test_state_attributes_report_progress_while_downloading(self) -> None:
+        """Regression: HA's `UpdateEntity.state_attributes` only honors the
+
+        `in_progress`/`update_percentage` properties when the PROGRESS
+        feature flag is declared — with `UpdateEntityFeature(0)` both
+        were silently ignored (in_progress always False, percentage
+        always None) and no property-level test could catch it.
+        """
+        from homeassistant.components.update import (
+            ATTR_IN_PROGRESS,
+            ATTR_UPDATE_PERCENTAGE,
+        )
+
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22",
+            target_version="6.62.3",
+            state=DEVICE_FW_STATE_DOWNLOADING,
+            progress=42,
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        attrs = entity.state_attributes
+        assert attrs[ATTR_IN_PROGRESS] is True
+        assert attrs[ATTR_UPDATE_PERCENTAGE] == 42
+
+    def test_available_requires_device_presence(self) -> None:
+        """A device removed from the hub must flip its orphan entity to
+
+        unavailable instead of reporting "Up to date" forever (HA never
+        evicts orphan registry entries on its own).
+        """
+        coordinator = self._make_coordinator(None)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        coordinator.last_update_success = True
+        assert entity.available is True
+        coordinator.devices = {}
+        assert entity.available is False
+
+    def test_info_lookup_is_casing_proof(self) -> None:
+        """Regression: the update map keys come from `streamHubObject`
+
+        while entities key off `Device.id` from the devices snapshot —
+        two services whose hex-id casing is not guaranteed to match.
+        Both sides normalize via `.upper()`.
+        """
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22", target_version="6.62.3", state=DEVICE_FW_STATE_NOT_STARTED
+        )
+        coordinator = self._make_coordinator(info, device_id="aa11bb22")
+        # Map keyed uppercase (as the coordinator writes it); entity was
+        # created from a lowercase snapshot id.
+        coordinator.device_firmware_updates = {"AA11BB22": info}
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "aa11bb22")
+        assert entity.latest_version == "6.62.3"
+
+    def test_failed_state_surfaces_in_release_summary(self) -> None:
+        """A failed install is the case the user most needs to see —
+
+        it must not render as an ordinary pending update.
+        """
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22",
+            target_version="6.62.3",
+            state=DEVICE_FW_STATE_FAILED,
+            is_critical=True,
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        # Still an update pending from HA's point of view…
+        assert entity.latest_version == "6.62.3"
+        summary = entity.release_summary
+        assert summary is not None
+        # …but the summary says the last attempt failed.
+        assert "failed" in summary.lower()
+        assert "critical" in summary.lower()
+
+    def test_completed_state_renders_up_to_date(self) -> None:
+        """A completed update lingers in the snapshot for up to an hour;
+
+        it must render as "Up to date", not as a pending update.
+        """
+        from homeassistant.const import STATE_OFF
+
+        info = DeviceFirmwareUpdateInfo(
+            device_id="AA11BB22",
+            target_version="6.62.3",
+            state=DEVICE_FW_STATE_COMPLETED,
+        )
+        coordinator = self._make_coordinator(info)
+        entity = AjaxDeviceFirmwareUpdate(coordinator, "AA11BB22")
+        assert entity.latest_version == entity.installed_version
+        assert entity.state == STATE_OFF
+        summary = entity.release_summary
+        assert summary is not None
+        assert "installed" in summary.lower()
 
     def test_device_class_firmware(self) -> None:
         from homeassistant.components.update import UpdateDeviceClass
@@ -443,3 +555,43 @@ class TestAsyncSetupEntryDeviceFirmware:
         # One per non-hub device; the hub device is excluded.
         assert len(device_entities) == 2
         assert all(e.entity_registry_enabled_default is False for e in device_entities)
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_hub_type_gets_no_duplicate_entity(self) -> None:
+        """Regression: a hub model newer than the vendored proto parses as
+
+        device_type "unknown", escaping the `startswith("hub")` filter.
+        The `device_id in seen` guard must still keep it out of the
+        per-device loop — otherwise two entities share one unique_id and
+        HA drops one.
+        """
+        from custom_components.aegis_ajax.api.models import Space
+        from custom_components.aegis_ajax.const import ConnectionStatus, SecurityState
+        from custom_components.aegis_ajax.update import async_setup_entry
+
+        hub_id = "002B1A51"
+        coordinator = MagicMock()
+        coordinator.rooms = {}
+        coordinator.spaces = {
+            "s1": Space(
+                id="s1",
+                hub_id=hub_id,
+                name="Home",
+                security_state=SecurityState.DISARMED,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+            )
+        }
+        coordinator.devices = {
+            # Future hub model → oneof unmatched → device_type "unknown".
+            hub_id: _make_device(hub_id, device_type="unknown", name="Hub Mega"),
+        }
+        coordinator.hub_firmware_updates = {}
+        coordinator.device_firmware_updates = {}
+        entry = MagicMock(runtime_data=coordinator)
+        async_add_entities = MagicMock()
+
+        await async_setup_entry(MagicMock(), entry, async_add_entities)
+        entities = async_add_entities.call_args[0][0]
+        assert len([e for e in entities if isinstance(e, AjaxHubFirmwareUpdate)]) == 1
+        assert [e for e in entities if isinstance(e, AjaxDeviceFirmwareUpdate)] == []


### PR DESCRIPTION
## Summary

Adds **per-device firmware update entities** (roadmap item 2.1), a per-device counterpart to the hub-level firmware update entity shipped in 1.4.0-beta.5.

Each non-hub device now gets an `update.<device>_firmware` entity sourced from the same read-only `streamHubObject` snapshot (field 200, `device_firmware_updates`). It surfaces:

- the pending target firmware version,
- download progress (during the download phase, via `update_percentage`),
- a security-critical flag,
- and renders **`Up to date`** when Ajax has no update queued for that device.

Like the hub entity, these are **informational only** — there is no install button and the integration never calls the install RPC (Ajax drives firmware rollout itself).

## Design notes

- **Disabled by default.** A typical install has 10-30 devices and most users only care about a specific device's firmware when it is failing to update, so entities are `entity_registry_enabled_default = False`. Enable the ones you want to watch.
- **Same read-only pattern** as the hub firmware entity — snapshot-only (deltas ignored), rebuilt fresh each hourly refresh cycle so cleared updates drop.
- **Installed version** uses the same `current` placeholder the hub entity uses, since Ajax doesn't expose the currently-installed per-device version.
- Localized entity name added to all **14 translation files**.

## Testing

- `1783 passed` (full unit suite; +27 new tests covering the parser, entity and coordinator wiring).
- `ruff check` / `ruff format --check` / `mypy` / `vulture` all clean.