### PR TITLE
fix(bypass): read the panel's real deactivation state and confirm writes (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A device deactivated in the Ajax app now shows as bypassed in Home Assistant (#338).** Deactivating a device from the Ajax app (or having an installer do it) excludes it from protection, but Home Assistant kept showing its bypass switch `off` and the sensor itself as live protection — the integration only read the snapshot's bypass flag, which stays unset for that path, and never read the four deactivation statuses the hub actually reports. The bypass switch now reads `on` for a device deactivated by anyone, through either the initial snapshot or a real-time change, and a new `deactivation_kinds` attribute names the mode in force so an automation can distinguish a fully disabled device from one with only its tamper protection off. Mind Ajax's own wording, which the attribute preserves: `temporary_deactivation_*` is the **permanent** deactivation (until re-enabled) and `one_time_deactivation_*` lasts a single arming cycle. The diagnostics download reports both sources side by side. Thanks to @wip3out3r for the four-mode hardware mapping and to @aavdberg for the analysis that scoped it.
+- **A bypass command the hub silently ignores no longer leaves the switch showing the wrong state (#338).** Toggling the bypass switch on an account that can't apply the deactivation still returned "success" from the hub while nothing changed on the device, so the switch sat in the requested position indefinitely. Every bypass write is now followed by an independent read-back of the device a few seconds later; the switch reverts to what the panel really reports and a warning naming the device is logged, making the silent no-op visible instead of invisible.
+
 ## [1.15.0] - 2026-07-26
 
 Push security events are decoded correctly, device tamper sensors work for the first time, and sirens become configurable from Home Assistant. Consolidates the 1.15.0-beta series.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ajax Systems provides co-branded versions of their mobile app to security compan
 - **Event Platform**: Security events from FCM push notifications (alarm, arm/disarm, tamper, panic, fire, flood, motion, and more)
 - **Device automation triggers**: every Ajax security event is a named device trigger on the hub device, selectable directly in the HA automation editor (no manual event-type strings)
 - **Doorbell events**: video-edge doorbells get a per-device `event` entity emitting HA's canonical `ring` event, and a doorbell motion push turns the doorbell's motion sensor on (30 s auto-off)
-- **Per-device bypass switches**: each non-hub device can get a `bypass` switch to deactivate / reactivate it; gated by the `bypass_switches` option (`auto` / `always` / `never`)
+- **Per-device bypass switches**: each non-hub device can get a `bypass` switch to deactivate / reactivate it; gated by the `bypass_switches` option (`auto` / `always` / `never`). The switch reads `on` for a device deactivated **anywhere** — from Home Assistant, the Ajax app, or by an installer — and its `deactivation_kinds` attribute names the mode in force. Mind Ajax's own wording: `temporary_deactivation_*` is the **permanent** deactivation (until you re-enable it), `one_time_deactivation_*` lasts a single arming cycle, and a `*_tamper` variant means only the device's tamper protection is off
 - **Logbook**: Human-readable security event descriptions with icons
 - **Real-time updates**: Persistent gRPC stream for instant sensor state changes (< 1 second latency)
 - **Push notifications**: FCM integration for immediate event delivery
@@ -119,7 +119,11 @@ Click the button above, or manually:
 > Trade-offs to know: without photo / video permission the MotionCam Photo-on-Demand
 > button won't work, and per-device bypass switches need the account to hold the
 > device-deactivation (`DEVICE_EDIT`) permission — the default `bypass_switches: auto`
-> simply won't create them for an account that lacks it.
+> simply won't create them for an account that lacks it. On an account that has the
+> switch but can't apply the deactivation mode the hub still answers "success" and
+> changes nothing; the integration re-reads the device a few seconds after every
+> bypass write and logs a warning when the panel disagrees, so the switch never
+> shows a state the hardware isn't in.
 
 ### Options
 

--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -18,6 +18,8 @@ from typing import Any
 
 from custom_components.aegis_ajax.api.models import BatteryInfo, Device
 from custom_components.aegis_ajax.const import (
+    DEACTIVATED_KEY,
+    DEACTIVATION_STATUS_KEYS,
     SIREN_ALARM_DURATION_KEY,
     SIREN_VOLUME_LEVEL_KEY,
     DeviceState,
@@ -458,6 +460,15 @@ def _parse_statuses(statuses: Any) -> dict[str, Any]:  # noqa: ANN401
             result["smart_lock_state"] = _LOCK_CONTROL_STATE_MAP.get(
                 int(status.lock_control_status.state), "unknown"
             )
+        elif which in DEACTIVATION_STATUS_KEYS:
+            # The device is deactivated (bypassed) on the panel — see
+            # `DEACTIVATION_STATUS_KEYS` for the inverted `temporary_` /
+            # `one_time_` naming and why `*_tamper` is deliberately NOT
+            # folded into `tamper`. The granular case is kept so the bypass
+            # switch can surface *which* mode is in force; the shared key is
+            # what the switch's state binds to (#338).
+            result[which] = True
+            result[DEACTIVATED_KEY] = True
     return result
 
 

--- a/custom_components/aegis_ajax/api/models.py
+++ b/custom_components/aegis_ajax/api/models.py
@@ -7,6 +7,8 @@ from enum import IntEnum
 from typing import Any
 
 from custom_components.aegis_ajax.const import (
+    DEACTIVATED_KEY,
+    DEACTIVATION_STATUS_KEYS,
     ChimeStatus,
     ConnectionStatus,
     DeviceState,
@@ -166,6 +168,35 @@ class Device:
     @property
     def is_online(self) -> bool:
         return self.state == DeviceState.ONLINE
+
+
+def is_device_deactivated(device: Any) -> bool:  # noqa: ANN401
+    """True when the panel has this device excluded from protection (#338).
+
+    Two independent sources say so and either is sufficient:
+    `profile.bypassed` (set when the deactivation came through the path the
+    snapshot models as a bypass) and the `*_deactivation_*` statuses (what a
+    device deactivated from the Ajax app actually reports — `bypassed` stays
+    False in that case, which is the whole reason #338 existed).
+
+    The granular statuses are checked as well as the folded key they normally
+    arrive with, so a device whose statuses came from an older persisted cache
+    (written before the fold existed) still reads correctly.
+
+    Takes the device structurally rather than as a `Device` method so the
+    entity layer and the coordinator share one definition of "deactivated".
+    """
+    return bool(
+        device.bypassed or device.statuses.get(DEACTIVATED_KEY) or device_deactivation_kinds(device)
+    )
+
+
+def device_deactivation_kinds(device: Any) -> list[str]:  # noqa: ANN401
+    """Which deactivation modes are in force, in `DEACTIVATION_STATUS_KEYS`
+    order (#338). Empty when the device is active, or when it is deactivated
+    only via the snapshot's `bypassed` flag, which carries no mode.
+    """
+    return [key for key in DEACTIVATION_STATUS_KEYS if device.statuses.get(key)]
 
 
 @dataclass(frozen=True)

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -327,6 +327,49 @@ SIREN_ALARM_DURATION_STEP = 1
 # fallback if the confirm read still races the write.
 SIREN_SETTINGS_CONFIRM_DELAY = 5.0
 
+# Status oneof cases that mean "this device is deactivated on the panel", i.e.
+# excluded from protection (#338). They are what the wire actually carries —
+# `profile.bypassed` stays False for a device deactivated from the Ajax app,
+# so without reading these HA reported a disabled sensor as live protection.
+#
+# READ THE NAMES BACKWARDS — Ajax's wording is inverted relative to English
+# intuition, and this has been verified against the app's own labels:
+#   * `temporary_*` / "forzata"  = the PERMANENT deactivation (until re-enabled)
+#   * `one_time_*`  / "unica"    = lasts a single arming cycle
+# Do not "fix" this mapping to match the English adjectives.
+#
+# `*_deactivation_tamper` means the device's TAMPER PROTECTION is disabled.
+# It is NOT a tamper alarm and must never feed the shared `tamper` key the
+# tamper binary_sensor binds to (#339/#340).
+#
+# The four `whole`/`tamper` variants are hardware-confirmed (#338, four-mode
+# mapping on a live fixture). The bare and `alarms`/`timer` variants exist in
+# the same oneof but have not been observed on hardware; they are folded the
+# same way because every one of them means "protection is off here", and
+# under-reporting that is the failure mode this fix exists to remove.
+DEACTIVATION_STATUS_KEYS: tuple[str, ...] = (
+    "temporary_deactivation_whole",
+    "temporary_deactivation_tamper",
+    "one_time_deactivation_whole",
+    "one_time_deactivation_tamper",
+    "temporary_deactivation_alarms",
+    "temporary_deactivation_timer",
+    "temporary_deactivation",
+    "one_time_deactivation",
+)
+
+# Shared status key every `DEACTIVATION_STATUS_KEYS` case folds into — the
+# bypass switch binds to it, so the entity reads `on` regardless of which
+# deactivation mode the panel applied or who applied it (#338).
+DEACTIVATED_KEY = "deactivated"
+
+# Settle delay (seconds) before the post-write bypass read-back (#338). The
+# bypass write has a real accept-but-inert failure mode (the hub returns
+# success and does nothing when the account can't apply the requested mode),
+# so a successful command is not evidence of a state change — only an
+# independent read is. Same rationale and cadence as the siren confirm above.
+BYPASS_CONFIRM_DELAY = 5.0
+
 # Opt-out for users who deliberately run without push notifications. When set,
 # the integration does not raise the recurring `fcm_not_configured` Repair card
 # or the WARNING log when the four FCM fields are empty, and clears any card

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -29,10 +29,14 @@ from custom_components.aegis_ajax.api.hub_object import (
 )
 from custom_components.aegis_ajax.api.media import MediaApi
 from custom_components.aegis_ajax.api.models import Device as DeviceModel
+from custom_components.aegis_ajax.api.models import is_device_deactivated
 from custom_components.aegis_ajax.api.security import SecurityApi
 from custom_components.aegis_ajax.api.session import AuthenticationError
 from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import (
+    BYPASS_CONFIRM_DELAY,
+    DEACTIVATED_KEY,
+    DEACTIVATION_STATUS_KEYS,
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
     HUB_DEVICE_TEMP_REFRESH_INTERVAL,
@@ -266,6 +270,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Sirens with a post-write settings confirm read in flight (single-flight
         # per device; see `schedule_siren_settings_confirm`).
         self._siren_confirm_pending: set[str] = set()
+        # Devices with a post-write bypass confirm read in flight (single-flight
+        # per device; see `schedule_bypass_confirm`).
+        self._bypass_confirm_pending: set[str] = set()
         # Independent poll safety-net timer (#178). On active hubs every HTS
         # update reschedules HA's built-in poll timer faster than
         # `poll_interval`, starving the scheduled `_async_update_data`; this
@@ -785,6 +792,63 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         finally:
             self._siren_confirm_pending.discard(device_id)
+
+    @callback
+    def schedule_bypass_confirm(self, device_id: str, *, expected: bool) -> None:
+        """Schedule an independent read-back after a bypass write (#338).
+
+        `DeviceCommandBypass` has an accept-but-inert failure mode: the hub
+        answers success and applies nothing when the account can't set the
+        requested deactivation mode. A successful command is therefore not
+        evidence of a state change, and an optimistic entity update would
+        actively lie about whether a sensor is protecting the property. Re-read
+        the device instead and let the switch show whatever the panel really
+        says; on a disagreement, warn so the silent no-op is visible in the log
+        rather than only in the (unchanged) hardware.
+
+        Single-flight per device — a second write while a confirm is pending
+        rides the scheduled read.
+        """
+        if device_id in self._bypass_confirm_pending:
+            return
+        self._bypass_confirm_pending.add(device_id)
+        self.hass.async_create_task(self._async_confirm_bypass(device_id, expected=expected))
+
+    async def _async_confirm_bypass(self, device_id: str, *, expected: bool) -> None:
+        try:
+            await asyncio.sleep(BYPASS_CONFIRM_DELAY)
+            device = self.devices.get(device_id)
+            if device is None:
+                return
+            space_id = next((s.id for s in self.spaces.values() if s.hub_id == device.hub_id), None)
+            if space_id is None:
+                return
+            try:
+                fresh_devices = await self._devices_api.get_devices_snapshot(space_id)
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Bypass confirm read failed for device %s", device_id, exc_info=True)
+                return
+            fresh = next((d for d in fresh_devices if d.id == device_id), None)
+            if fresh is None:
+                return
+            self._handle_devices_snapshot([fresh])
+            current = self.devices.get(device_id)
+            if current is None:
+                return
+            actual = is_device_deactivated(current)
+            if actual != expected:
+                _LOGGER.warning(
+                    "Bypass %s for device %s (%s) was accepted by the hub but "
+                    "the device still reads %s — the account most likely lacks "
+                    "the rights for this deactivation mode, so the command was "
+                    "a silent no-op (#338)",
+                    "enable" if expected else "disable",
+                    device_id,
+                    device.name,
+                    "deactivated" if actual else "active",
+                )
+        finally:
+            self._bypass_confirm_pending.discard(device_id)
 
     def _schedule_poll_safety_refresh(self) -> None:
         """Start the independent poll safety-net timer (#178).
@@ -1713,6 +1777,18 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     new_statuses.pop("tamper", None)
             else:
                 new_statuses["tamper"] = True
+
+        # Same fold for the deactivation statuses (#338): the bypass switch
+        # binds to the shared `DEACTIVATED_KEY`, so a device deactivated from
+        # the Ajax app while HA is running must reach it through this path too
+        # — not only through the next full snapshot. On REMOVE the shared key
+        # only clears once no other deactivation mode is still in force.
+        if status_name in DEACTIVATION_STATUS_KEYS:
+            if op == 3:
+                if not any(new_statuses.get(k) for k in DEACTIVATION_STATUS_KEYS):
+                    new_statuses.pop(DEACTIVATED_KEY, None)
+            else:
+                new_statuses[DEACTIVATED_KEY] = True
 
         updated = DeviceModel(
             id=device.id,

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_PASSWORD
 
+from custom_components.aegis_ajax.api.models import (
+    device_deactivation_kinds,
+    is_device_deactivated,
+)
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
@@ -105,6 +110,12 @@ async def async_get_config_entry_diagnostics(
                 "online": d.is_online,
                 "malfunctions": d.malfunctions,
                 "bypassed": d.bypassed,
+                # What the bypass switch actually shows (#338). `bypassed` is
+                # only one of the two sources: a device deactivated from the
+                # Ajax app leaves it False and reports `*_deactivation_*`
+                # statuses instead, so both are dumped side by side.
+                "deactivated": is_device_deactivated(d),
+                "deactivation_kinds": device_deactivation_kinds(d),
                 "battery": (
                     {"level": d.battery.level, "low": d.battery.is_low} if d.battery else None
                 ),

--- a/custom_components/aegis_ajax/switch.py
+++ b/custom_components/aegis_ajax/switch.py
@@ -10,7 +10,11 @@ from homeassistant.const import EntityCategory
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aegis_ajax.api.models import DeviceCommand
+from custom_components.aegis_ajax.api.models import (
+    DeviceCommand,
+    device_deactivation_kinds,
+    is_device_deactivated,
+)
 from custom_components.aegis_ajax.const import (
     BYPASS_REQUIRED_PERMISSION,
     BYPASS_SWITCHES_ALWAYS,
@@ -275,8 +279,15 @@ class AjaxSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):
 class AjaxBypassSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):
     """Deactivate (bypass) a device so it's excluded while the system is armed.
 
-    `on` = device bypassed/deactivated (permanent, "engineering"), `off` =
-    active. Mirrors the `bypassed` flag the snapshot reports.
+    `on` = the device is excluded from protection, `off` = active. The state
+    reflects the panel's reality regardless of who deactivated the device —
+    the Ajax app, an installer, or this switch — because a device deactivated
+    outside HA reports it through the `*_deactivation_*` statuses and leaves
+    the snapshot's `bypassed` flag False (#338). Reading only that flag showed
+    a disabled sensor as live protection.
+
+    Writing still goes out as the permanent ("engineering") deactivation; the
+    granular mode in force is exposed as the `deactivation_kinds` attribute.
     """
 
     _attr_has_entity_name = True
@@ -313,7 +324,20 @@ class AjaxBypassSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity
         device = self._device
         if device is None:
             return None
-        return bool(device.bypassed)
+        return is_device_deactivated(device)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Expose which deactivation mode(s) the panel has in force (#338).
+
+        Automations that only care about a fully disabled device can gate on
+        `temporary_deactivation_whole` / `one_time_deactivation_whole` instead
+        of the switch state, which also turns on for a tamper-only
+        deactivation. Mind the inverted naming — see `DEACTIVATION_STATUS_KEYS`.
+        """
+        device = self._device
+        kinds = device_deactivation_kinds(device) if device is not None else []
+        return {"deactivation_kinds": kinds}
 
     async def async_turn_on(self, **kwargs: object) -> None:
         await self._set_bypass(enable=True)
@@ -329,6 +353,10 @@ class AjaxBypassSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity
             enable=enable,
         )
         await async_send_device_command(self.coordinator, cmd)
+        # The hub can accept this command and apply nothing (#338), so the
+        # entity must be corrected by an independent read rather than trusting
+        # the success response. Only reached when the write did not raise.
+        self.coordinator.schedule_bypass_confirm(self._device_id, expected=enable)
 
 
 class AjaxChimeSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 from dataclasses import replace
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -41,7 +42,7 @@ def _make_space(space_id: str = "s1") -> Space:
     )
 
 
-def _make_device(device_id: str = "d1") -> Device:
+def _make_device(device_id: str = "d1", statuses: dict | None = None) -> Device:
     return Device(
         id=device_id,
         hub_id="hub-1",
@@ -52,7 +53,7 @@ def _make_device(device_id: str = "d1") -> Device:
         state=DeviceState.ONLINE,
         malfunctions=0,
         bypassed=False,
-        statuses={},
+        statuses=statuses if statuses is not None else {},
         battery=None,
     )
 
@@ -1016,6 +1017,51 @@ class TestStreamHandlers:
         coordinator.devices["d1"] = _make_device("d1")
 
         coordinator._handle_status_update("d1", "door_opened", {"op": 1})
+
+        assert "tamper" not in coordinator.devices["d1"].statuses
+
+    def test_handle_status_update_deactivation_folds_into_deactivated(self) -> None:
+        # #338: the realtime path must reach the same shared key as the
+        # snapshot parser, or a device deactivated while HA is running keeps
+        # reporting live protection until the next full snapshot.
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+
+        coordinator._handle_status_update("d1", "temporary_deactivation_whole", {"op": 1})
+
+        statuses = coordinator.devices["d1"].statuses
+        assert statuses.get("temporary_deactivation_whole") is True
+        assert statuses.get("deactivated") is True
+
+    def test_handle_status_update_deactivation_clears_on_remove(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+
+        coordinator._handle_status_update("d1", "one_time_deactivation_whole", {"op": 1})
+        coordinator._handle_status_update("d1", "one_time_deactivation_whole", {"op": 3})
+
+        statuses = coordinator.devices["d1"].statuses
+        assert "one_time_deactivation_whole" not in statuses
+        assert "deactivated" not in statuses
+
+    def test_handle_status_update_deactivation_holds_while_other_kind_active(self) -> None:
+        # Tamper protection re-enabled while the whole-device deactivation
+        # stands → the switch must stay on.
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+
+        coordinator._handle_status_update("d1", "temporary_deactivation_whole", {"op": 1})
+        coordinator._handle_status_update("d1", "temporary_deactivation_tamper", {"op": 1})
+        coordinator._handle_status_update("d1", "temporary_deactivation_tamper", {"op": 3})
+
+        statuses = coordinator.devices["d1"].statuses
+        assert statuses.get("deactivated") is True
+
+    def test_handle_status_update_deactivation_tamper_is_not_a_tamper_alarm(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+
+        coordinator._handle_status_update("d1", "temporary_deactivation_tamper", {"op": 1})
 
         assert "tamper" not in coordinator.devices["d1"].statuses
 
@@ -3019,6 +3065,107 @@ class TestSirenSettingsConfirm:
 
         coordinator._devices_api.get_hub_device_siren_settings.assert_not_called()
         assert "gone" not in coordinator._siren_confirm_pending
+
+
+class TestBypassConfirm:
+    """#338 option A — a bypass write the hub accepts but never applies must
+    not leave the switch showing the requested state. An independent read-back
+    corrects the entity and logs a warning."""
+
+    def _make(self, *, statuses: dict | None = None) -> AjaxCobrandedCoordinator:  # noqa: F821
+        coordinator = _make_coordinator(["s1"])
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.spaces = {"s1": _make_space("s1")}
+        coordinator.devices = {"d1": _make_device("d1", statuses=statuses)}
+        return coordinator
+
+    def test_schedule_creates_confirm_task(self) -> None:
+        coordinator = self._make()
+
+        coordinator.schedule_bypass_confirm("d1", expected=True)
+
+        coordinator.hass.async_create_task.assert_called_once()
+        assert "d1" in coordinator._bypass_confirm_pending
+
+    def test_schedule_is_single_flight_per_device(self) -> None:
+        coordinator = self._make()
+
+        coordinator.schedule_bypass_confirm("d1", expected=True)
+        coordinator.schedule_bypass_confirm("d1", expected=True)
+
+        coordinator.hass.async_create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_confirm_applies_the_fresh_snapshot(self) -> None:
+        coordinator = self._make()
+        fresh = _make_device(
+            "d1", statuses={"temporary_deactivation_whole": True, "deactivated": True}
+        )
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[fresh])
+        coordinator._bypass_confirm_pending.add("d1")
+
+        with patch("custom_components.aegis_ajax.coordinator.BYPASS_CONFIRM_DELAY", 0):
+            await coordinator._async_confirm_bypass("d1", expected=True)
+
+        assert coordinator.devices["d1"].statuses.get("deactivated") is True
+        assert "d1" not in coordinator._bypass_confirm_pending
+
+    @pytest.mark.asyncio
+    async def test_confirm_warns_when_the_hub_ignored_the_write(self, caplog) -> None:  # noqa: ANN001
+        # The accept-but-inert case: the command returned success, the read
+        # back shows the device still active.
+        coordinator = self._make()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[_make_device("d1")])
+        coordinator._bypass_confirm_pending.add("d1")
+
+        with (
+            patch("custom_components.aegis_ajax.coordinator.BYPASS_CONFIRM_DELAY", 0),
+            caplog.at_level(logging.WARNING, logger="custom_components.aegis_ajax.coordinator"),
+        ):
+            await coordinator._async_confirm_bypass("d1", expected=True)
+
+        assert "d1" in caplog.text
+        assert "338" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_confirm_silent_when_the_hub_applied_the_write(self, caplog) -> None:  # noqa: ANN001
+        coordinator = self._make(statuses={"deactivated": True})
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(
+            return_value=[_make_device("d1", statuses={"deactivated": True})]
+        )
+        coordinator._bypass_confirm_pending.add("d1")
+
+        with (
+            patch("custom_components.aegis_ajax.coordinator.BYPASS_CONFIRM_DELAY", 0),
+            caplog.at_level(logging.WARNING, logger="custom_components.aegis_ajax.coordinator"),
+        ):
+            await coordinator._async_confirm_bypass("d1", expected=True)
+
+        assert caplog.text == ""
+
+    @pytest.mark.asyncio
+    async def test_confirm_read_error_clears_pending(self) -> None:
+        coordinator = self._make()
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(side_effect=RuntimeError("boom"))
+        coordinator._bypass_confirm_pending.add("d1")
+
+        with patch("custom_components.aegis_ajax.coordinator.BYPASS_CONFIRM_DELAY", 0):
+            await coordinator._async_confirm_bypass("d1", expected=True)
+
+        assert "d1" not in coordinator._bypass_confirm_pending
+
+    @pytest.mark.asyncio
+    async def test_confirm_vanished_device_is_noop(self) -> None:
+        coordinator = self._make()
+        coordinator.devices = {}
+        coordinator._devices_api.get_devices_snapshot = AsyncMock()
+        coordinator._bypass_confirm_pending.add("d1")
+
+        with patch("custom_components.aegis_ajax.coordinator.BYPASS_CONFIRM_DELAY", 0):
+            await coordinator._async_confirm_bypass("d1", expected=True)
+
+        coordinator._devices_api.get_devices_snapshot.assert_not_called()
+        assert "d1" not in coordinator._bypass_confirm_pending
 
 
 class TestPollSafetyTimer:

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1024,6 +1024,47 @@ class TestStatusParser:
         assert result.get("door_opened") is True
         assert "tamper" not in result
 
+    # --- #338: deactivation (bypass) statuses --------------------------------
+    # A device deactivated from the Ajax app reports one of these; the
+    # snapshot's `profile.bypassed` flag stays False, so before #338 the
+    # integration showed a panel-disabled sensor as live protection.
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            "temporary_deactivation_whole",
+            "temporary_deactivation_tamper",
+            "one_time_deactivation_whole",
+            "one_time_deactivation_tamper",
+            "temporary_deactivation_alarms",
+            "temporary_deactivation_timer",
+            "temporary_deactivation",
+            "one_time_deactivation",
+        ],
+    )
+    def test_deactivation_real_proto_folds_into_deactivated(self, case: str) -> None:
+        lds = _LDS()
+        status = lds(**{case: lds.Simple()})
+        result = DevicesApi._parse_statuses([status])
+        assert result.get(case) is True
+        assert result.get("deactivated") is True
+
+    def test_door_opened_real_proto_does_not_set_deactivated(self) -> None:
+        # Negative control for the deactivation fold.
+        lds = _LDS()
+        status = lds(door_opened=lds.Simple())
+        result = DevicesApi._parse_statuses([status])
+        assert "deactivated" not in result
+
+    def test_deactivation_tamper_is_not_a_tamper_alarm(self) -> None:
+        # `*_deactivation_tamper` means the tamper protection is DISABLED —
+        # it must never feed the `tamper` key the tamper sensor binds to
+        # (#338 vs the #339/#340 fold in the same function).
+        lds = _LDS()
+        status = lds(temporary_deactivation_tamper=lds.Simple())
+        result = DevicesApi._parse_statuses([status])
+        assert "tamper" not in result
+
     def test_high_temperature(self) -> None:
         status = MagicMock()
         status.WhichOneof.return_value = "high_temperature_detected"

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -126,6 +126,34 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert "door_opened" in dev_info["statuses"]
 
     @pytest.mark.asyncio
+    async def test_active_device_reports_no_deactivation(self, entry: MagicMock) -> None:
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+        dev_info = result["devices"]["dev-1"]
+        assert dev_info["deactivated"] is False
+        assert dev_info["deactivation_kinds"] == []
+
+    @pytest.mark.asyncio
+    async def test_app_deactivated_device_is_visible(self, coordinator: MagicMock) -> None:
+        # #338: `bypassed` alone can't answer "is this sensor protecting
+        # anything" — a device deactivated from the Ajax app leaves it False.
+        from dataclasses import replace
+
+        coordinator.devices["dev-1"] = replace(
+            _make_device(),
+            statuses={"temporary_deactivation_whole": True, "deactivated": True},
+        )
+        e = MagicMock()
+        e.runtime_data = coordinator
+        e.data = {"spaces": ["space-1"]}
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), e)
+
+        dev_info = result["devices"]["dev-1"]
+        assert dev_info["bypassed"] is False
+        assert dev_info["deactivated"] is True
+        assert dev_info["deactivation_kinds"] == ["temporary_deactivation_whole"]
+
+    @pytest.mark.asyncio
     async def test_firmware_update_maps_included(self, entry: MagicMock) -> None:
         # 2.1 / project rule (#148): every entity-driving field must land
         # in the diagnostics dump — both `update.*` sources included.

--- a/tests/unit/test_switch.py
+++ b/tests/unit/test_switch.py
@@ -192,7 +192,10 @@ class TestAjaxBypassSwitch:
     """Per-device bypass (deactivation) switch (#bypass)."""
 
     def _make(
-        self, device_type: str = "door_protect", bypassed: bool = False
+        self,
+        device_type: str = "door_protect",
+        bypassed: bool = False,
+        statuses: dict | None = None,
     ) -> tuple[object, MagicMock]:
         from custom_components.aegis_ajax.switch import AjaxBypassSwitch
 
@@ -202,6 +205,7 @@ class TestAjaxBypassSwitch:
         device.device_type = device_type
         device.bypassed = bypassed
         device.is_online = True
+        device.statuses = statuses if statuses is not None else {}
         coordinator.devices = {"d1": device}
         sw = AjaxBypassSwitch(
             coordinator=coordinator, device_id="d1", hub_id="h1", device_type=device_type
@@ -271,6 +275,89 @@ class TestAjaxBypassSwitch:
         cmd = coordinator.devices_api.send_command.call_args[0][0]
         assert cmd.action == "bypass"
         assert cmd.bypass_enable is False
+
+    # --- #338: the switch must read the panel's real deactivation state -----
+    # A device deactivated from the Ajax app never sets `profile.bypassed`;
+    # the truth arrives as one of the `*_deactivation_*` statuses. Without
+    # this the switch shows `off` (= protected) on a sensor the panel has
+    # disabled — the dangerous half of #338.
+
+    def test_is_on_true_when_temporary_deactivation_whole_present(self) -> None:
+        sw, _ = self._make(bypassed=False, statuses={"temporary_deactivation_whole": True})
+        assert sw.is_on is True
+
+    def test_is_on_true_when_one_time_deactivation_tamper_present(self) -> None:
+        sw, _ = self._make(bypassed=False, statuses={"one_time_deactivation_tamper": True})
+        assert sw.is_on is True
+
+    def test_is_on_true_when_folded_deactivated_key_present(self) -> None:
+        # The parser/delta fold writes the shared key; the switch binds to it.
+        sw, _ = self._make(bypassed=False, statuses={"deactivated": True})
+        assert sw.is_on is True
+
+    def test_is_on_false_when_unrelated_status_present(self) -> None:
+        sw, _ = self._make(bypassed=False, statuses={"door_opened": True})
+        assert sw.is_on is False
+
+    def test_attributes_expose_active_deactivation_kinds(self) -> None:
+        sw, _ = self._make(
+            bypassed=False,
+            statuses={
+                "deactivated": True,
+                "temporary_deactivation_whole": True,
+                "one_time_deactivation_tamper": True,
+                "door_opened": True,
+            },
+        )
+        assert sw.extra_state_attributes == {
+            "deactivation_kinds": [
+                "temporary_deactivation_whole",
+                "one_time_deactivation_tamper",
+            ]
+        }
+
+    def test_attributes_empty_list_when_active(self) -> None:
+        sw, _ = self._make(bypassed=False, statuses={"door_opened": True})
+        assert sw.extra_state_attributes == {"deactivation_kinds": []}
+
+    @pytest.mark.asyncio
+    async def test_turn_on_schedules_confirm_read(self) -> None:
+        # #338 option A: the write can be accepted and silently not applied,
+        # so the entity must be corrected by an independent read-back.
+        sw, coordinator = self._make()
+        coordinator.devices_api.send_command = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+
+        await sw.async_turn_on()
+
+        coordinator.schedule_bypass_confirm.assert_called_once_with("d1", expected=True)
+
+    @pytest.mark.asyncio
+    async def test_turn_off_schedules_confirm_read(self) -> None:
+        sw, coordinator = self._make(bypassed=True)
+        coordinator.devices_api.send_command = AsyncMock()
+        coordinator.async_request_refresh = AsyncMock()
+
+        await sw.async_turn_off()
+
+        coordinator.schedule_bypass_confirm.assert_called_once_with("d1", expected=False)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_scheduled_when_the_write_fails(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+
+        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+
+        sw, coordinator = self._make()
+        coordinator.devices_api.send_command = AsyncMock(
+            side_effect=DeviceCommandError("bypass: permission_denied", reason="permission_denied")
+        )
+        coordinator.async_request_refresh = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await sw.async_turn_on()
+
+        coordinator.schedule_bypass_confirm.assert_not_called()
 
 
 class TestBypassSwitchSetup:


### PR DESCRIPTION
## Summary

Relates to #338 — implements the decision posted in the issue: **read-first, plus option A**. Option B (switching the write lever to `BYPASS_ONE_TIME_DISABLE`) is untouched and still waits on the hardware datapoint requested there.

**Read (the dangerous half).** A device deactivated from the Ajax app leaves `profile.bypassed` False and reports one of the `*_deactivation_*` statuses instead — none of which the parser read. Home Assistant therefore showed a panel-disabled sensor as live protection, with its bypass switch `off`. Those statuses are now read on **both** paths (the snapshot parser and the realtime delta handler) and folded into a shared `deactivated` key the bypass switch binds to, so the switch is honest regardless of who deactivated the device. The granular mode is exposed as a `deactivation_kinds` attribute for automations that only care about a fully disabled device.

Two things are deliberate and documented at the mapping site so nobody "fixes" them backwards:
- Ajax's naming is inverted — `temporary_deactivation_*` is the **permanent** deactivation, `one_time_deactivation_*` lasts one arming cycle.
- `*_deactivation_tamper` means the device's **tamper protection is disabled**. It is not a tamper alarm and is kept out of the #339/#340 tamper fold that lives in the same function (covered by an explicit negative test).

The four `whole`/`tamper` variants are the hardware-confirmed ones; the bare and `alarms`/`timer` variants from the same oneof are folded the same way, since each of them also means "protection is off here" and under-reporting that is exactly the failure mode this fix removes.

**Write (option A).** `DeviceCommandBypass` has a real accept-but-inert mode: the hub answers success and applies nothing when the account can't set the requested deactivation. A successful command is therefore not evidence of a state change, so instead of an optimistic update every write schedules an independent per-device read-back (single-flight, 5 s settle, same shape as the #337 siren confirm). The switch reverts to whatever the panel really reports, and a warning naming the device is logged so the silent no-op is visible in the log rather than only in the unchanged hardware.

## Test plan

- [x] `make check` passes locally on a freshly built Docker image (1945 tests, coverage 89.70%)
- [x] New behaviour covered by unit tests in `tests/unit/`
- [x] Coverage stays at or above the 80% threshold
- [x] User-facing strings updated in `strings.json` and the 14 translation files — n/a, no new strings (`deactivation_kinds` is a state attribute, and the warning is a log line)
- [x] `README.md` / `CHANGELOG.md` updated when the change is user-visible

New tests: all eight deactivation cases parsed from **real protos** (not mocks) and folded, with negative controls for both folds; delta ADD / REMOVE / hold-while-another-mode-active; switch state and attributes; confirm-read applies the fresh snapshot, warns on disagreement, stays silent on agreement, clears its pending flag on a read error, and no confirm is scheduled when the write itself raised.

## Notes for the reviewer

- **Not validated on hardware.** The read path is derived from @wip3out3r's four-mode mapping and the compiled protos; the accept-but-inert warning is the code path I'd most like confirmed against the live fixture that is still standing (deactivate a device from the app → the switch should flip to `on` within a snapshot; toggle bypass from an account that can't apply it → expect the warning and the switch snapping back).
- `is_device_deactivated` / `device_deactivation_kinds` are module functions in `api/models.py` rather than `Device` properties, so the entity layer, the coordinator and diagnostics share one definition.
- Diagnostics now dump `bypassed`, `deactivated` and `deactivation_kinds` side by side — the point being that the first one alone cannot answer "is this sensor protecting anything".
- The confirm read reuses `get_devices_snapshot` for the device's space and routes the result through `_handle_devices_snapshot`, so a cleared deactivation is dropped properly rather than merged on top of the stale state.
