### PR TITLE
feat(hts): probe the Button activity-timestamp keys 0x39/0x40 (#348)

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -152,6 +152,57 @@ _HTS_TAMPER_CANDIDATE_KEYS: tuple[int, ...] = (0x04, 0x0F)
 # entirely — hence a probe and not a feature.
 _HTS_BYPASS_CANDIDATE_KEYS: tuple[int, ...] = (0xB6, 0xB7)
 
+# HTS per-device kv keys that may carry a Button's last-activity timestamp
+# (#348) — read-only probe, nothing is routed off them.
+#
+# A hardware log of an Ajax Button in control mode showed `0x39` on the
+# device's STATUS_UPDATE row moving to the exact second of each press, twice,
+# on two independent presses: a press logged at 08:18:25 local carried
+# `0x39=6a683b9f` (05:18:23Z) and one at 08:23:10 carried `0x39=6a683cbd`
+# (05:23:09Z) on a UTC+3 install. So `0x39` decodes as a big-endian Unix epoch
+# and it is the only signal a control-mode press produces at all — the
+# `button_1_on` / `button_2_on` FCM tags never appeared, and the coincident
+# gRPC delta is a plain `battery` status.
+#
+# Two things that capture could NOT establish, which is why this is a probe and
+# not an event entity:
+#
+#   1. **Short vs long click are indistinguishable in it.** Both presses moved
+#      `0x39` and nothing else; `0x40` stayed `00000000` on that device. So a
+#      one-key signal cannot carry the two separate actions the issue asks for.
+#      (`0x40` did hold an old epoch — 2026-07-03 — on the install's *other*
+#      Button, so it means something rarer than a press, not the second action.)
+#   2. **Whether it moves without a press.** Ajax peripherals ping the hub for
+#      supervision, and if `0x39` were last-radio-contact rather than
+#      last-press, routing an HA event off it would fire phantom presses on
+#      every ping. Logging only *transitions* makes an idle install the control
+#      case: silence over a quiet window falsifies the ping reading, while a
+#      1:1 match with presses confirms it.
+_HTS_BUTTON_ACTIVITY_CANDIDATE_KEYS: tuple[int, ...] = (0x39, 0x40)
+
+# Bounds for treating a 4-byte HTS value as a big-endian Unix epoch. Deliberately
+# wide — the point is only to reject values that clearly aren't timestamps (`00000000`,
+# a counter, a bitfield) so the probe never dresses an unrelated key up as a date.
+_HTS_EPOCH_MIN = 1_420_070_400  # 2015-01-01Z
+_HTS_EPOCH_MAX = 4_102_444_800  # 2100-01-01Z
+
+
+def _describe_hts_epoch(value: bytes) -> str:
+    """Render a 4-byte HTS value as a big-endian UTC timestamp, or say why not.
+
+    Used by the #348 Button probe so a DEBUG line can be lined up against the
+    wall-clock moment of a press without hand-converting hex. Anything that is
+    not a plausible epoch is reported as such rather than being forced into a
+    date — see `_HTS_BUTTON_ACTIVITY_CANDIDATE_KEYS`.
+    """
+    if len(value) != 4:
+        return f"not an epoch: {len(value)}b"
+    seconds = int.from_bytes(value, "big")
+    if not _HTS_EPOCH_MIN <= seconds <= _HTS_EPOCH_MAX:
+        return f"not an epoch: {seconds}"
+    return dt_util.utc_from_timestamp(seconds).isoformat()
+
+
 # Marks a `tamper` status as sourced from the HTS status stream rather than the
 # gRPC device stream. The gRPC snapshot on these hubs has no tamper field at
 # all, so a fresh snapshot would silently wipe the status; this lets
@@ -323,6 +374,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # authoritative re-read. Tracking the last value avoids re-nudging on
         # every 60s STATUS_BODY probe (which re-reports the same flag).
         self._space_security_arm_flags: dict[str, int] = {}
+        # Last-seen value of each Button activity-candidate key (#348), keyed by
+        # `(device_id_hex, kv_key)`. Only a *change* is logged, so an untouched
+        # Button is silent and a quiet window becomes the control case that
+        # tells a press apart from a supervision ping. See
+        # `_HTS_BUTTON_ACTIVITY_CANDIDATE_KEYS`.
+        self._hts_button_activity: dict[tuple[str, int], str] = {}
         # One-shot guard for the #206 Bug-B SmartLock id probe (DEBUG-only).
         self._smart_lock_probe_done = False
         # Per-space monotonic timestamp of when the hub first reported
@@ -1133,6 +1190,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Bypass-configuration candidate keys (#338) — read-only, logged before
         # anything that can return early so every device family reports them.
         self._log_hts_bypass_candidates(device_id_hex, device, kv)
+        # Button activity-timestamp candidate keys (#348) — read-only, same
+        # placement rationale as the bypass probe above: every device family
+        # gets probed, and the keys are Button-specific in every capture so far.
+        self._log_hts_button_activity_candidates(device_id_hex, device, kv)
         # Internal temperature via HTS 0x02 (#229), for device families with no
         # gRPC temperature source (Curtain Outdoor Plus/Base). Additive: only
         # fills when the device doesn't already carry a temperature, so devices
@@ -1226,6 +1287,49 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             is_device_deactivated(device),
             device_deactivation_kinds(device),
         )
+
+    def _log_hts_button_activity_candidates(
+        self, device_id_hex: str, device: Device, kv: dict[int, bytes]
+    ) -> None:
+        """DEBUG-log transitions of the Button activity-candidate keys (#348).
+
+        Read-only by design — see `_HTS_BUTTON_ACTIVITY_CANDIDATE_KEYS`. Logs
+        only when a value *changes*, which is the whole point: the reading to
+        falsify is that these keys track supervision pings rather than presses,
+        and that shows up as transitions on a Button nobody is touching. A
+        first sighting is recorded silently, because the boot snapshot re-reports
+        whatever the last press left behind and would otherwise look like a press
+        at every restart.
+
+        Each 4-byte value is also rendered as a big-endian Unix epoch, so the log
+        can be compared against the wall-clock moment of a press without anyone
+        having to convert hex by hand. Values that are not 4 bytes, or that fall
+        outside a plausible epoch window, are reported as `raw` only — a key that
+        carries something else on another firmware must not be dressed up as a
+        timestamp.
+
+        Silent when the row carries none of the keys, so device families that
+        don't report them add no log noise.
+        """
+        for key in _HTS_BUTTON_ACTIVITY_CANDIDATE_KEYS:
+            value = kv.get(key)
+            if value is None:
+                continue
+            current = value.hex()
+            cache_key = (device_id_hex, key)
+            previous = self._hts_button_activity.get(cache_key)
+            self._hts_button_activity[cache_key] = current
+            if previous is None or previous == current:
+                continue
+            _LOGGER.debug(
+                "HTS button probe: device=%s type=%s key=0x%02X %s -> %s (%s)",
+                device_id_hex,
+                device.device_type,
+                key,
+                previous,
+                current,
+                _describe_hts_epoch(value),
+            )
 
     def _maybe_apply_hts_device_tamper(
         self, device_id_hex: str, device: Device, kv: dict[int, bytes]

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2351,6 +2351,166 @@ class TestHtsBypassCandidateProbe:
         coordinator.async_set_updated_data.assert_not_called()
 
 
+class TestHtsButtonActivityProbe:
+    """HTS `0x39`/`0x40` as a Button's last-activity timestamp (#348).
+
+    Evidence base: one install's Ajax Button in control mode, where `0x39` on
+    the device's STATUS_UPDATE row moved to the exact second of each press —
+    `6a683b9f` (05:18:23Z) for a press logged 08:18:25 local and `6a683cbd`
+    (05:23:09Z) for one logged 08:23:10, on a UTC+3 install. Both a short and a
+    long click moved that one key, so it cannot carry the two separate actions
+    the issue asks for, and whether it also moves on a supervision ping is
+    unproven. Hence a transition-only probe: an untouched Button must stay
+    silent, because that silence is what falsifies the ping reading.
+
+    The values below are the real captured ones.
+    """
+
+    # 0x39 as captured on two consecutive presses of the same Button.
+    FIRST_PRESS = b"\x6a\x68\x3b\x9f"  # 2026-07-28T05:18:23Z
+    SECOND_PRESS = b"\x6a\x68\x3c\xbd"  # 2026-07-28T05:23:09Z
+
+    def _make_device(self, device_type: str = "button") -> Device:
+        return Device(
+            id="313E5F32",
+            hub_id="hub-1",
+            name="Boto",
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    def test_a_press_after_a_known_value_logs_the_decoded_transition(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device()
+
+        # First row establishes the baseline, second is the press.
+        coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: self.FIRST_PRESS})
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: self.SECOND_PRESS})
+
+        assert "HTS button probe" in caplog.text
+        assert "key=0x39" in caplog.text
+        assert "6a683b9f -> 6a683cbd" in caplog.text
+        # The decoded epoch is what lets a reporter line the line up against
+        # the wall-clock moment they pressed.
+        assert "2026-07-28T05:23:09" in caplog.text
+
+    def test_first_sighting_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        # The boot snapshot re-reports whatever the last press left behind;
+        # logging it would look like a press at every restart.
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device()
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: self.FIRST_PRESS})
+
+        assert "HTS button probe" not in caplog.text
+
+    def test_an_unchanged_value_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        # This is the control case the whole probe exists for: the 60s
+        # STATUS_BODY re-reports the same value, and an untouched Button must
+        # produce no line at all — otherwise silence proves nothing.
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device()
+
+        coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: self.FIRST_PRESS})
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            for _ in range(5):
+                coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: self.FIRST_PRESS})
+
+        assert "HTS button probe" not in caplog.text
+
+    def test_the_two_keys_are_tracked_independently(self, caplog: pytest.LogCaptureFixture) -> None:
+        # `0x40` held an old epoch on the install's other Button, so it means
+        # something rarer than a press. It must not be conflated with `0x39`.
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device()
+
+        coordinator._on_hts_device_kv(
+            "0023F477", "313E5F32", {0x39: self.FIRST_PRESS, 0x40: b"\x00\x00\x00\x00"}
+        )
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv(
+                "0023F477", "313E5F32", {0x39: self.SECOND_PRESS, 0x40: b"\x00\x00\x00\x00"}
+            )
+
+        assert "key=0x39" in caplog.text
+        assert "key=0x40" not in caplog.text
+
+    def test_a_non_timestamp_value_is_not_dressed_up_as_a_date(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A key that carries a counter or bitfield on another firmware must be
+        # reported as raw, not converted into a plausible-looking date.
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device()
+
+        coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x40: b"\x00\x00\x00\x00"})
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x40: b"\x00\x00\x00\x01"})
+
+        assert "HTS button probe" in caplog.text
+        assert "not an epoch: 1" in caplog.text
+
+    def test_a_short_value_is_reported_by_length(self, caplog: pytest.LogCaptureFixture) -> None:
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device()
+
+        coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: b"\x00"})
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: b"\x01"})
+
+        assert "not an epoch: 1b" in caplog.text
+
+    def test_two_buttons_do_not_share_a_baseline(self, caplog: pytest.LogCaptureFixture) -> None:
+        # The install has two Buttons with different `0x39` values; a shared
+        # cache would report a press on each alternating row.
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device()
+        coordinator.devices["313E63EC"] = replace(self._make_device(), id="313E63EC")
+
+        coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: self.FIRST_PRESS})
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("0023F477", "313E63EC", {0x39: self.SECOND_PRESS})
+
+        assert "HTS button probe" not in caplog.text
+
+    def test_nothing_logged_for_a_device_without_the_keys(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device(device_type="relay")
+        # A relay row carries electrical readings, which reach the update path.
+        coordinator.async_set_updated_data = MagicMock()
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x42: b"\x00\x00\x00\x00"})
+
+        assert "HTS button probe" not in caplog.text
+
+    def test_probe_does_not_change_any_state(self) -> None:
+        # Read-only: short vs long click is still unresolved, and emitting an
+        # HA event off a key that may track supervision pings would fire
+        # phantom presses into the user's automations.
+        coordinator = _make_coordinator()
+        coordinator.devices["313E5F32"] = self._make_device()
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: self.FIRST_PRESS})
+        coordinator._on_hts_device_kv("0023F477", "313E5F32", {0x39: self.SECOND_PRESS})
+
+        assert coordinator.devices["313E5F32"].statuses == {}
+        coordinator.async_set_updated_data.assert_not_called()
+
+
 class TestHtsCaseTamperRouting:
     """HTS `0x04`/`0x0f` drive the shared `tamper` status (#339).
 


### PR DESCRIPTION
## Summary

Relates to #348. Read-only DEBUG probe, no behaviour change at default log level.

@raven2k24 posted a DEBUG capture of an Ajax Button in control mode, and it answers the question I asked — just not with the answer I expected.

**What the capture establishes.** HTS key `0x39` on the Button's `STATUS_UPDATE` row moves to the exact second of each press. Two independent presses, on a UTC+3 install:

| press logged (local) | `0x39` | decoded |
|---|---|---|
| 08:18:25 (long click) | `6a683b9f` | 05:18:23Z |
| 08:23:10 (short click) | `6a683cbd` | 05:23:09Z |

So it decodes as a big-endian Unix epoch, and it is the *only* signal a control-mode press produces: the `button_1_on` / `button_2_on` tags never appeared, and the coincident gRPC delta is a plain `battery` status (a sleepy device reporting battery as it wakes to transmit).

Worth recording that `Button1On` / `Button2On` are hub **event** tags in the FCM vocabulary, and their proto neighbours are `ArcFaultDetected` (20), then `RelayCurrentHigh` (23), `RelayOnByButton`… — a relay/wall-switch cluster. That makes them likelier to be a two-gang switch's rockers than the standalone Button, which weakens the original theory in #348 rather than confirming it.

**What it does not establish**, and why this is a probe and not an event entity:

1. **Short vs long click are indistinguishable in it.** Both presses moved `0x39` and nothing else. One key cannot carry the two separate actions the issue asks for. `0x40` isn't the second action either — it held a three-week-old epoch (2026-07-03) on the install's *other* Button, so it tracks something rarer than a press.
2. **Whether `0x39` moves without a press is unknown.** Ajax peripherals ping the hub for supervision. If this key is last-radio-contact rather than last-press, routing an HA event off it would fire phantom presses into users' automations on every ping.

**Why transition-only.** Logging only *changes* is what makes the next capture conclusive: an untouched Button stays silent, so silence across a quiet window falsifies the ping reading, while a 1:1 match with presses confirms it. Same shape as the #338 bypass and #339 tamper candidate probes. A first sighting is recorded silently — the boot snapshot re-reports whatever the last press left behind and would otherwise look like a press at every restart.

Values render as UTC so a reporter can line the log up against the moment they pressed without converting hex by hand; anything that isn't a plausible epoch is reported as raw rather than forced into a date, since these keys may carry something else on another firmware.

## Test plan

- [x] `make check` passes on a freshly built Docker image (1973 tests, coverage 89.81%)
- [x] New behaviour covered by unit tests in `tests/unit/` — 9 tests, using the real captured `0x39` values
- [x] Coverage stays at or above the 80% threshold
- [x] User-facing strings updated in `strings.json` and the 14 translation files — n/a, DEBUG log line only
- [x] `README.md` / `CHANGELOG.md` updated when the change is user-visible — n/a, invisible at default log level, same as the #338/#339 candidate probes

Tests pin both directions: a press after a known baseline logs the decoded transition; a first sighting, an unchanged value repeated across five `STATUS_BODY` ticks, a second Button with a different value, and a device without the keys are all silent. Plus: the two keys are tracked independently, a non-epoch value is not dressed up as a date, and the probe mutates no state.

## Notes for the reviewer

- The `0x39` = press reading rests on **one install, two presses**. Deliberately routed to nothing.
- Open question for the reporter, which decides the eventual shape: whether FCM push is configured on that install at all. If it is and no `button_*` tag appeared, the hub genuinely doesn't push control-mode presses and the HTS timestamp is the only path — which caps the feature at a single "pressed" event, not the two the issue wants. Asking on the issue.
- Alarm-mode Buttons already work today via the mapped `panic_button_pressed` tag; this is only about control mode.
