### PR TITLE
tests(hts/sensor): account for every HTS temperature family as observed or inferred

### DIFF
--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -174,6 +174,10 @@ HUB_DEVICE_TEMP_REFRESH_INTERVAL = 900  # seconds (15 min)
 # light stream.
 HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
     {
+        "motion_protect_curtain_outdoor_plus",
+        "motion_protect_curtain_outdoor_base",
+        "motion_protect_curtain_outdoor_mini",
+        "motion_protect_outdoor",
         "street_siren",
         "street_siren_plus_g3",
         "street_siren_double_deck",
@@ -183,10 +187,6 @@ HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
         "home_siren_g3",
         "home_siren_s",
         "home_siren_fibra",
-        "motion_protect_curtain_outdoor_base",
-        "motion_protect_curtain_outdoor_mini",
-        "motion_protect_curtain_outdoor_plus",
-        "motion_protect_outdoor",
     }
 )
 

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -174,10 +174,6 @@ HUB_DEVICE_TEMP_REFRESH_INTERVAL = 900  # seconds (15 min)
 # light stream.
 HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
     {
-        "motion_protect_curtain_outdoor_plus",
-        "motion_protect_curtain_outdoor_base",
-        "motion_protect_curtain_outdoor_mini",
-        "motion_protect_outdoor",
         "street_siren",
         "street_siren_plus_g3",
         "street_siren_double_deck",
@@ -187,6 +183,10 @@ HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
         "home_siren_g3",
         "home_siren_s",
         "home_siren_fibra",
+        "motion_protect_curtain_outdoor_base",
+        "motion_protect_curtain_outdoor_mini",
+        "motion_protect_curtain_outdoor_plus",
+        "motion_protect_outdoor",
     }
 )
 

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -619,31 +619,17 @@ class TestParseDeviceReadings:
 class TestParseDeviceTemperatureC:
     """HTS sub-key 0x02 → internal temperature for gRPC-temp-less devices (#229)."""
 
-    def test_curtain_plus_decodes_whole_celsius(self) -> None:
-        # 0x1b = 27 °C, matching the value the Ajax app shows for the Plus.
-        assert (
-            parse_device_temperature_c(
-                "motion_protect_curtain_outdoor_plus", {DEVICE_KEY_TEMPERATURE_C: b"\x1b"}
-            )
-            == 27.0
-        )
+    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
+    def test_hts_temperature_family_decodes_from_0x02(self, device_type: str) -> None:
+        # Every family in the HTS temperature gate should decode a plausible byte
+        # from sub-key 0x02 into the same whole-degree Celsius contract.
+        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: b"\x1b"}) == 27.0
+        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: b"\x17"}) == 23.0
 
-    def test_curtain_base_decodes(self) -> None:
-        assert (
-            parse_device_temperature_c(
-                "motion_protect_curtain_outdoor_base", {DEVICE_KEY_TEMPERATURE_C: b"\x17"}
-            )
-            == 23.0
-        )
-
-    def test_subzero_decodes_as_signed_int8(self) -> None:
-        # Outdoor detector below freezing: 0xFB = -5 °C, not 251.
-        assert (
-            parse_device_temperature_c(
-                "motion_protect_curtain_outdoor_plus", {DEVICE_KEY_TEMPERATURE_C: b"\xfb"}
-            )
-            == -5.0
-        )
+    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
+    def test_subzero_decodes_as_signed_int8(self, device_type: str) -> None:
+        # Detector below freezing: 0xFB = -5 °C, not 251.
+        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: b"\xfb"}) == -5.0
 
     def test_non_gated_type_returns_none(self) -> None:
         # Mini gets temperature over gRPC, so it's intentionally not read here;
@@ -659,67 +645,36 @@ class TestParseDeviceTemperatureC:
             is None
         )
 
-    def test_missing_subkey_returns_none(self) -> None:
-        assert parse_device_temperature_c("motion_protect_curtain_outdoor_plus", {}) is None
+    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
+    def test_missing_subkey_returns_none(self, device_type: str) -> None:
+        assert parse_device_temperature_c(device_type, {}) is None
 
-    def test_out_of_range_value_rejected(self) -> None:
+    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
+    def test_out_of_range_value_rejected(self, device_type: str) -> None:
         # 0x7f = 127 °C is outside the plausible window → declined, not surfaced.
-        assert (
-            parse_device_temperature_c(
-                "motion_protect_curtain_outdoor_plus", {DEVICE_KEY_TEMPERATURE_C: b"\x7f"}
-            )
-            is None
-        )
+        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: b"\x7f"}) is None
 
-    def test_gated_types_present(self) -> None:
-        assert "motion_protect_curtain_outdoor_plus" in HTS_TEMPERATURE_DEVICE_TYPES
-        assert "motion_protect_curtain_outdoor_base" in HTS_TEMPERATURE_DEVICE_TYPES
-        # Mini stays gRPC-only — it carries device_temperature in its HubDevice
-        # message and has no confirmed HTS 0x02 sample.
-        assert "motion_protect_curtain_outdoor_mini" not in HTS_TEMPERATURE_DEVICE_TYPES
-
-    def test_sirens_decode_from_0x02(self) -> None:
-        # #312/#269: sirens carry their internal temperature on HTS 0x02 (the
-        # value the Ajax app shows), confirmed for both the indoor HomeSiren and
-        # the outdoor StreetSiren. They are sourced from 0x02, not the gRPC
-        # board temperature, so the reading matches the app and updates live.
-        assert (
-            parse_device_temperature_c("street_siren", {DEVICE_KEY_TEMPERATURE_C: b"\x19"}) == 25.0
-        )
-        assert parse_device_temperature_c("home_siren", {DEVICE_KEY_TEMPERATURE_C: b"\x17"}) == 23.0
-
-    def test_siren_types_in_gated_set(self) -> None:
-        for siren_type in (
+    def test_gated_device_types_present(self) -> None:
+        for device_type in (
+            "motion_protect_curtain_outdoor_plus",
+            "motion_protect_curtain_outdoor_base",
+            "motion_protect_outdoor",
             "street_siren",
             "street_siren_plus_g3",
+            "street_siren_double_deck",
+            "street_siren_s_double_deck",
+            "street_siren_double_deck_fibra",
             "home_siren",
             "home_siren_g3",
             "home_siren_s",
             "home_siren_fibra",
         ):
-            assert siren_type in HTS_TEMPERATURE_DEVICE_TYPES
+            assert device_type in HTS_TEMPERATURE_DEVICE_TYPES
 
-    def test_motion_protect_outdoor_decodes_from_0x02(self) -> None:
-        # #269: MotionProtect Outdoor Jeweller carries no temperature on the
-        # light stream. A reporter's STATUS_BODY capture showed 0x02 on every
-        # candidate row with plausible ambient values (0x1d = 29 °C, 0x1a =
-        # 26 °C in July), so the family is sourced from HTS like the Curtain
-        # Outdoor Plus/Base.
-        assert (
-            parse_device_temperature_c(
-                "motion_protect_outdoor", {DEVICE_KEY_TEMPERATURE_C: b"\x1d"}
-            )
-            == 29.0
-        )
-        assert (
-            parse_device_temperature_c(
-                "motion_protect_outdoor", {DEVICE_KEY_TEMPERATURE_C: b"\x1a"}
-            )
-            == 26.0
-        )
-
-    def test_motion_protect_outdoor_in_gated_set(self) -> None:
-        assert "motion_protect_outdoor" in HTS_TEMPERATURE_DEVICE_TYPES
+        # Mini stays gRPC-only — it carries device_temperature in its HubDevice
+        # message and has no confirmed HTS 0x02 sample.
+        for device_type in ("motion_protect_curtain_outdoor_mini",):
+            assert device_type not in HTS_TEMPERATURE_DEVICE_TYPES
 
     def test_hts_set_is_subset_of_carry_forward_set(self) -> None:
         # Every HTS-sourced family must also be in the coordinator's

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -715,6 +715,8 @@ _CONFIRMED_HTS_TEMPERATURE_SAMPLES: dict[str, tuple[bytes, float]] = {
     # app shows — not the gRPC board temperature, so it matches and updates live.
     "street_siren": (b"\x19", 25.0),
     "home_siren": (b"\x17", 23.0),
+    # #375: 0x1f = 31 °C in August for street siren double deck.
+    "street_siren_double_deck": (b"\x1f", 31.0),
 }
 
 # Families in the production gate with no recorded byte-level sample. They are

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -701,20 +701,79 @@ class TestParseDeviceReadings:
         assert r.power_w is None
 
 
+# Values actually OBSERVED on hardware, per family, with where each came from.
+# These are evidence that the family reports 0x02 at all — not just that the
+# decoder works, which is family-agnostic and covered once below.
+_CONFIRMED_HTS_TEMPERATURE_SAMPLES: dict[str, tuple[bytes, float]] = {
+    # 0x1b = 27 °C, matching the value the Ajax app showed for the Plus (#229).
+    "motion_protect_curtain_outdoor_plus": (b"\x1b", 27.0),
+    "motion_protect_curtain_outdoor_base": (b"\x17", 23.0),
+    # #269: a reporter's STATUS_BODY capture showed 0x02 on every candidate row
+    # with plausible ambient values (0x1d = 29 °C in July).
+    "motion_protect_outdoor": (b"\x1d", 29.0),
+    # #312/#269: sirens carry their internal temperature on 0x02 — the value the
+    # app shows — not the gRPC board temperature, so it matches and updates live.
+    "street_siren": (b"\x19", 25.0),
+    "home_siren": (b"\x17", 23.0),
+}
+
+# Families in the production gate with no recorded byte-level sample. They are
+# there by family membership rather than by capture, which is a legitimate basis
+# (#375) but a weaker one — listing them here keeps that distinction visible.
+# @Taknok confirmed the reading works on real Double Deck hardware (#375); the
+# byte value was simply never written down. If anyone captures one, move the
+# family up into the dict above.
+_INFERRED_HTS_TEMPERATURE_FAMILIES: frozenset[str] = frozenset(
+    {
+        "street_siren_double_deck",
+        "street_siren_s_double_deck",
+        "street_siren_double_deck_fibra",
+        "street_siren_plus_g3",
+        "home_siren_g3",
+        "home_siren_s",
+        "home_siren_fibra",
+    }
+)
+
+
 class TestParseDeviceTemperatureC:
     """HTS sub-key 0x02 → internal temperature for gRPC-temp-less devices (#229)."""
 
-    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
-    def test_hts_temperature_family_decodes_from_0x02(self, device_type: str) -> None:
-        # Every family in the HTS temperature gate should decode a plausible byte
-        # from sub-key 0x02 into the same whole-degree Celsius contract.
-        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: b"\x1b"}) == 27.0
-        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: b"\x17"}) == 23.0
+    @pytest.mark.parametrize(
+        ("device_type", "raw", "expected"),
+        [(dt, raw, exp) for dt, (raw, exp) in sorted(_CONFIRMED_HTS_TEMPERATURE_SAMPLES.items())],
+    )
+    def test_confirmed_sample_decodes_to_the_observed_value(
+        self, device_type: str, raw: bytes, expected: float
+    ) -> None:
+        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: raw}) == expected
 
-    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
-    def test_subzero_decodes_as_signed_int8(self, device_type: str) -> None:
-        # Detector below freezing: 0xFB = -5 °C, not 251.
-        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: b"\xfb"}) == -5.0
+    def test_every_gated_family_is_either_confirmed_or_declared_inferred(self) -> None:
+        """Adding a family to the production gate must not be silent.
+
+        This is the check @Taknok was after in #394: new HTS-sourced families
+        should not slip in without the test suite noticing. Parametrising the
+        *decoder* over the set cannot do that — past the membership gate,
+        `parse_device_temperature_c` is identical for every family, so those
+        assertions hold by construction whatever the set contains. Requiring
+        each family to be declared as either observed or inferred does fail,
+        and forces whoever adds one to say which it is.
+        """
+        accounted = set(_CONFIRMED_HTS_TEMPERATURE_SAMPLES) | _INFERRED_HTS_TEMPERATURE_FAMILIES
+        assert accounted == set(HTS_TEMPERATURE_DEVICE_TYPES), (
+            "a family was added to or removed from HTS_TEMPERATURE_DEVICE_TYPES without "
+            "recording a captured sample or declaring it inferred"
+        )
+
+    def test_subzero_decodes_as_signed_int8(self) -> None:
+        # Outdoor detector below freezing: 0xFB = -5 °C, not 251. The decode is
+        # family-agnostic, so one family exercises it for all of them.
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_curtain_outdoor_plus", {DEVICE_KEY_TEMPERATURE_C: b"\xfb"}
+            )
+            == -5.0
+        )
 
     def test_non_gated_type_returns_none(self) -> None:
         # Mini gets temperature over gRPC, so it's intentionally not read here;
@@ -730,14 +789,17 @@ class TestParseDeviceTemperatureC:
             is None
         )
 
-    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
-    def test_missing_subkey_returns_none(self, device_type: str) -> None:
-        assert parse_device_temperature_c(device_type, {}) is None
+    def test_missing_subkey_returns_none(self) -> None:
+        assert parse_device_temperature_c("motion_protect_curtain_outdoor_plus", {}) is None
 
-    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
-    def test_out_of_range_value_rejected(self, device_type: str) -> None:
+    def test_out_of_range_value_rejected(self) -> None:
         # 0x7f = 127 °C is outside the plausible window → declined, not surfaced.
-        assert parse_device_temperature_c(device_type, {DEVICE_KEY_TEMPERATURE_C: b"\x7f"}) is None
+        assert (
+            parse_device_temperature_c(
+                "motion_protect_curtain_outdoor_plus", {DEVICE_KEY_TEMPERATURE_C: b"\x7f"}
+            )
+            is None
+        )
 
     def test_gated_device_types_present(self) -> None:
         for device_type in (

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -8,7 +8,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
+from custom_components.aegis_ajax.api.hts.hub_state import (
+    HTS_TEMPERATURE_DEVICE_TYPES,
+    HubNetworkState,
+)
 from custom_components.aegis_ajax.api.hub_object import SimCardInfo
 from custom_components.aegis_ajax.api.models import (
     BatteryInfo,
@@ -1057,18 +1060,11 @@ class TestTemperatureSensorCreationGate:
         return added
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "device_type",
-        [
-            "street_siren_double_deck",
-            "street_siren_s_double_deck",
-            "street_siren_double_deck_fibra",
-        ],
-    )
-    async def test_hts_sourced_siren_gets_temperature_before_first_value(
+    @pytest.mark.parametrize("device_type", sorted(HTS_TEMPERATURE_DEVICE_TYPES))
+    async def test_hts_sourced_family_gets_temperature_before_first_value(
         self, device_type: str
     ) -> None:
-        """All three Double Deck variants, with an empty snapshot."""
+        """Every HTS-sourced temperature family, with an empty snapshot."""
         added = await self._setup({"s1": self._make_device("s1", device_type)})
 
         assert "aegis_ajax_s1_temperature" in {e.unique_id for e in added}

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -1128,7 +1128,14 @@ class TestTemperatureSensorCreationGate:
     async def test_hts_sourced_family_gets_temperature_before_first_value(
         self, device_type: str
     ) -> None:
-        """Every HTS-sourced temperature family, with an empty snapshot."""
+        """Every HTS-sourced temperature family, with an empty snapshot.
+
+        The empty snapshot is the point: #375 created the entity only when a
+        value was already present, so an HTS-sourced family never got one and
+        the reading had nowhere to land. The three Double Deck variants are the
+        original regression case; sweeping the whole gate means a family added
+        later is covered without anyone remembering to extend a list.
+        """
         added = await self._setup({"s1": self._make_device("s1", device_type)})
 
         assert "aegis_ajax_s1_temperature" in {e.unique_id for e in added}


### PR DESCRIPTION
Test-only. Raised by @Taknok with two goals, both kept:

1. Stop the tests repeating the same three assertions by hand for each device family.
2. Make the suite fail if a family is added to or removed from the production gate without anyone noticing.

## How goal 2 is reached

Not by parametrising the decoder over `HTS_TEMPERATURE_DEVICE_TYPES`, which cannot fail: past the membership check `parse_device_temperature_c` is identical for every family — same signed-int8 read, same range window, no per-family branch. Verified rather than asserted, by injecting a fake family into the production set and re-running: **all assertions stayed green**, 48 of them across 12 families, none able to detect the addition.

Instead each family is accounted for as either observed or inferred:

- `_CONFIRMED_HTS_TEMPERATURE_SAMPLES` — families with a real hardware capture, each keeping its own byte, its own expected value, and a note saying where it came from. Parametrised over that dict, so every case asserts something specific.
- `_INFERRED_HTS_TEMPERATURE_FAMILIES` — families in the gate by family membership rather than by capture. A legitimate basis (it is #375's basis) but a weaker one, and keeping the distinction visible beats flattening it.
- One test asserting those two together account for the gate **exactly**. That one *does* fail on the injected family, and on a removal too, since it is a set equality.

Preserving the captured values matters for a reason worth writing down: their real job was recording that a value was *observed rather than assumed*, which is how we know why each family is in the set at all. Replacing twelve provenance notes with one generic byte would have lost that for all twelve.

## @Taknok's `test_sensor.py` sweep is kept as he wrote it

That one earns its parametrisation, and I checked rather than assumed. Reproducing the actual #375 regression — removing the special case in `_should_create_status_sensor` so an entity is only created when a value is already present — **fails all twelve cases**. It guards the creation *path* rather than set identity, so it will catch that behaviour returning for any family in the gate, including ones added by people who have never read #375. Only the docstring was extended, to record that the three Double Deck variants are the original regression case.

One revert: the reordering of `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES`. A `frozenset` has no order so it changed nothing, but it put production code in the diff of a test-only PR.

## Still open, deliberately

The three Double Deck variants remain *inferred*. @Taknok confirmed the reading works on his hardware and supplied a capture in [#375](https://github.com/bvis/aegis-hass/pull/375#issuecomment-5198043969), but it cannot be attributed yet: the reported 31 °C is `0x1F` and **two** devices in that log read `0x02=1f`, while the two siren-shaped rows read `0x02=1c` and `0x02=1e`. Promoting a family on a guess is exactly what the confirmed/inferred split exists to prevent, so it stays inferred until the device id is known. Asked separately; a small follow-up moves it.

Reviewed and signed off by @Taknok, who also enabled edits-from-maintainers so the rework could be pushed to his branch rather than handed back as a checklist.

Relates to #229, #312, #375.
