### PR TITLE
docs(keyfobs): correct the HTS-only premise and probe modeled SpaceControls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   This is diagnostic groundwork rather than a cure: if your IMEI sensor is unavailable it will now tell you *why*, which is what we need in order to fix the underlying cause.
 
+### Documentation
+- **Two things the keyfob documentation got wrong (#311).** It said a keyfob can only be deactivated by an installer or monitoring company because "there's no toggle in the Ajax app". There is one — *forced deactivation* on a SpaceControl — but it is a **different mechanism**: measured on hardware, it is the same temporary exclusion the bypass switch already shows, and it leaves the flag the **Active** sensor reads untouched. Anyone who tried it expecting to produce the missing *inactive* example got a reading that had not moved.
+
+  And it implied every install gets keyfob sensors. Some hubs report the keyfob as an **ordinary device** instead, which gives it its own device page with the usual bypass switch and **no Active sensor at all** — so an install can have a SpaceControl and no *Keyfobs* device, by design rather than as a fault. That also scopes the "every keyfob seen so far is active" observation: it only ever covered hubs of the other kind.
+
+  The README now says both, and a debug-level probe reports that second kind of hub's keyfob settings so it can contribute to confirming the indicator, which until now it structurally could not. No entity, state or attribute changes. Both findings are @wip3out3r's, from a hub that has a SpaceControl and no keyfob entity.
+
 ## [1.15.1] - 2026-08-04
 
 Consolidates the `1.15.1-beta.1` – `1.15.1-beta.12` series. Every fix below was confirmed on the reporter's hardware or on a live Home Assistant install before this release.

--- a/README.md
+++ b/README.md
@@ -380,7 +380,9 @@ Use these in automation templates, e.g. `{{ trigger.event.data.device_name }}`.
 ### Keyfobs (experimental)
 SpaceControl keyfobs are grouped under a single **Keyfobs** device (one per hub), with one **Active** binary sensor per keyfob, named after it (using the keyfob name set in the Ajax app).
 
-> **The active/inactive state is experimental and not yet confirmed.** On every install seen so far each keyfob reports as **active**, and a keyfob can only be deactivated by an installer or monitoring company (there's no toggle in the Ajax app, or here), so there has been no *inactive* example to validate against — the sensor may not yet reflect a genuinely deactivated keyfob.
+> **Not every hub produces these sensors, and that is expected.** Some hubs report the keyfob as an ordinary device instead, in which case it gets its own device page — with the usual bypass switch, which already shows whether it is deactivated — and no **Active** sensor. The **Keyfobs** device only appears on hubs that report their keyfobs solely over the status channel.
+
+> **The active/inactive state is experimental and not yet confirmed.** On every install that produces the sensor each keyfob reports as **active**, and a keyfob can only be deactivated server-side by an installer or monitoring company, so there has been no *inactive* example to validate against — the sensor may not yet reflect a genuinely deactivated keyfob. The Ajax app's *forced deactivation* on a keyfob is a **different** mechanism (it is the same temporary exclusion as the bypass switch) and does not produce that example.
 >
 > **You can help finalize it:** if you have a keyfob that your installer/CRA has deactivated, a **Download diagnostics** (Settings → Devices & Services → Aegis for Ajax → ⋮ → Download diagnostics) plus a debug log (`custom_components.aegis_ajax: debug`) attached to a [GitHub issue](https://github.com/bvis/aegis-hass/issues/new) would let us confirm the indicator and get it right. See [Help Wanted](#help-wanted).
 
@@ -452,7 +454,7 @@ This integration covers the hardware I personally own and can validate against a
 Areas where the integration could grow with community input:
 
 - **Video streaming** — cameras behind an Ajax **NVR** already have a live-view path via Home Assistant's native ONVIF integration ([guide](#video-cameras-onvif--rtsp)). Still open: the radio **MotionCam Video** family that isn't bridged through an NVR, and any in-integration (proxied) streaming.
-- **A deactivated SpaceControl keyfob** — keyfobs now appear as a *Keyfobs* device with an experimental per-keyfob **Active** sensor (`1.10.0`), but the active/inactive value is unconfirmed because every keyfob seen so far is active. If yours has one deactivated by your installer/CRA, a diagnostics dump + debug log would let us finalize the indicator — see #311.
+- **A deactivated SpaceControl keyfob** — keyfobs now appear as a *Keyfobs* device with an experimental per-keyfob **Active** sensor (`1.10.0`), but the active/inactive value is unconfirmed because every keyfob seen so far is active. It has to be one your **installer or monitoring company** deactivated: the app's own *forced deactivation* is a different, temporary mechanism and doesn't produce the example. A diagnostics dump + debug log would let us finalize the indicator — see #311.
 - **Device settings beyond sirens** — siren volume and alarm duration are covered since `1.15.0` (#310); detector sensitivity, LED brightness and alert thresholds still need captures from owners of that hardware.
 - **Co-branded apps** the integration doesn't yet recognise in the `App Label` dropdown.
 - **Any new device family** that shows up in the snapshot without entities.

--- a/custom_components/aegis_ajax/api/hts/keyfobs.py
+++ b/custom_components/aegis_ajax/api/hts/keyfobs.py
@@ -1,10 +1,25 @@
 """Parser for Ajax SpaceControl keyfob rows in the HTS SETTINGS_BODY.
 
-Keyfobs (the physical "llaveros") are **HTS-only**: they never appear in the
-gRPC `StreamLightDevices` snapshot that populates `coordinator.devices`. Instead
-they arrive as device rows inside `SETTINGS_BODY` (HTS sub-key 5) over the same
-`on_device_kv` callback used for #123 electrical readings, and were simply
-unmapped until now.
+Keyfobs (the physical "llaveros") are HTS-only **on some hubs, not all** — and
+this file only handles that class. Where they are HTS-only they never appear in
+the gRPC `StreamLightDevices` snapshot that populates `coordinator.devices`, and
+arrive instead as device rows inside `SETTINGS_BODY` (HTS sub-key 5) over the
+same `on_device_kv` callback used for #123 electrical readings.
+
+**The other class exists and this parser never sees it (#311).** `ObjectType`
+carries both `space_control` (25) and `space_control_s` (224), so a hub can
+report its keyfob as an ordinary modeled device. @wip3out3r's install does: his
+SpaceControl is in the snapshot with a group id, gets a normal HA device and
+the bypass switch that already reports deactivation, and its 47-sub-key
+SETTINGS_BODY row — carrying every one of `SpaceControl`'s own field numbers
+(0x2e, 0x31, 0x33, 0x34, 0x35, 0xc3) — never reaches this module, because
+`_on_hts_device_kv` only takes the keyfob branch for rows *absent* from the
+snapshot. That is why such an install has a SpaceControl and no keyfob entity;
+the shape not matching `KEYFOB_SHAPE` is a consequence, not the cause. Nothing
+here should be widened to absorb that row: it is a different family's device
+row, and the modeled path already surfaces the device properly. The
+coordinator's `_log_hts_space_control_settings` probe is where that class is
+observed.
 
 Empirically (live capture, 6 keyfobs) every keyfob row carries an identical
 15-sub-key set; only the name (`0x02`) and a per-device index (`0x0a`) differ:
@@ -17,8 +32,10 @@ Empirically (live capture, 6 keyfobs) every keyfob row carries an identical
     0x16 = ffff
 
 **The "active" flag is EXPERIMENTAL/unverified.** Every observed keyfob reads
-`0x0b == 0x01`; we have no `inactive` sample (only a CRA admin can deactivate a
-keyfob server-side, and that toggle is not in the mobile app). We assume
+`0x0b == 0x01`; we have no `inactive` sample. Only a CRA admin can deactivate a
+keyfob server-side — the app's *forced deactivation* toggle is a different
+mechanism, measured on hardware: it moves `0xb6`/`0xb7` and reports
+`temporary_deactivation_whole`, leaving `0x0b` untouched (#311). We assume
 `0x0b == 0x01` means "active" and expose it as an experimental diagnostic, while
 DEBUG-logging the full row (`looks_like_keyfob_candidate`) so a user who *does*
 have a deactivated keyfob can paste their log and let us confirm the real flag.

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -187,6 +187,33 @@ _HTS_BUTTON_ACTIVITY_CANDIDATE_KEYS: tuple[int, ...] = (0x39, 0x40)
 # hub-wide and is not this device's activity.
 _HTS_BUTTON_PRESS_KEY = 0x39
 
+# SpaceControl settings keys on a *gRPC-modeled* keyfob's HTS row (#311) —
+# read-only probe, nothing is routed off them.
+#
+# Keyfobs are HTS-only on some hubs but not all: `ObjectType` carries both
+# `space_control` and `space_control_s`, and on a hub that reports one the
+# keyfob is an ordinary modeled device, so its SETTINGS_BODY row never reaches
+# the keyfob classifier in `api/hts/keyfobs.py` (see `_handle_keyfob_kv`).
+# @wip3out3r's 47-key capture is that row, and it carries every one of these
+# six — they are `SpaceControl`'s own field numbers in the hub's device model,
+# which is what identifies the row as a SpaceControl's rather than as an
+# unrecognised keyfob variant. The loose keyfob-candidate predicate cannot see
+# it either: that row has no name key at all, and the predicate requires one.
+#
+# So this class of hub contributes nothing to the still-unverified activation
+# flag (#311) unless its row is logged, which is what this does. None of the
+# six is user-typed text, so the line carries no names.
+_HTS_SPACE_CONTROL_SETTINGS_KEYS: dict[int, str] = {
+    0x2E: "siren_triggers",
+    0x31: "panic_enabled",
+    0x33: "associated_group_id",
+    0x34: "associated_user_id",
+    0x35: "false_press_filter",
+    0xC3: "subtype",
+}
+# The two `ObjectType` cases a keyfob arrives as when the snapshot models it.
+_SPACE_CONTROL_DEVICE_TYPES: frozenset[str] = frozenset({"space_control", "space_control_s"})
+
 # Bounds for treating a 4-byte HTS value as a big-endian Unix epoch. Deliberately
 # wide — the point is only to reject values that clearly aren't timestamps (`00000000`,
 # a counter, a bitfield) so the probe never dresses an unrelated key up as a date.
@@ -1325,6 +1352,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Bypass-configuration candidate keys (#338) — read-only, logged before
         # anything that can return early so every device family reports them.
         self._log_hts_bypass_candidates(device_id_hex, device, kv)
+        # A modeled SpaceControl's settings row (#311) — read-only, same
+        # placement rationale as the bypass probe: this hub class never reaches
+        # the keyfob path, so this is the only place its row is ever visible.
+        self._log_hts_space_control_settings(device_id_hex, device, kv)
         # Button activity-timestamp candidate keys (#348) — read-only, same
         # placement rationale as the bypass probe above: every device family
         # gets probed, and the keys are Button-specific in every capture so far.
@@ -1421,6 +1452,46 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             device_id_hex,
             device.device_type,
             {f"0x{key:02X}": value.hex() for key, value in present.items()},
+            is_device_deactivated(device),
+            device_deactivation_kinds(device),
+        )
+
+    def _log_hts_space_control_settings(
+        self, device_id_hex: str, device: Device, kv: dict[int, bytes]
+    ) -> None:
+        """DEBUG-log a gRPC-modeled SpaceControl's HTS settings row (#311).
+
+        Read-only by design — see `_HTS_SPACE_CONTROL_SETTINGS_KEYS`. Gated by
+        device type and not by shape, because the same sub-key numbers mean
+        unrelated things on other families.
+
+        The deactivation state goes on the same line for the reason the bypass
+        probe does it: on this class of hub the keyfob already has the bypass
+        switch, so a row taken while the panel has it deactivated and one taken
+        while it does not are the pair that would locate the activation flag —
+        the flag the `Active` sensor guesses at on HTS-only hubs. The full key
+        list (numbers only, no values) rides along so a capture shows whether
+        the row's shape moved, without putting any field's contents in a log.
+
+        Silent when the row carries none of the settings keys, so the 60 s
+        status rows for the same device add no noise.
+        """
+        if device.device_type not in _SPACE_CONTROL_DEVICE_TYPES:
+            return
+        present = {
+            name: kv[key].hex()
+            for key, name in _HTS_SPACE_CONTROL_SETTINGS_KEYS.items()
+            if key in kv
+        }
+        if not present:
+            return
+        _LOGGER.debug(
+            "HTS SpaceControl probe: device=%s type=%s settings=%s row_keys=%s "
+            "deactivated=%s kinds=%s",
+            device_id_hex,
+            device.device_type,
+            present,
+            [f"0x{key:02x}" for key in sorted(kv)],
             is_device_deactivated(device),
             device_deactivation_kinds(device),
         )
@@ -1660,8 +1731,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _handle_keyfob_kv(self, hub_id: str, device_id_hex: str, kv: dict[int, bytes]) -> None:
         """Classify a non-gRPC SETTINGS_BODY row as a SpaceControl keyfob.
 
-        Keyfobs are HTS-only — they never appear in the gRPC device snapshot, so
-        they reach this path (where `self.devices` has no entry). A recognised
+        Reached only for rows the gRPC snapshot does not model. Keyfobs are
+        HTS-only on some hubs but not all: a hub that reports the keyfob as an
+        `ObjectType.space_control` device gives it a normal modeled device, and
+        its row never arrives here — see `api/hts/keyfobs.py` and
+        `_log_hts_space_control_settings` (#311). A recognised
         keyfob is stored in `self.keyfobs` and announced via `SIGNAL_NEW_DEVICE`
         so the binary_sensor platform can add its device + experimental "Active"
         sensor at runtime. Rows that merely *look* like keyfobs are DEBUG-logged

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -3881,6 +3881,139 @@ class TestOnHtsDeviceKvKeyfob:
         mock_send.assert_not_called()
 
 
+# The sub-key set @wip3out3r captured for the SpaceControl on his hub (#311),
+# where the keyfob is a gRPC-modeled device rather than HTS-only: 47 keys,
+# identical across two SETTINGS_BODY messages. Only the six family keys carry
+# meaningful values here — the rest are present in his capture and are kept so
+# the row's *shape* is the real one, since that shape is what the classifier
+# and the probe both key off. Values are synthetic; he reported keys, not bytes.
+_MODELED_SPACE_CONTROL_ROW_KEYS = (
+    0x08, 0x09, 0x0A, 0x11, 0x12, 0x15, 0x16, 0x20, 0x21, 0x22, 0x23, 0x24,
+    0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2E, 0x31, 0x33, 0x34, 0x35, 0x50,
+    0x70, 0x71, 0x73, 0xAC, 0xAD, 0xAE, 0xB0, 0xB5, 0xB6, 0xBB, 0xBC, 0xC0,
+    0xC1, 0xC3, 0xC5, 0xCB, 0xEC, 0xED, 0xEE, 0xEF, 0xF0, 0xF4, 0xF8,
+)  # fmt: skip
+
+
+def _modeled_space_control_kv() -> dict[int, bytes]:
+    """A modeled SpaceControl's SETTINGS_BODY row, in @wip3out3r's shape (#311)."""
+    row = {key: b"\x00" for key in _MODELED_SPACE_CONTROL_ROW_KEYS}
+    row[0x2E] = b"\x01"  # siren_triggers
+    row[0x31] = b"\x01"  # panic_enabled
+    row[0x33] = b"\x00\x02"  # associated_group_id
+    row[0x34] = b"\x00\x07"  # associated_user_id
+    row[0x35] = b"\x01"  # false_press_filter
+    row[0xC3] = b"\x00"  # subtype (SpaceControl vs SpaceControl S)
+    return row
+
+
+class TestModeledSpaceControlIsNotAKeyfobRow:
+    """A SpaceControl the gRPC snapshot models is not on the keyfob path (#311).
+
+    Keyfobs are HTS-only on *some* hubs, not all: `ObjectType` carries both
+    `space_control` and `space_control_s`, and on a hub that reports one there
+    the device gets an ordinary HA device (with the bypass switch that already
+    shows deactivation) and its SETTINGS_BODY row never reaches the keyfob
+    classifier — which is why @wip3out3r's install has a SpaceControl and no
+    keyfob `Active` entity. Pinned so nobody "fixes" that into a duplicate
+    entity, and so the shape mismatch is not mistaken for the cause.
+    """
+
+    def _make_space_control(self, device_type: str = "space_control") -> Device:
+        return Device(
+            id="2ACCB91C",
+            hub_id="hub-1",
+            name="Keyfob",
+            device_type=device_type,
+            room_id=None,
+            group_id="g1",
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    def test_modeled_space_control_row_never_enters_the_keyfob_path(self) -> None:
+        # Asserted on the *call*, not only on the empty result: the strict shape
+        # check would keep `keyfobs` empty anyway, so a result-only assertion
+        # could not tell whether the branch had been taken.
+        coordinator = _make_coordinator()
+        coordinator.devices["2ACCB91C"] = self._make_space_control()
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._handle_keyfob_kv = MagicMock()  # type: ignore[method-assign]
+
+        with patch("custom_components.aegis_ajax.coordinator.async_dispatcher_send") as mock_send:
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", _modeled_space_control_kv())
+
+        coordinator._handle_keyfob_kv.assert_not_called()
+        assert coordinator.keyfobs == {}
+        mock_send.assert_not_called()
+
+    def test_the_row_carries_every_space_control_family_key(self) -> None:
+        # Provenance for the classification: these six are `SpaceControl`'s own
+        # field numbers in the hub's device model, and the captured row has all
+        # of them. That is what identifies the row as a SpaceControl's rather
+        # than as an unrecognised keyfob variant.
+        row = _modeled_space_control_kv()
+        assert {0x2E, 0x31, 0x33, 0x34, 0x35, 0xC3} <= set(row)
+
+    def test_probe_logs_the_family_settings_with_the_deactivation_state(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Same rationale as the bypass probe: the bytes are only conclusive
+        # paired with what the device's deactivation state actually is.
+        coordinator = _make_coordinator()
+        coordinator.devices["2ACCB91C"] = replace(
+            self._make_space_control(),
+            statuses={"temporary_deactivation_whole": True, "deactivated": True},
+        )
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", _modeled_space_control_kv())
+
+        assert "HTS SpaceControl probe" in caplog.text
+        assert "associated_user_id" in caplog.text
+        assert "panic_enabled" in caplog.text
+        assert "deactivated=True" in caplog.text
+        assert "temporary_deactivation_whole" in caplog.text
+
+    def test_probe_runs_for_the_s_variant_too(self, caplog: pytest.LogCaptureFixture) -> None:
+        coordinator = _make_coordinator()
+        coordinator.devices["2ACCB91C"] = self._make_space_control(device_type="space_control_s")
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", _modeled_space_control_kv())
+
+        assert "HTS SpaceControl probe" in caplog.text
+
+    def test_probe_is_silent_for_other_device_families(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The same sub-key numbers mean unrelated things on other families, so
+        # the probe stays gated by device type rather than by shape.
+        coordinator = _make_coordinator()
+        coordinator.devices["003AE89B"] = _make_device(device_id="003AE89B")
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("002B1A51", "003AE89B", _modeled_space_control_kv())
+
+        assert "HTS SpaceControl probe" not in caplog.text
+
+    def test_probe_is_silent_when_the_row_carries_no_family_key(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A STATUS_BODY row for the same device carries status keys, not the
+        # settings family — no log noise on every 60 s probe.
+        coordinator = _make_coordinator()
+        coordinator.devices["2ACCB91C"] = self._make_space_control()
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", {0x04: b"\x00", 0x06: b"\x01"})
+
+        assert "HTS SpaceControl probe" not in caplog.text
+
+
 class TestOnHtsDeviceKvSpaceSecurity:
     """#284: keypad full-arm of a group reaches us only as a STATUS_UPDATE arm-flag
     flip on a hub-internal space-security object (00000001/00000002) — no type=0x08


### PR DESCRIPTION
## Summary

Keyfobs are HTS-only on *some* hubs, not all — and the code said otherwise, in a docstring that has been load-bearing for anyone reading it since `1.10.0`.

`ObjectType` carries both `space_control` (25) and `space_control_s` (224), so a hub can report its keyfob as an ordinary modeled device. `_on_hts_device_kv` only takes the keyfob branch for rows the gRPC snapshot does **not** model, so on such a hub the SpaceControl gets a normal HA device — with the bypass switch that already shows deactivation — and no keyfob `Active` entity is ever created.

That single branch explains both halves of @wip3out3r's report in #311: no keyfob entity in the registry, and **zero** `looks_like_keyfob_candidate` lines in a capture whose `SETTINGS_BODY` did arrive. His 47-sub-key row is the canonical SpaceControl device row: it carries every one of `SpaceControl`'s own field numbers (`0x2e`, `0x31`, `0x33`, `0x34`, `0x35`, `0xc3`), and scoring every message under `protobuf/hub/device/` by own-field coverage puts SpaceControl first at 6/6. The row not matching `KEYFOB_SHAPE` is a **consequence, not the cause** — and the loose candidate predicate could not have seen it either, since it requires a name key (`0x02`) that a modeled row does not carry.

Also corrects a second wrong premise: that the deactivation toggle is absent from the Ajax app. It exists (*forced deactivation*), but it is a different mechanism — measured on hardware, it moves `0xb6`/`0xb7` and reports `temporary_deactivation_whole`, leaving `0x0b` untouched. Anyone trying it to produce the missing `inactive` sample gets a row that has not moved where it matters.

## Changes

- **`_log_hts_space_control_settings`** — DEBUG probe, read-only. Gated on `device_type in {space_control, space_control_s}` rather than on shape, because the same sub-keys mean unrelated things on other families; silent when the row carries none of the six keys, so 60 s status rows add no noise. Pairs the values with `deactivated=` / `kinds=` for the same reason the #338 bypass probe does — a bare byte proves nothing, the same byte next to a known deactivation state identifies the field. Carries no user-typed text (and the name key is absent from this row anyway).
- **Docstrings** in `api/hts/keyfobs.py` and `_handle_keyfob_kv` corrected, with the two hub classes and where each is handled.
- **README** — says that some hubs produce no keyfob sensors *by design*, and scopes the "every keyfob seen so far is active" observation to the other hub class. Fixes the app-toggle claim.
- **Tests** pin that a modeled row never enters the keyfob path, asserted on the **call** rather than on the result: the strict shape check keeps `keyfobs` empty either way, so a result-only assertion could not detect the branch being taken.

Why this is a probe and not a feature: on a modeled hub the deactivation surface already exists and is better than the experimental sensor. What is still missing for #311 is a CRA-deactivated sample, which this cannot manufacture — the reporter has no monitoring company on the account. The probe exists so a *different* owner of this hub class can contribute at all, which until now was structurally impossible.

## Test plan

- [x] `make check` passes locally on a freshly built Docker image (2162 passed, coverage 90.38%)
- [x] New behaviour covered by unit tests in `tests/unit/`
- [x] Tests verified able to fail — three mutations, each turning a distinct test red: making the keyfob path reachable for modeled devices, dropping the device-type gate, and dropping the empty-row guard
- [x] Coverage stays at or above the 80% threshold
- [ ] User-facing strings updated in `strings.json` and the 14 translation files — n/a, no user-facing strings change (DEBUG log only)
- [x] `README.md` / `CHANGELOG.md` updated

## Notes for the reviewer

No entity, state or attribute changes. Relates to #311; the issue stays open, since it still needs the same CRA-deactivated sample it needed before.
