### PR TITLE
Route 2FA-required re-login to the reauth flow instead of retrying forever

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -34,7 +34,7 @@ from custom_components.aegis_ajax.api.models import (
     is_device_deactivated,
 )
 from custom_components.aegis_ajax.api.security import SecurityApi
-from custom_components.aegis_ajax.api.session import AuthenticationError
+from custom_components.aegis_ajax.api.session import AuthenticationError, TwoFactorRequiredError
 from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import (
     BUTTON_PRESS_DEVICE_TYPES,
@@ -623,6 +623,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
         try:
             await self._login_and_persist()
+        except TwoFactorRequiredError as err:
+            self.update_interval = timedelta(minutes=30)
+            _LOGGER.error(
+                "Ajax requires a 2FA code to log in again — triggering reauth so the "
+                "code can be entered."
+            )
+            raise ConfigEntryAuthFailed("Two-factor authentication required") from err
         except AuthenticationError as err:
             self.update_interval = timedelta(minutes=30)
             _LOGGER.error("Authentication failed: %s — triggering reauth.", err)
@@ -661,6 +668,16 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._client.session.clear_session()
             try:
                 await self._login_and_persist()
+            except TwoFactorRequiredError as tfa_err:
+                # Ajax wants a 2FA code, which only the config flow can
+                # collect. Without this branch the error falls through to
+                # the generic `UpdateFailed` handler and HA just keeps
+                # retrying setup — and every retry asks Ajax for a *new*
+                # 2FA code, invalidating the one the user is currently
+                # typing into the reconfigure form. `ConfigEntryAuthFailed`
+                # stops the polling and opens the reauth flow, which does
+                # know how to ask for the code.
+                raise ConfigEntryAuthFailed("Two-factor authentication required") from tfa_err
             except AuthenticationError as auth_err:
                 raise ConfigEntryAuthFailed(str(auth_err)) from auth_err
             all_spaces = await self._spaces_api.list_spaces()

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -730,6 +730,57 @@ class TestAsyncUpdateData:
             await coordinator._async_update_data()
 
     @pytest.mark.asyncio
+    async def test_update_data_raises_auth_failed_when_relogin_needs_2fa(self) -> None:
+        """A fresh login that needs 2FA must open the reauth flow, not retry forever.
+
+        `TwoFactorRequiredError` is not an `AuthenticationError` subclass, so
+        without an explicit branch it fell through to the generic
+        `UpdateFailed` handler. HA then retried setup indefinitely, and every
+        retry asked Ajax for a new 2FA code — invalidating the code the user
+        was typing into the reconfigure form.
+        """
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+
+        from custom_components.aegis_ajax.api.session import TwoFactorRequiredError
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = False
+        coordinator._client.login = AsyncMock(side_effect=TwoFactorRequiredError("req-1"))
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_update_data_raises_auth_failed_when_token_rejected_and_relogin_needs_2fa(
+        self,
+    ) -> None:
+        """The stale-token recovery path must also route 2FA to the reauth flow.
+
+        This is the path a user hits after revoking sessions in the Ajax app:
+        the stored token is rejected, the forced re-login needs a 2FA code.
+        """
+        import grpc
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+
+        from custom_components.aegis_ajax.api.session import TwoFactorRequiredError
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+
+        unauth = grpc.aio.AioRpcError(  # type: ignore[call-arg]
+            code=grpc.StatusCode.UNAUTHENTICATED,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="User is not authenticated",
+        )
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(side_effect=unauth)
+        coordinator._client.login = AsyncMock(side_effect=TwoFactorRequiredError("req-1"))
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
     async def test_login_persists_session_via_callback(self) -> None:
         """A successful login pushes the new token through on_session_persist."""
         coordinator = _make_coordinator()


### PR DESCRIPTION
Fixes #399

## The bug

After revoking the Home Assistant session from the Ajax app, the integration never recovers. It retries setup forever and cannot be fixed from the UI either.

`TwoFactorRequiredError` is not an `AuthenticationError` subclass:

```python
# api/session.py
class AuthenticationError(Exception): ...
class TwoFactorRequiredError(Exception): ...
```

Both re-login sites in `coordinator.py` only mapped `AuthenticationError` to `ConfigEntryAuthFailed`, so a 2FA-required login fell through to the generic handler and became `UpdateFailed("Error fetching Ajax data")`. HA reads that as transient and keeps retrying.

## Why it also breaks Reconfigure

The loop is self-defeating. Every retry performs a fresh `login()`, and each of those makes Ajax issue a **new** `request_id` and send a **new** code. A user working through *Reconfigure* is racing the coordinator — the code being typed is invalidated by the next background retry. The reconfigure step surfaces that as `invalid_auth` / `invalid_totp` and logs nothing, so it reads as a wrong password.

Disabling the config entry stops the loop, but HA then hides the *Reconfigure* option, so there is no way out from the UI.

## The change

Both `_ensure_authenticated()` and the stale-token recovery in `_refresh_spaces()` now raise `ConfigEntryAuthFailed` when the re-login needs 2FA. That stops the polling and opens the reauth flow, which already knows how to collect the code — `async_step_reauth_confirm` catches `TwoFactorRequiredError` and hands off to `async_step_reauth_2fa`, so no flow changes were needed.

## Tests

Two regression tests, one per call site:

- `test_update_data_raises_auth_failed_when_relogin_needs_2fa`
- `test_update_data_raises_auth_failed_when_token_rejected_and_relogin_needs_2fa`

The second mirrors the real-world path: stored token rejected with `UNAUTHENTICATED`, forced re-login demands 2FA.

Found by hitting it on my own install after clearing sessions in the Ajax app. `ruff check` and `ruff format --check` are clean.