### PR TITLE
fix(siren): report why a siren settings snapshot came back empty (#354)

### DIFF
--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -126,6 +126,43 @@ def _build_object_type(device_type: str) -> Any:  # noqa: ANN401
     return obj
 
 
+def _log_empty_siren_settings(hub_device_id: str, hub_device: Any) -> None:  # noqa: ANN401
+    """DEBUG-report why a siren's settings snapshot yielded nothing (#354).
+
+    An empty result has three different causes needing three different fixes,
+    and the caller can't tell them apart from `{}` alone:
+
+    1. The `device` oneof case is one we don't model, so the whole sub-message
+       is undecodable — the snapshot arrives but reads as unset. This is what
+       kept the DoubleDeck / Fibra / S sirens unreadable before #354.
+    2. The case is modelled but carries no `common_siren_part`, i.e. this SKU
+       genuinely doesn't expose its settings on this stream.
+    3. The part is there but neither value is set.
+
+    Logging the case name plus whether the siren part is present separates all
+    three, which is exactly what a reporter's log has to answer before anyone
+    guesses at a fix. Mirrors the same probe on the temperature path (#229).
+    """
+    case = hub_device.WhichOneof("device") if hasattr(hub_device, "WhichOneof") else None
+    sub = getattr(hub_device, case, None) if case else None
+    has_siren_part: bool | None = None
+    if sub is not None and hasattr(sub, "HasField"):
+        try:
+            has_siren_part = sub.HasField("common_siren_part")
+        except (ValueError, TypeError):
+            # This SKU's message has no such field at all — distinct from
+            # having one that is unset, so report it as unknown rather than
+            # False.
+            has_siren_part = None
+    _LOGGER.debug(
+        "StreamHubDevice (siren settings) for %s carried no settings; "
+        "HubDevice oneof case=%r common_siren_part=%s",
+        hub_device_id,
+        case,
+        has_siren_part,
+    )
+
+
 def _encode_string_field(field_number: int, value: str) -> bytes:
     """Encode a protobuf string field (wire type 2)."""
     tag = (field_number << 3) | 2
@@ -342,7 +379,10 @@ class DevicesApi:
             if msg.HasField("success"):
                 if msg.success.WhichOneof("success") == "snapshot":
                     hub_device = msg.success.snapshot.hub_device
-                    return devices_parser.parse_hub_device_siren_settings(hub_device)
+                    settings = devices_parser.parse_hub_device_siren_settings(hub_device)
+                    if not settings:
+                        _log_empty_siren_settings(hub_device_id, hub_device)
+                    return settings
             elif msg.HasField("failure"):
                 _LOGGER.debug(
                     "StreamHubDevice (siren settings) failed for device %s: %s",

--- a/tests/unit/test_siren_settings.py
+++ b/tests/unit/test_siren_settings.py
@@ -233,6 +233,98 @@ class TestGetHubDeviceSirenSettings:
         assert result == {SIREN_ALARM_DURATION_KEY: 60, SIREN_VOLUME_LEVEL_KEY: 1}
 
     @pytest.mark.asyncio
+    async def test_empty_snapshot_reports_the_oneof_case(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """#354: `{}` alone can't say which of three causes was hit.
+
+        nimahel's DoubleDeck reads `unknown` on `1.15.1-beta.6` even though the
+        oneof case is now modelled and writes reach the hub. The log has to name
+        the case the server actually sent and whether it carried a siren part,
+        or the next step is guesswork.
+        """
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import (
+            hub_device_pb2,
+            street_siren_pb2,
+        )
+
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        api = DevicesApi(client)
+
+        msg = MagicMock()
+        msg.HasField.side_effect = lambda field: field == "success"
+        msg.success.WhichOneof.return_value = "snapshot"
+        # A modelled case whose siren part is simply absent.
+        msg.success.snapshot.hub_device = hub_device_pb2.HubDevice(
+            street_siren_double_deck=street_siren_pb2.StreetSirenDoubleDeck()
+        )
+
+        with (
+            caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.api.devices"),
+            _patch_stream_hub_device(_stub_yielding(msg)),
+        ):
+            result = await api.get_hub_device_siren_settings("hub-1", "30EA219B")
+
+        assert result == {}
+        assert "carried no settings" in caplog.text
+        assert "case='street_siren_double_deck'" in caplog.text
+        assert "common_siren_part=False" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_empty_snapshot_reports_an_unmodelled_case_as_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The pre-#354 shape: nothing decodes, so there is no case at all. This
+        # is the reading that says "extend the proto", as opposed to "this SKU
+        # doesn't expose settings here".
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import hub_device_pb2
+
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        api = DevicesApi(client)
+
+        msg = MagicMock()
+        msg.HasField.side_effect = lambda field: field == "success"
+        msg.success.WhichOneof.return_value = "snapshot"
+        msg.success.snapshot.hub_device = hub_device_pb2.HubDevice()
+
+        with (
+            caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.api.devices"),
+            _patch_stream_hub_device(_stub_yielding(msg)),
+        ):
+            result = await api.get_hub_device_siren_settings("hub-1", "30EA219B")
+
+        assert result == {}
+        assert "case=None" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_populated_snapshot_logs_nothing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The probe must stay silent on the healthy path, or it becomes noise on
+        # every one of the 900 s sweeps.
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        api = DevicesApi(client)
+
+        msg = MagicMock()
+        msg.HasField.side_effect = lambda field: field == "success"
+        msg.success.WhichOneof.return_value = "snapshot"
+        msg.success.snapshot.hub_device = _street_siren(alarm_duration=60, volume_level=1)
+
+        with (
+            caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.api.devices"),
+            _patch_stream_hub_device(_stub_yielding(msg)),
+        ):
+            await api.get_hub_device_siren_settings("hub-1", "30EA219B")
+
+        assert "carried no settings" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_returns_empty_on_failure_message(self) -> None:
         client = MagicMock()
         client._get_channel.return_value = MagicMock()


### PR DESCRIPTION
## Summary

On `1.15.1-beta.6` a Street Siren DoubleDeck materialises both config entities and **accepts writes**, but the values never populate — @nimahel reported it staying `unknown` after half an hour, and app-side changes not reflecting either.

An empty settings dict has three causes needing three different fixes, and nothing in the log distinguished them:

1. The `device` oneof case is one we don't model, so the sub-message is undecodable and the snapshot reads as unset. (This is what #356 was meant to fix.)
2. The case is modelled but carries no `common_siren_part` — this SKU genuinely doesn't expose its settings on this stream.
3. The part is there but both values are unset.

The read path now DEBUG-logs the oneof case the server actually sent, plus whether a siren part was present, on the empty path only. That's the same probe the temperature path has had since #229; the siren path was simply missing it, which is why the reporter's log can't currently answer the question.

A message type with no such field at all reports `None` rather than `False`, so "field absent" stays distinct from "field unset" — that difference is exactly what separates cause 1 from cause 2.

No behaviour change; diagnostics only. Relates to #354.

## Test plan

- [x] `make check` passes locally on a freshly built Docker image
- [x] New behaviour covered by unit tests in `tests/unit/`
- [x] Coverage stays at or above the 80% threshold
- [ ] User-facing strings updated in `strings.json` and the 14 translation files — n/a, DEBUG log only
- [ ] `README.md` / `CHANGELOG.md` updated — n/a, no user-visible change

Three tests: a modelled case with no siren part reports `case='street_siren_double_deck' common_siren_part=False`, an unmodelled case reports `case=None`, and the healthy path logs nothing at all (otherwise the 900 s sweep would print this on every cycle for every siren).

## Notes for the reviewer

This is deliberately a diagnostic rather than a fix. I don't yet know which of the three causes @nimahel is hitting, and each implies different work — extending the proto further, accepting that the SKU has no readable settings, or looking at the write-then-read-back path. Guessing without his log would risk shipping a second half-fix on top of the first.

Worth deciding separately: while the read is broken, the two entities show `unknown` but writes do work. That's the "permanently empty entity" outcome the old `SIREN_DEVICE_TYPES` comment set out to avoid. My inclination is to leave them — writing is genuinely useful and pulling entities back out hurts anyone who has already put them on a dashboard — but it's reversible either way.