### PR TITLE
Show hub firmware in device info

### DIFF
--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -30,6 +30,7 @@ _MODEL_OVERRIDES: dict[str, str] = {
 def build_device_info(
     device: Device,
     rooms: Mapping[str, Room] | None = None,
+    *,
     firmware_version: str | None = None,
 ) -> DeviceInfo:
     """Build a HA DeviceInfo for an Ajax device.
@@ -37,6 +38,8 @@ def build_device_info(
     Sets `serial_number` from the Ajax device id (the hex hardware identifier
     shown in the Ajax app) and `suggested_area` from the device's Ajax room
     when available, so HA can auto-assign devices to matching areas.
+    `firmware_version` is keyword-only so call sites stay explicit about
+    populating `sw_version` (#388).
     """
     is_hub = device.device_type.startswith("hub")
     info = DeviceInfo(

--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -30,6 +30,7 @@ _MODEL_OVERRIDES: dict[str, str] = {
 def build_device_info(
     device: Device,
     rooms: Mapping[str, Room] | None = None,
+    firmware_version: str | None = None,
 ) -> DeviceInfo:
     """Build a HA DeviceInfo for an Ajax device.
 
@@ -53,6 +54,8 @@ def build_device_info(
         room = rooms.get(device.room_id) if isinstance(rooms, dict) else None
         if room is not None:
             info["suggested_area"] = room.name
+    if firmware_version:
+        info["sw_version"] = firmware_version
     return info
 
 

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -43,6 +43,7 @@ from custom_components.aegis_ajax.entity import build_device_info
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.device_registry import DeviceInfo
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 _LOGGER = logging.getLogger(__name__)
@@ -106,13 +107,21 @@ class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateE
         super().__init__(coordinator)
         self._hub_id = hub_id
         self._attr_unique_id = f"aegis_ajax_{hub_id}_firmware"
-        hub_device = coordinator.devices.get(hub_id)
-        if hub_device:
-            self._attr_device_info = build_device_info(
-                hub_device,
-                coordinator.rooms,
-                self._hub_reported_version,
-            )
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        # Recomputed per access rather than frozen in `__init__`: the hub
+        # reports its firmware over HTS, which routinely arrives after the
+        # entity is constructed. Pinning it at construction time would leave
+        # `sw_version` permanently unset on those hubs (#388).
+        hub_device = self.coordinator.devices.get(self._hub_id)
+        if hub_device is None:
+            return None
+        return build_device_info(
+            hub_device,
+            self.coordinator.rooms,
+            firmware_version=self._hub_reported_version,
+        )
 
     @property
     def _info(self) -> HubFirmwareUpdateInfo | None:

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -26,6 +26,8 @@ from homeassistant.components.update import (
     UpdateEntity,
     UpdateEntityFeature,
 )
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.hub_object import (
@@ -37,13 +39,13 @@ from custom_components.aegis_ajax.api.hub_object import (
     DeviceFirmwareUpdateInfo,
     HubFirmwareUpdateInfo,
 )
+from custom_components.aegis_ajax.const import DOMAIN
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
-    from homeassistant.helpers.device_registry import DeviceInfo
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 _LOGGER = logging.getLogger(__name__)
@@ -107,21 +109,49 @@ class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateE
         super().__init__(coordinator)
         self._hub_id = hub_id
         self._attr_unique_id = f"aegis_ajax_{hub_id}_firmware"
+        hub_device = coordinator.devices.get(hub_id)
+        if hub_device:
+            self._attr_device_info = build_device_info(
+                hub_device,
+                coordinator.rooms,
+                firmware_version=self._hub_reported_version,
+            )
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        # Recomputed per access rather than frozen in `__init__`: the hub
-        # reports its firmware over HTS, which routinely arrives after the
-        # entity is constructed. Pinning it at construction time would leave
-        # `sw_version` permanently unset on those hubs (#388).
-        hub_device = self.coordinator.devices.get(self._hub_id)
-        if hub_device is None:
-            return None
-        return build_device_info(
-            hub_device,
-            self.coordinator.rooms,
-            firmware_version=self._hub_reported_version,
-        )
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        # Covers the case where the version landed between construction and
+        # the entity actually being added — `device_info` was already read
+        # by then, so the registry needs telling either way.
+        self._async_write_sw_version()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._async_write_sw_version()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_write_sw_version(self) -> None:
+        """Push the hub's reported firmware into the device registry (#388).
+
+        Home Assistant reads `device_info` exactly once, in
+        `entity_platform._async_add_entity`, and hands it to
+        `async_get_or_create`; it is never consulted again. The hub reports
+        its firmware over HTS, whose handshake is still in flight when the
+        platforms are forwarded, so the version is essentially never known
+        at that moment. Writing it to the registry as it arrives is what
+        actually gets it onto the hub's device page, and it keeps following
+        the hub across firmware upgrades.
+        """
+        version = self._hub_reported_version
+        if not version:
+            return
+        registry = dr.async_get(self.hass)
+        entry = registry.async_get_device(identifiers={(DOMAIN, self._hub_id)})
+        # Guard on equality so a steady stream of HTS updates doesn't write
+        # to (and re-save) the registry on every coordinator tick.
+        if entry is None or entry.sw_version == version:
+            return
+        registry.async_update_device(entry.id, sw_version=version)
 
     @property
     def _info(self) -> HubFirmwareUpdateInfo | None:

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -108,7 +108,11 @@ class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateE
         self._attr_unique_id = f"aegis_ajax_{hub_id}_firmware"
         hub_device = coordinator.devices.get(hub_id)
         if hub_device:
-            self._attr_device_info = build_device_info(hub_device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                hub_device,
+                coordinator.rooms,
+                self._hub_reported_version,
+            )
 
     @property
     def _info(self) -> HubFirmwareUpdateInfo | None:

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -69,6 +69,24 @@ class TestBuildDeviceInfo:
         info = build_device_info(_make_device(device_type="motion_protect_outdoor"))
         assert info["model"] == "Motion Protect Outdoor"
 
+    def test_sw_version_set_from_firmware_version(self) -> None:
+        info = build_device_info(
+            _make_device(device_type="hub_two_4g", device_id="HUB7"),
+            firmware_version="2.41.116",
+        )
+        assert info["sw_version"] == "2.41.116"
+
+    def test_no_sw_version_when_firmware_version_omitted(self) -> None:
+        info = build_device_info(_make_device(device_type="hub_two_4g", device_id="HUB7"))
+        assert "sw_version" not in info
+
+    def test_no_sw_version_when_firmware_version_empty(self) -> None:
+        info = build_device_info(
+            _make_device(device_type="hub_two_4g", device_id="HUB7"),
+            firmware_version="",
+        )
+        assert "sw_version" not in info
+
 
 class TestAsyncSendDeviceCommand:
     """Maps Ajax command failures to clear, translated HomeAssistantErrors."""

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -582,6 +582,7 @@ class TestHubMonitoringCompanySensor:
             "pending_approval_companies": ["Central Two"],
             "pending_removal_companies": ["Central Three"],
         }
+
     def test_state_payload_is_json_serializable(self) -> None:
         coordinator = self._make_coordinator(
             (
@@ -613,14 +614,6 @@ class TestHubMonitoringCompanySensor:
         sensor = AjaxHubMonitoringCompanySensor(coordinator, "space-1", "hub-1")
 
         assert sensor.available is False
-
-
-def test_hub_device_info_includes_sw_version_when_reported() -> None:
-    from custom_components.aegis_ajax.entity import build_device_info
-
-    device = _make_hub_device("hub-1")
-    info = build_device_info(device, firmware_version="2.41.116")
-    assert info["sw_version"] == "2.41.116"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -582,7 +582,6 @@ class TestHubMonitoringCompanySensor:
             "pending_approval_companies": ["Central Two"],
             "pending_removal_companies": ["Central Three"],
         }
-
     def test_state_payload_is_json_serializable(self) -> None:
         coordinator = self._make_coordinator(
             (
@@ -614,6 +613,14 @@ class TestHubMonitoringCompanySensor:
         sensor = AjaxHubMonitoringCompanySensor(coordinator, "space-1", "hub-1")
 
         assert sensor.available is False
+
+
+def test_hub_device_info_includes_sw_version_when_reported() -> None:
+    from custom_components.aegis_ajax.entity import build_device_info
+
+    device = _make_hub_device("hub-1")
+    info = build_device_info(device, firmware_version="2.41.116")
+    assert info["sw_version"] == "2.41.116"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -128,6 +128,31 @@ class TestAjaxHubFirmwareUpdate:
         assert "2.41.116" in summary
         assert "not exposed" not in summary
 
+    def test_device_info_includes_hub_reported_firmware(self) -> None:
+        coordinator = self._make_coordinator(None, firmware_version="2.41.116")
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert (entity.device_info or {}).get("sw_version") == "2.41.116"
+
+    def test_device_info_picks_up_firmware_reported_after_construction(self) -> None:
+        # The hub's firmware arrives over HTS, often after the entity has been
+        # constructed. `device_info` must reflect it then, not stay frozen at
+        # the construction-time value (#388).
+        from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
+
+        coordinator = self._make_coordinator(None)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert "sw_version" not in (entity.device_info or {})
+
+        coordinator.hub_network = {"002B1A51": HubNetworkState(firmware_version="2.41.116")}
+
+        assert (entity.device_info or {}).get("sw_version") == "2.41.116"
+
+    def test_device_info_is_none_when_hub_device_missing(self) -> None:
+        coordinator = self._make_coordinator(None)
+        coordinator.devices = {}
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert entity.device_info is None
+
     def test_latest_version_reflects_pending_update(self) -> None:
         info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)
         coordinator = self._make_coordinator(info)

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -128,30 +128,104 @@ class TestAjaxHubFirmwareUpdate:
         assert "2.41.116" in summary
         assert "not exposed" not in summary
 
-    def test_device_info_includes_hub_reported_firmware(self) -> None:
+    def test_device_info_includes_hub_reported_firmware_when_known_early(self) -> None:
         coordinator = self._make_coordinator(None, firmware_version="2.41.116")
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
-        assert (entity.device_info or {}).get("sw_version") == "2.41.116"
+        assert (entity._attr_device_info or {}).get("sw_version") == "2.41.116"
 
-    def test_device_info_picks_up_firmware_reported_after_construction(self) -> None:
-        # The hub's firmware arrives over HTS, often after the entity has been
-        # constructed. `device_info` must reflect it then, not stay frozen at
-        # the construction-time value (#388).
+    def test_no_sw_version_in_device_info_when_firmware_not_yet_reported(self) -> None:
+        coordinator = self._make_coordinator(None)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        assert "sw_version" not in (entity._attr_device_info or {})
+
+    def _registry(
+        self, entity: AjaxHubFirmwareUpdate, *, sw_version: str | None = None
+    ) -> MagicMock:
+        """Attach a fake device registry and return it.
+
+        `dr.async_get` is patched per-test rather than using a real registry:
+        these are plain unit tests with a MagicMock coordinator and no running
+        HA instance.
+        """
+        registry = MagicMock()
+        registry.async_get_device.return_value = MagicMock(id="reg-1", sw_version=sw_version)
+        entity.hass = MagicMock()
+        return registry
+
+    def test_firmware_reported_after_setup_is_written_to_the_registry(self) -> None:
+        # The real timing: HTS is still handshaking when platforms are
+        # forwarded, so `device_info` — which HA reads exactly once, at add
+        # time — never carries the version. It has to be pushed to the
+        # registry as it arrives (#388).
+        from unittest.mock import patch
+
         from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
 
         coordinator = self._make_coordinator(None)
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
-        assert "sw_version" not in (entity.device_info or {})
+        registry = self._registry(entity)
 
         coordinator.hub_network = {"002B1A51": HubNetworkState(firmware_version="2.41.116")}
 
-        assert (entity.device_info or {}).get("sw_version") == "2.41.116"
+        with patch("custom_components.aegis_ajax.update.dr.async_get", return_value=registry):
+            entity._async_write_sw_version()
 
-    def test_device_info_is_none_when_hub_device_missing(self) -> None:
-        coordinator = self._make_coordinator(None)
-        coordinator.devices = {}
+        registry.async_update_device.assert_called_once_with("reg-1", sw_version="2.41.116")
+
+    def test_registry_is_not_written_when_version_is_unchanged(self) -> None:
+        # HTS pushes hub status rows continuously; rewriting an identical
+        # value on every tick would re-save the device registry for nothing.
+        from unittest.mock import patch
+
+        coordinator = self._make_coordinator(None, firmware_version="2.41.116")
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
-        assert entity.device_info is None
+        registry = self._registry(entity, sw_version="2.41.116")
+
+        with patch("custom_components.aegis_ajax.update.dr.async_get", return_value=registry):
+            entity._async_write_sw_version()
+
+        registry.async_update_device.assert_not_called()
+
+    def test_registry_is_not_written_when_no_version_reported(self) -> None:
+        from unittest.mock import patch
+
+        coordinator = self._make_coordinator(None)
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        registry = self._registry(entity)
+
+        with patch("custom_components.aegis_ajax.update.dr.async_get", return_value=registry):
+            entity._async_write_sw_version()
+
+        registry.async_update_device.assert_not_called()
+
+    def test_registry_write_is_skipped_when_hub_not_in_registry(self) -> None:
+        from unittest.mock import patch
+
+        coordinator = self._make_coordinator(None, firmware_version="2.41.116")
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        registry = MagicMock()
+        registry.async_get_device.return_value = None
+        entity.hass = MagicMock()
+
+        with patch("custom_components.aegis_ajax.update.dr.async_get", return_value=registry):
+            entity._async_write_sw_version()
+
+        registry.async_update_device.assert_not_called()
+
+    def test_coordinator_update_syncs_the_registry(self) -> None:
+        # The write has to be wired to the coordinator callback, not just
+        # available as a helper.
+        from unittest.mock import patch
+
+        coordinator = self._make_coordinator(None, firmware_version="2.41.116")
+        entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
+        registry = self._registry(entity)
+        entity.async_write_ha_state = MagicMock()
+
+        with patch("custom_components.aegis_ajax.update.dr.async_get", return_value=registry):
+            entity._handle_coordinator_update()
+
+        registry.async_update_device.assert_called_once_with("reg-1", sw_version="2.41.116")
 
     def test_latest_version_reflects_pending_update(self) -> None:
         info = HubFirmwareUpdateInfo(target_version="2.17.0", state=HUB_FW_STATE_NOT_STARTED)


### PR DESCRIPTION
## Summary
- expose the hub firmware version in hub device info via `sw_version`
- keep the update entity backed by the same reported firmware version
- add a regression test for the new device info field

## Notes
This keeps the firmware visible in both the update entity and the hub device details in Home Assistant.