### PR TITLE
docs(notification): correct the stale space-routing comment (#358)

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -888,7 +888,11 @@ class AjaxNotificationListener:
                     event_data.get("raw_tag"),
                     event_data.get("group_id"),
                 )
-                # Try to route to the correct space by matching hub_id from raw bytes
+                # Route to the space the push itself names (#358). This used to
+                # scan the payload for the hub id as raw bytes, which never
+                # matched a genuine push — the id travels as ASCII text — so
+                # every event took the fallback below and was delivered to every
+                # space. Don't reintroduce a byte scan here.
                 target_space = self._find_space_for_event(raw)
                 if target_space:
                     self._dispatch_to_loop(


### PR DESCRIPTION
One-line comment fix, no behaviour change.

The comment above the `_find_space_for_event` call still read:

```python
# Try to route to the correct space by matching hub_id from raw bytes
```

That describes the **pre-#358** behaviour, and it is exactly the wrong mental model that caused every push to be delivered to every configured space: the hub id travels as ASCII text, so the byte scan never matched a genuine payload and every event fell through to the fan-out path. The function was fixed in `1.15.1-beta.9` and reads `Notification.space.id` structurally; only the call-site comment was left behind — where it reads as documentation of what the code *does* rather than of what it must never do again.

Replaced with a note that states what the code does now, why the byte scan was wrong, and not to reintroduce it.

Spotted while investigating #359 (unrelated) and worth correcting on its own: the next person to touch this path would have been handed the discredited model in a comment.

`make check` green (2072 tests).