### PR TITLE
chore(deps): stop Dependabot proposing grpcio-tools minor/major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,27 @@ updates:
       - python
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # grpcio-tools is pinned exactly, not floored, and bumping it is a piece of
+      # work rather than a dependency update: the compiler bakes its Protobuf
+      # gencode version into every generated stub, so the pin can only move
+      # together with a full recompile of the proto tree AND a matching rise of
+      # the runtime `protobuf` floor in pyproject.toml.
+      #
+      # That last part is the real blocker: 1.75.1 emits gencode 6.31.1, while
+      # 1.83.0 emits 7.35.1 — the exact version from the #354 failure
+      # ("gencode 7.35.1 runtime 6.32.0") that broke every install on
+      # 1.15.1-beta.6 → beta.10. Home Assistant ships protobuf 6.x, so stubs
+      # built by a 7.x compiler cannot be imported at all.
+      #
+      # CI cannot catch this: a bump on its own changes no stub, so every check
+      # passes and the breakage only lands on the next `make proto`. Hence the
+      # rule rather than a review habit. Patch bumps stay allowed — those keep
+      # gencode at 6.31.1. Revisit when Home Assistant itself ships protobuf 7.x.
+      - dependency-name: "grpcio-tools"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       # Bundle all minor / patch bumps into one PR per week to reduce noise.
       python-minor-patch:


### PR DESCRIPTION
Follow-up to closing #377.

Dependabot offered `grpcio-tools` 1.75.1 → 1.83.0 as a routine weekly bump. It is not one: the pin is exact rather than floored because the compiler bakes its Protobuf gencode version into every generated stub.

| grpcio-tools | requires | gencode emitted |
|---|---|---|
| `1.75.1` (current) | `protobuf>=6.31.1,<7.0.0` | **6.31.1** |
| `1.83.0` | `protobuf>=7.35.1,<8.0.0` | **7.35.1** |

`7.35.1` is the exact gencode from the #354 failure — `gencode 7.35.1 runtime 6.32.0` — which broke **every** install on `1.15.1-beta.6` through `beta.10`. Home Assistant ships protobuf 6.x, so a stub built by a 7.x compiler cannot be imported at all.

**Why a rule and not a review habit.** CI cannot catch this. A pin bump on its own changes no generated stub, so every check passes — `proto-runtime-floor` included, correctly, because the committed tree still agrees with the declared floor. The breakage is deferred to whoever next runs `make proto`, and then ships to users. That is the same structural blind spot #354 documented: the dev environment installs the newest protobuf while the bug requires the oldest.

Moving the pin properly means three things together — bump, recompile the whole proto tree, raise the runtime `protobuf` floor — and the third is blocked on Home Assistant shipping protobuf 7.x. Until then there is nothing to merge, so the noise is pure risk.

**Patch bumps stay allowed** (`1.75.1` → `1.75.2` keeps gencode `6.31.1`); only minor and major are ignored. Revisit when Home Assistant itself moves to protobuf 7.x.