### PR TITLE
Fix IMEI sensor availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Thanks to @Taknok, who owns a Double Deck, found both device-type lists, worked out why there are two, and tested the change on the real siren — the confirmation this needed and that could not be produced without the hardware.
 
 ### Fixed
+- **The hub IMEI sensor is now created whether or not the SIM read has succeeded yet (#379).** It was only offered for hubs the integration had already read SIM details from, so a read that failed or had not completed produced no entity at all — and because Home Assistant never removes an entity an integration stops offering, one created on an earlier start sat `unavailable` indefinitely with nothing to explain it. Creation now follows from the hub being present; whether the SIM details are readable is left to the entity's availability, which is what availability is for.
+
+  The sensor is disabled by default, as before, so a hub that never reports SIM details does not gain a visible dead entity. Fixed by @aavdberg, who reported the issue and sent the fix.
+
 - **Diagnostics downloads no longer contain the names you gave your devices, spaces, groups or keyfobs.** These downloads are routinely attached to bug reports, and Ajax names are free text that people set to where a thing is — street names and home addresses turn up as device names in practice. Each name is now reported as a **length** instead of a value, which still distinguishes a named device from an unnamed one while identifying nothing. It is the same rule the hub IMEI already followed.
 
   Nothing is lost for troubleshooting: devices are keyed by their id, which is what links them across the file, and a device's group id still matches an entry in that space's group list. The one casualty is the resolved group *name* that briefly accompanied each device's group id in `1.16.0-beta.1`; the id linkage replaces it. Raised by @wip3out3r, whose own device names include a street and an address.

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -152,7 +152,7 @@ async def async_setup_entry(
 
     # Add SIM sensors for hub devices that have SIM info
     for space in coordinator.spaces.values():
-        if space.hub_id in coordinator.sim_info:
+        if space.hub_id and coordinator.devices.get(space.hub_id):
             entities.append(AjaxSimImeiSensor(coordinator=coordinator, hub_id=space.hub_id))
         if space.hub_id and coordinator.devices.get(space.hub_id):
             entities.append(

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -345,6 +345,16 @@ class TestAjaxSimImeiSensor:
         assert sensor.available is False
 
 
+class TestAjaxSimImeiSensorConstruction:
+    def test_sensor_can_be_constructed_when_hub_device_exists_but_sim_info_is_empty(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": _make_hub_device("hub-1")}
+        coordinator.sim_info = {}
+        sensor = AjaxSimImeiSensor(coordinator=coordinator, hub_id="hub-1")
+        assert sensor.unique_id == "aegis_ajax_hub-1_sim_imei"
+        assert sensor.available is False
+
+
 class TestHubWifiSensors:
     def _make_coordinator(self, hub_id: str = "hub-1") -> MagicMock:
         coordinator = MagicMock()

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -354,6 +354,60 @@ class TestAjaxSimImeiSensorConstruction:
         assert sensor.unique_id == "aegis_ajax_hub-1_sim_imei"
         assert sensor.available is False
 
+    @staticmethod
+    async def _setup(sim_info: dict) -> list:
+        """Run the real platform setup with a hub present and a given sim_info."""
+        from custom_components.aegis_ajax.sensor import async_setup_entry
+
+        coordinator = MagicMock()
+        coordinator.devices = {"hub-1": _make_hub_device("hub-1")}
+        coordinator.rooms = {}
+        coordinator.spaces = {
+            "space-1": Space(
+                id="space-1",
+                hub_id="hub-1",
+                name="Home",
+                security_state=SecurityState.DISARMED,
+                connection_status=ConnectionStatus.ONLINE,
+                malfunctions_count=0,
+            )
+        }
+        coordinator.sim_info = sim_info
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+        with patch("custom_components.aegis_ajax.sensor._remove_orphan_outlet_power_derived"):
+            await async_setup_entry(MagicMock(), entry, added.extend)
+        return added
+
+    @pytest.mark.asyncio
+    async def test_imei_entity_is_created_even_when_the_sim_read_has_not_succeeded(self) -> None:
+        """#379: creation must not depend on the SIM read having worked.
+
+        This is the assertion that actually guards the fix. Gating creation on
+        `sim_info` meant a failed or slow read produced no entity at all, and
+        Home Assistant never removes an entity an integration stops offering —
+        so one created on an earlier start sat `unavailable` forever with
+        nothing to explain it.
+
+        Note the sibling test above passes with or without the fix, because it
+        constructs the sensor directly and never exercises the setup path where
+        the condition lives.
+        """
+        added = await self._setup(sim_info={})
+
+        assert any(isinstance(e, AjaxSimImeiSensor) for e in added)
+
+    @pytest.mark.asyncio
+    async def test_imei_entity_is_still_created_when_the_sim_read_did_succeed(self) -> None:
+        # Negative control: the previously-working path must keep working.
+        added = await self._setup(
+            sim_info={"hub-1": SimCardInfo(active_sim=1, status=2, imei="123456789012345")}
+        )
+
+        assert any(isinstance(e, AjaxSimImeiSensor) for e in added)
+
 
 class TestHubWifiSensors:
     def _make_coordinator(self, hub_id: str = "hub-1") -> MagicMock:


### PR DESCRIPTION
Addresses #379.

The IMEI sensor was only created when sim_info was already cached, which could leave it missing even though the hub object returned SIM metadata. This change makes the IMEI sensor setup depend on the hub device being present and keeps refreshing sim_info whenever the coordinator can read it.

Validation:
- docker run --rm -v C:\Users\AndrevandenBerg\Documents\Git\aegis-hass:/app -w /app aegis-hass-dev pytest tests/unit/test_sensor.py -q
- Result: 84 passed

Refs #379
