### PR TITLE
fix(devices): name the access-card count record instead of calling it unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Thanks to @Taknok, who owns a Double Deck, found both device-type lists, worked out why there are two, and tested the change on the real siren — the confirmation this needed and that could not be produced without the hardware.
 
 ### Fixed
+- **A routine record in the hub's device list is no longer reported as something the integration couldn't handle (#383).** One entry in that list arrives in a shape our copy of the protocol doesn't describe, and the debug log called it an *unsupported device*. It turns out not to be a device at all: it is the space's **access-card count** — how many cards or tags exist, plus the key the Ajax app sorts them by — which is why it appears exactly once per full refresh whatever your system contains, and why the installation it was first seen on had no hardware matching it.
+
+  The log line now says what the record is and reports the count, instead of dumping bytes under a heading that implied something was wrong. Nothing was ever broken: no entity was affected, and skipping the record is still the right thing to do since a count of credentials is not a device. Two installations confirmed the reading independently — one with access tags reports a count, and @wip3out3r's, with no keypad and no cards, reports none at all. Found and fully decoded by @wip3out3r.
+
+  A record that is *not* this one still gets the full diagnostic treatment, deliberately: the recogniser is strict, so a genuinely new variant surfaces its structure rather than being quietly absorbed.
+
 - **The hub IMEI sensor is now created whether or not the SIM read has succeeded yet (#379).** It was only offered for hubs the integration had already read SIM details from, so a read that failed or had not completed produced no entity at all — and because Home Assistant never removes an entity an integration stops offering, one created on an earlier start sat `unavailable` indefinitely with nothing to explain it. Creation now follows from the hub being present; whether the SIM details are readable is left to the entity's availability, which is what availability is for.
 
   The sensor is disabled by default, as before, so a hub that never reports SIM details does not gain a visible dead entity. Fixed by @aavdberg, who reported the issue and sent the fix.

--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -47,9 +47,9 @@ def _decode_proto_wire_shape(data: bytes) -> str:
     (or `=varint`/`=i32`/`=i64` for fixed-size cases) for each one. No
     values are surfaced — only field numbers and shapes — so this output
     is safe to paste even when the original proto carries device names
-    or other PII. Used to spot a new oneof case (e.g. `field=5`) on a
-    `LightDevice` that our compiled `.proto` doesn't yet know about (#179
-    Outlet Type E hypothesis).
+    or other PII. Used to spot a new oneof case on a `LightDevice` that
+    our compiled `.proto` doesn't know about — this is how field 5 was
+    found and then identified as the access-card count (#383).
     """
     parts: list[str] = []
     i = 0
@@ -88,6 +88,56 @@ def _decode_proto_wire_shape(data: bytes) -> str:
     return ",".join(parts) if parts else "<empty>"
 
 
+# The 5th `LightDevice` oneof case, which our compiled `.proto` predates (#383).
+# It is not a device: it is the space's **access-card count**, one summary record
+# per full device-list fetch, carrying a `count` (field 1, absent when zero) and a
+# `sorting_key` (field 2, the constant the app orders its list by). Two installs
+# corroborate it — a hub with no keypad and no cards sends no count at all, one
+# with six tags sends 6 — and it appears exactly once regardless of how many
+# devices, groups or scenarios the space has.
+_ACCESS_CARDS_COUNT_FIELD = 5
+_ACCESS_CARDS_COUNT_MEMBERS = frozenset({1, 2})  # count, sorting_key
+
+
+def _access_cards_count(data: bytes) -> int | None:
+    """Return the access-card count iff *data* is that record, else `None`.
+
+    Deliberately strict: field 5 must be the only top-level field and may
+    contain nothing but `count` and `sorting_key`. Anything else — an extra
+    sibling, an unexpected member — is a record we do not recognise after all,
+    and falls through to the unsupported-case probe rather than being quietly
+    absorbed. `count` absent means zero, as proto3 omits scalar defaults.
+    """
+    try:
+        tag, i = _decode_varint(data, 0)
+        if tag != (_ACCESS_CARDS_COUNT_FIELD << 3) | 2:
+            return None
+        length, i = _decode_varint(data, i)
+        if i + length != len(data):
+            return None  # truncated, or field 5 is not the only field
+        count = 0
+        end = i + length
+        while i < end:
+            tag, i = _decode_varint(data, i)
+            field, wire = tag >> 3, tag & 0x07
+            if field not in _ACCESS_CARDS_COUNT_MEMBERS:
+                return None
+            if wire == 0:
+                value, i = _decode_varint(data, i)
+                if field == 1:
+                    count = value
+            elif wire == 2:
+                size, i = _decode_varint(data, i)
+                i += size
+            else:
+                return None
+        if i != end:
+            return None
+    except (ValueError, IndexError):
+        return None
+    return count
+
+
 def _decode_varint(data: bytes, i: int) -> tuple[int, int]:
     """Read a protobuf varint at offset `i`, returning `(value, next_offset)`.
 
@@ -122,9 +172,9 @@ def _redact_proto_bytes_to_hex(data: bytes) -> str:
     `'A'`) still come through as hex, while real text fields (device
     names, ids, emails) are length-preserving redacted. Numeric values
     almost always contain at least one non-printable byte (`0x00` is the
-    most common), so electrical readings stay fully visible — exactly
-    what we need to map an unknown LightDevice oneof case (#179) from a
-    public bug-report log.
+    most common), so numeric values stay fully visible — which is what
+    lets an unknown LightDevice oneof case be mapped from a bug-report
+    log without the log carrying anyone's device names.
     """
     out: list[str] = []
     i = 0
@@ -576,50 +626,59 @@ def parse_device(proto_light_device: Any) -> Device | None:  # noqa: ANN401
         return _parse_hub_device(proto_light_device.hub_device)
     if device_kind == "video_edge_channel":
         return _parse_video_edge_channel(proto_light_device.video_edge_channel)
-    _LOGGER.debug("Skipping unsupported device type: %s", device_kind)
     # `device_kind is None` means the LightDevice proto's `device`
     # oneof didn't match any case we know (`hub_device`,
-    # `video_edge`, `video_edge_channel`, `smart_lock`). The bytes
-    # are preserved as protobuf unknown fields — most likely a NEW
-    # oneof case the cloud started emitting for a device family
-    # we haven't pulled into the local `.proto` yet (#179 Outlet
-    # Type E hypothesis: 18 of these landed during a load-toggle
-    # capture with zero matching HTS deltas). Surface enough
-    # structure to identify the new field number AND the redacted
-    # contents so the case can be reconstructed from a single
-    # capture without another user round-trip.
-    if device_kind is None and _LOGGER.isEnabledFor(logging.DEBUG):
+    # `video_edge`, `video_edge_channel`, `smart_lock`), and the bytes
+    # are preserved as protobuf unknown fields.
+    #
+    # One such case is identified and is NOT a device: field 5 is the
+    # space's access-card count (#383) — see `_access_cards_count`.
+    # Recognising it before the probe keeps a routine, once-per-fetch
+    # summary record out of the "unsupported" wording, which said the
+    # integration had met something it could not handle when it had
+    # not. Anything else is genuinely unknown and still gets the
+    # probe: enough structure to identify the new field number AND the
+    # redacted contents, so a new case can be reconstructed from a
+    # single capture without another user round-trip.
+    raw = b""
+    if device_kind is None:
         try:
             raw = proto_light_device.SerializeToString()
         except Exception:  # noqa: BLE001
             return None
-        if raw:
+        cards = _access_cards_count(raw)
+        if cards is not None:
             _LOGGER.debug(
-                "Unsupported LightDevice (%db) wire-shape: %s",
-                len(raw),
-                _decode_proto_wire_shape(raw),
+                "Skipping the space's access-card count record (count=%d) — "
+                "a summary, not a device (#383)",
+                cards,
             )
-            # Tiny protos (≤ TINY_PROTO_THRESHOLD bytes total) are
-            # protocol-level state messages, not user-data payloads —
-            # there's no room for a device name / room / email inside
-            # that envelope. Render them with raw hex so short ASCII
-            # codes (3-char status strings like `OFF`/`ON`, hub-id
-            # suffixes, device-type tags) come through directly.
-            # Larger protos (real device records that DO carry
-            # user-set names) keep the ≥3-byte ASCII redaction. From
-            # #179: beta.6 capture showed 18 events with the shape
-            # `f5={f2:<3 ASCII chars>}` lining up with Outlet load
-            # transitions — but redaction hid exactly the 3 chars
-            # needed to identify whether they encode state or just
-            # a device-id reference.
-            bytes_str = (
-                raw.hex() if len(raw) <= _TINY_PROTO_THRESHOLD else _redact_proto_bytes_to_hex(raw)
-            )
-            _LOGGER.debug(
-                "Unsupported LightDevice (%db) bytes: %s",
-                len(raw),
-                bytes_str,
-            )
+            return None
+    _LOGGER.debug("Skipping unsupported device type: %s", device_kind)
+    if raw and _LOGGER.isEnabledFor(logging.DEBUG):
+        _LOGGER.debug(
+            "Unsupported LightDevice (%db) wire-shape: %s",
+            len(raw),
+            _decode_proto_wire_shape(raw),
+        )
+        # Tiny protos (≤ TINY_PROTO_THRESHOLD bytes total) are
+        # protocol-level state messages, not user-data payloads —
+        # there's no room for a device name / room / email inside
+        # that envelope. Render them with raw hex so short ASCII
+        # codes (3-char status strings like `OFF`/`ON`, hub-id
+        # suffixes, device-type tags) come through directly.
+        # Larger protos (real device records that DO carry user-set
+        # names) keep the ≥3-byte ASCII redaction. That threshold is
+        # what made #383 answerable: the access-card record falls under
+        # it, so its `sorting_key` arrived readable instead of masked.
+        bytes_str = (
+            raw.hex() if len(raw) <= _TINY_PROTO_THRESHOLD else _redact_proto_bytes_to_hex(raw)
+        )
+        _LOGGER.debug(
+            "Unsupported LightDevice (%db) bytes: %s",
+            len(raw),
+            bytes_str,
+        )
     return None
 
 

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -83,11 +83,16 @@ class TestParseDevice:
         codes come through (#179 follow-up).
 
         The original probe in beta.6 redacted any printable-ASCII run ≥3
-        chars, which hid exactly the 3-char strings we needed to identify
-        whether SaetanSaDiablo's 18 unsupported LightDevice events were
-        encoding state codes (`OFF`/`ON`/etc) or just a device-id reference.
-        A 7-byte proto has no room for a user-set name / room / email
-        anyway, so raw hex is privacy-safe at this size.
+        chars, which hid exactly the 3-char strings needed to tell whether
+        the unsupported LightDevice events encoded state codes or just a
+        reference. A 7-byte proto has no room for a user-set name / room /
+        email anyway, so raw hex is privacy-safe at this size — and that
+        threshold is what eventually answered #383.
+
+        Uses **field 6**, not the field 5 this originally probed: field 5 is
+        now identified as the space's access-card count and is recognised
+        before this path, so a field-5 payload no longer reaches the probe.
+        See `TestAccessCardsCountRecord`.
         """
         import logging as _logging  # noqa: PLC0415
 
@@ -95,10 +100,10 @@ class TestParseDevice:
             light_device_pb2,
         )
 
-        # 7-byte proto mimicking the actual capture shape: field=5
+        # 7-byte proto in the same shape as a real capture: field=6
         # length-delimited (5 bytes) → field=2 length-delimited (3 ASCII
         # bytes 'O', 'F', 'F').
-        unknown_field = bytes([0x2A, 0x05, 0x12, 0x03, 0x4F, 0x46, 0x46])
+        unknown_field = bytes([0x32, 0x05, 0x12, 0x03, 0x4F, 0x46, 0x46])
         proto_device = light_device_pb2.LightDevice()
         proto_device.MergeFromString(unknown_field)
         assert proto_device.WhichOneof("device") is None
@@ -109,7 +114,7 @@ class TestParseDevice:
         bytes_line = next(record.message for record in caplog.records if "bytes:" in record.message)
         # Full raw hex must be visible — no `<text:Nb>` masking on a tiny
         # protocol-state envelope.
-        assert "2a051203" in bytes_line
+        assert "32051203" in bytes_line
         assert "4f4646" in bytes_line  # 'OFF' in ASCII bytes
         assert "<text:" not in bytes_line
 
@@ -266,6 +271,77 @@ class TestParseDevice:
         assert any("Skipping unsupported device type" in r.message for r in caplog.records)
         assert not any("wire-shape" in r.message for r in caplog.records)
         assert not any("bytes:" in r.message for r in caplog.records)
+
+
+class TestAccessCardsCountRecord:
+    """The 5th `LightDevice` oneof case is the space's access-card count (#383).
+
+    It is not a device and must not be reported as an unrecognised one: the
+    stream carries exactly one per full device-list fetch, on every install.
+    Both byte strings below are real captures, unmodified.
+    """
+
+    # @wip3out3r's hub: f5={f2:"5_0"} — no count field at all, i.e. 0 cards,
+    # which matches his inventory (no keypad, no access cards).
+    NO_CARDS = bytes.fromhex("2a051203355f30")
+    # bvis-home: f5={f1:6, f2:"5_0"} — six access cards on that account.
+    SIX_CARDS = bytes.fromhex("2a0708061203355f30")
+
+    def _parse(self, raw: bytes, caplog: pytest.LogCaptureFixture) -> Device | None:
+        import logging as _logging  # noqa: PLC0415
+
+        from v3.mobilegwsvc.commonmodels.space.device.light import (  # noqa: PLC0415
+            light_device_pb2,
+        )
+
+        # Field 5 is absent from our compiled proto, so it lands in unknown
+        # fields — exactly as it does live.
+        proto_device = light_device_pb2.LightDevice.FromString(raw)
+        with caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"):
+            return DevicesApi.parse_device(proto_device)
+
+    def test_zero_cards_is_recognised_and_not_called_unsupported(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        assert self._parse(self.NO_CARDS, caplog) is None
+        assert "access-card count" in caplog.text
+        assert "count=0" in caplog.text
+        assert "Unsupported LightDevice" not in caplog.text
+        assert "Skipping unsupported device type" not in caplog.text
+
+    def test_the_count_is_reported(self, caplog: pytest.LogCaptureFixture) -> None:
+        assert self._parse(self.SIX_CARDS, caplog) is None
+        assert "count=6" in caplog.text
+        assert "Unsupported LightDevice" not in caplog.text
+
+    def test_a_genuinely_unknown_case_still_hits_the_probe(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Field 6 — a real new oneof case would look like this, and must keep
+        # surfacing its shape and bytes.
+        assert self._parse(bytes.fromhex("32020801"), caplog) is None
+        assert "Unsupported LightDevice" in caplog.text
+        assert "f6=bytes(2)" in caplog.text
+
+    def test_field_5_with_an_unexpected_member_falls_through_to_the_probe(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # f5={f3:1} — same field number, different contents. Recognising it as
+        # the access-card count would hide a change in the record, so the probe
+        # must still fire.
+        assert self._parse(bytes.fromhex("2a021801"), caplog) is None
+        assert "Unsupported LightDevice" in caplog.text
+        assert "access-card count" not in caplog.text
+
+    def test_field_5_alongside_another_field_falls_through_to_the_probe(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The recogniser requires field 5 to be the *only* top-level field, so
+        # a record that merely includes it is not mistaken for the count.
+        # `+ 3001` appends a field 6 varint.
+        assert self._parse(self.NO_CARDS + bytes.fromhex("3001"), caplog) is None
+        assert "Unsupported LightDevice" in caplog.text
+        assert "access-card count" not in caplog.text
 
 
 class TestDecodeProtoWireShape:


### PR DESCRIPTION
## Summary

The 5th `LightDevice` oneof case — absent from our compiled `.proto`, so it lands in unknown fields and `WhichOneof` returns `None` — is the space's **access-card count**: a `count` (omitted when zero) plus a `sorting_key`, the constant the Ajax app orders its card list by. It is not a device. That explains every open question in #383 at once: why exactly one arrives per full device-list fetch whatever the space contains, why the count tracks neither groups nor scenarios, why it never appears on the periodic poll, and why the install it was first seen on had no matching hardware.

Two independent captures corroborate each other:

| install | bytes | count | inventory |
|---|---|---|---|
| @wip3out3r | `2a051203355f30` | **absent → 0** | no keypad, no access cards |
| bvis-home | `2a0708061203355f30` | **6** | has access tags |

The two-byte difference is the zero default being omitted, not a firmware variation.

## Changes

- **`_access_cards_count`** recognises the record and logs `Skipping the space's access-card count record (count=N)`, replacing the `Unsupported LightDevice` wire-shape/bytes pair. That wording said the integration had met something it could not handle, when it had met something routine. The record is still skipped — a count of credentials is not a device, and the issue asked what the record *was*, not for a sensor.
- **Deliberately strict**, so this cannot swallow a real discovery: field 5 must be the only top-level field and may contain nothing but members 1 and 2. A record that merely includes field 5, or whose members differ, still falls through to the probe with its full structure. An unparsed record could be hiding a device family — that is how #179 started, and it is the only reason the probe is worth keeping.
- **Stale #179 comments corrected.** They still framed the probe as an open Outlet Type E lead ("18 events lining up with Outlet load transitions"). #179 shipped long ago by a different route entirely (HTS `STATUS_BODY` sub-keys), so the comment was sending readers down a dead path — it sent me down it once.

## ⚠️ One pre-existing test moved, and why

`test_parse_unsupported_oneof_tiny_proto_logs_raw_hex` used a synthetic `f5={f2:"OFF"}` payload — a guess from that same dead theory, that field 5 carried state codes like `OFF`/`ON`. The recogniser now correctly classifies that payload as an access-card record, so the test moved to **field 6**. Its actual subject is unchanged: tiny protos (≤16 B) bypass redaction so short protocol strings survive. That threshold is what made this decode possible at all — the record sits on the useful side of it, so its string arrived readable rather than masked.

## Test plan

- [x] `make check` on a freshly built Docker image
- [x] New behaviour covered by unit tests in `tests/unit/` — both real capture byte strings, unmodified
- [x] Tests verified able to fail — three mutations, each turning a distinct test red: neutering the recogniser, dropping the "field 5 is the only top-level field" check, and dropping the inner-member check
- [x] Coverage stays at or above the 80% threshold
- [ ] User-facing strings updated in `strings.json` and the 14 translation files — n/a, no user-facing strings change (DEBUG log only)
- [x] `README.md` / `CHANGELOG.md` updated

## Notes for the reviewer

No entity, state or attribute changes. Found and fully decoded by @wip3out3r, who also established the "full fetch, never the periodic poll" timing with nine polls as a negative control. Relates to #383, which this closes out.
