### PR TITLE
Stop reauth from discarding the session token it just obtained

### DIFF
--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -330,9 +330,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
     # Restore session token from stored data to skip re-login (and 2FA) on restart
     if entry.data.get("session_token") and entry.data.get("user_hex_id"):
         _LOGGER.debug(
-            "Restoring stored Ajax session for entry %s (user=%s)",
+            # The device id is logged because Ajax binds the session token to
+            # it: a restored token paired with a different id is rejected with
+            # UNAUTHENTICATED, and without this the mismatch is invisible.
+            "Restoring stored Ajax session for entry %s (user=%s, device_id=%s)",
             entry.entry_id,
             entry.data["user_hex_id"],
+            client.session.device_id,
         )
         client.session.set_session(str(entry.data["session_token"]), str(entry.data["user_hex_id"]))
     else:
@@ -348,13 +352,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
         Called by the coordinator after every successful login so that a
         restart can reuse the freshest token instead of forcing another
         login (which would create yet another active session in Ajax).
+
+        The device id rides along because Ajax binds the token to it. Entries
+        created before the id was stored get one generated per setup, so
+        without persisting it here the very next restart presents the token
+        under a different id and Ajax rejects it.
         """
+        device_id = client.session.device_id
         if (
             entry.data.get("session_token") == token
             and entry.data.get("user_hex_id") == user_hex_id
+            and entry.data.get("device_id") == device_id
         ):
             return
-        new_data = {**entry.data, "session_token": token, "user_hex_id": user_hex_id}
+        new_data = {
+            **entry.data,
+            "session_token": token,
+            "user_hex_id": user_hex_id,
+            "device_id": device_id,
+        }
         hass.config_entries.async_update_entry(entry, data=new_data)
         _LOGGER.debug("Persisted refreshed Ajax session for entry %s", entry.entry_id)
 

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -62,6 +62,7 @@ except TypeError as exc:
     _log_proto_descriptor_collision(exc)
     raise
 from custom_components.aegis_ajax.const import (  # noqa: E402
+    APPLICATION_LABEL,
     CONF_AUTO_CREATE_LABELS,
     CONF_DISABLE_PUSH_WARNING,
     CONF_PERSISTENT_NOTIFICATION_EVENTS,
@@ -314,7 +315,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
             email=entry.data["email"],
             password_hash=entry.data["password_hash"],
             device_id=entry.data.get("device_id"),
-            app_label=entry.data.get("app_label", ""),
+            app_label=entry.data.get("app_label", APPLICATION_LABEL),
         )
     else:
         _LOGGER.warning(
@@ -325,18 +326,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
             email=entry.data["email"],
             password=entry.data.get("password", ""),
             device_id=entry.data.get("device_id"),
-            app_label=entry.data.get("app_label", ""),
+            app_label=entry.data.get("app_label", APPLICATION_LABEL),
         )
     # Restore session token from stored data to skip re-login (and 2FA) on restart
     if entry.data.get("session_token") and entry.data.get("user_hex_id"):
         _LOGGER.debug(
-            # The device id is logged because Ajax binds the session token to
-            # it: a restored token paired with a different id is rejected with
-            # UNAUTHENTICATED, and without this the mismatch is invisible.
-            "Restoring stored Ajax session for entry %s (user=%s, device_id=%s)",
+            # The device id and app label are logged because Ajax binds the
+            # session token to both: a restored token paired with a different
+            # id or label is rejected with UNAUTHENTICATED, and without this
+            # the mismatch is invisible. Only a token prefix is logged — it
+            # identifies which token is in play without exposing a usable one.
+            "Restoring stored Ajax session for entry %s "
+            "(user=%s, device_id=%s, app_label=%r, token=%s…)",
             entry.entry_id,
             entry.data["user_hex_id"],
             client.session.device_id,
+            client.session.app_label,
+            str(entry.data["session_token"])[:8],
         )
         client.session.set_session(str(entry.data["session_token"]), str(entry.data["user_hex_id"]))
     else:
@@ -372,7 +378,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
             "device_id": device_id,
         }
         hass.config_entries.async_update_entry(entry, data=new_data)
-        _LOGGER.debug("Persisted refreshed Ajax session for entry %s", entry.entry_id)
+        _LOGGER.debug(
+            "Persisted refreshed Ajax session for entry %s (device_id=%s, token=%s…)",
+            entry.entry_id,
+            device_id,
+            token[:8],
+        )
 
     coordinator = AjaxCobrandedCoordinator(
         hass=hass,

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -61,6 +61,7 @@ try:
 except TypeError as exc:
     _log_proto_descriptor_collision(exc)
     raise
+from custom_components.aegis_ajax.api.session import log_fingerprint  # noqa: E402
 from custom_components.aegis_ajax.const import (  # noqa: E402
     APPLICATION_LABEL,
     CONF_AUTO_CREATE_LABELS,
@@ -331,18 +332,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
     # Restore session token from stored data to skip re-login (and 2FA) on restart
     if entry.data.get("session_token") and entry.data.get("user_hex_id"):
         _LOGGER.debug(
-            # The device id and app label are logged because Ajax binds the
-            # session token to both: a restored token paired with a different
-            # id or label is rejected with UNAUTHENTICATED, and without this
-            # the mismatch is invisible. Only a token prefix is logged — it
-            # identifies which token is in play without exposing a usable one.
+            # Ajax binds the session token to the device id, so a restored token
+            # paired with a different id is rejected with UNAUTHENTICATED and the
+            # mismatch is otherwise invisible. Both go through `log_fingerprint`:
+            # they are in `diagnostics.TO_REDACT`, and telling two ids apart is
+            # all a log needs from them. The app label is a brand string, not an
+            # identifier, so it is logged as-is.
             "Restoring stored Ajax session for entry %s "
-            "(user=%s, device_id=%s, app_label=%r, token=%s…)",
+            "(user=%s, device_id=%s, app_label=%r, token=%s)",
             entry.entry_id,
             entry.data["user_hex_id"],
-            client.session.device_id,
+            log_fingerprint(client.session.device_id),
             client.session.app_label,
-            str(entry.data["session_token"])[:8],
+            log_fingerprint(entry.data["session_token"]),
         )
         client.session.set_session(str(entry.data["session_token"]), str(entry.data["user_hex_id"]))
     else:
@@ -379,10 +381,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
         }
         hass.config_entries.async_update_entry(entry, data=new_data)
         _LOGGER.debug(
-            "Persisted refreshed Ajax session for entry %s (device_id=%s, token=%s…)",
+            "Persisted refreshed Ajax session for entry %s (device_id=%s, token=%s)",
             entry.entry_id,
-            device_id,
-            token[:8],
+            log_fingerprint(device_id),
+            log_fingerprint(token),
         )
 
     coordinator = AjaxCobrandedCoordinator(
@@ -454,7 +456,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
             fcm_api_key=_get_fcm("fcm_api_key"),
             fcm_sender_id=_get_fcm("fcm_sender_id"),
             entry_id=entry.entry_id,
-            app_label=str(entry.data.get("app_label", "")),
+            app_label=str(entry.data.get("app_label", APPLICATION_LABEL)),
             disable_push_warning=bool(
                 entry.options.get(CONF_DISABLE_PUSH_WARNING, DEFAULT_DISABLE_PUSH_WARNING)
             ),
@@ -653,7 +655,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntr
     common_kwargs = {
         "email": entry.data["email"],
         "device_id": entry.data.get("device_id"),
-        "app_label": entry.data.get("app_label", ""),
+        "app_label": entry.data.get("app_label", APPLICATION_LABEL),
     }
     try:
         if entry.data.get("password_hash"):

--- a/custom_components/aegis_ajax/api/session.py
+++ b/custom_components/aegis_ajax/api/session.py
@@ -16,6 +16,36 @@ from custom_components.aegis_ajax.const import (
 )
 
 
+def log_fingerprint(value: object) -> str:
+    """Stable one-way fingerprint of a session identifier, safe to put in a log.
+
+    `session_token` and `device_id` are both in `diagnostics.TO_REDACT`, so
+    neither belongs in a log line either — and debug logs travel *further* than
+    a diagnostics dump does, because people paste them into public issues while
+    a dump is a file someone downloads. Stripping a value from one and printing
+    it in the other would be disagreeing with ourselves.
+
+    What a log actually needs from these is only "is this the same one as
+    before?" — which a digest answers without carrying the value. Truncated
+    because a log needs to be readable and 48 bits is far more than enough to
+    tell two ids apart by eye.
+
+    Same contract as `_fcm_creds_hash`: a change-detection fingerprint compared
+    only against itself, never used to authenticate anything, so a fast hash is
+    correct and a KDF would be pointless. `usedforsecurity=False` documents that
+    intent and keeps it FIPS-safe.
+
+    Accepts `object` and coerces, deliberately. Every call sits inside a
+    `_LOGGER.debug(...)` argument list, which Python evaluates eagerly — so a
+    `TypeError` in here would not spoil a log line, it would take down the login
+    path that was being logged. A diagnostic must not be able to break the thing
+    it observes, and no caller should have to defend a log statement.
+    """
+    if not value:
+        return "none"
+    return hashlib.sha256(str(value).encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
+
+
 class AuthenticationError(Exception):
     """Raised when authentication fails."""
 

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -461,6 +461,19 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
             # this was stored, or whose flow fell back to a generated id,
             # would otherwise keep an id that does not match the new token.
             new_data["device_id"] = self._client.session.device_id
+            _LOGGER.debug(
+                "Reauth persisting session for entry %s (device_id=%s, app_label=%r, token=%s…)",
+                entry.entry_id,
+                self._client.session.device_id,
+                self._app_label,
+                str(self._client.session.session_token)[:8],
+            )
+        else:
+            _LOGGER.warning(
+                "Reauth finished without a session token for entry %s — "
+                "the entry keeps its previous (rejected) token",
+                entry.entry_id,
+            )
         return self.async_update_reload_and_abort(entry, data=new_data, reason="reauth_successful")
 
     async def _async_finish_reconfigure(self) -> ConfigFlowResult:
@@ -479,6 +492,20 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
             new_data["session_token"] = self._client.session.session_token
             new_data["user_hex_id"] = self._client.session.user_hex_id
             new_data["device_id"] = self._client.session.device_id
+            _LOGGER.debug(
+                "Reconfigure persisting session for entry %s "
+                "(device_id=%s, app_label=%r, token=%s…)",
+                entry.entry_id,
+                self._client.session.device_id,
+                self._app_label,
+                str(self._client.session.session_token)[:8],
+            )
+        else:
+            _LOGGER.warning(
+                "Reconfigure finished without a session token for entry %s — "
+                "the entry keeps its previous (rejected) token",
+                entry.entry_id,
+            )
         # Refresh the visible title and unique_id too, not just the data —
         # otherwise switching accounts leaves the old email on the entry's
         # front page until a second reconfigure (#241).

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -94,6 +94,10 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         self._password_hash: str = ""
         self._app_label: str = APPLICATION_LABEL
         self._request_id: str = ""
+        # Snapshot of a freshly issued session, taken before the channel is
+        # closed. `AjaxGrpcClient.close()` clears the session, so reading the
+        # token off the client afterwards yields nothing.
+        self._session_snapshot: dict[str, Any] | None = None
 
     async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
         """Entry point when an Ajax hub is seen on the local network.
@@ -120,6 +124,24 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
             "name": discovery_info.hostname or f"Ajax hub ({discovery_info.ip})"
         }
         return await self.async_step_user()
+
+    def _capture_session(self) -> None:
+        """Snapshot a freshly issued session before the channel is closed.
+
+        `AjaxGrpcClient.close()` clears the session, so the reauth and
+        reconfigure paths — which close the channel before persisting — used
+        to read an already-wiped token and silently leave the entry on its
+        old, rejected one. That produced an unbreakable UNAUTHENTICATED loop:
+        every retry re-logged in, and every re-login demanded 2FA again.
+        """
+        if self._client is None or not self._client.session.session_token:
+            return
+        session = self._client.session
+        self._session_snapshot = {
+            "session_token": session.session_token,
+            "user_hex_id": session.user_hex_id,
+            "device_id": session.device_id,
+        }
 
     async def _async_close_client(self) -> None:
         """Close and drop the in-flight gRPC client after a failed login.
@@ -296,6 +318,7 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
                 await self._client.connect()
                 await asyncio.wait_for(self._client.login(), timeout=30)
+                self._capture_session()
                 await self._client.close()
                 return await self._async_finish_reconfigure()
             except TwoFactorRequiredError as e:
@@ -347,6 +370,7 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                     timeout=30,
                 )
+                self._capture_session()
                 await self._client.close()
                 return await self._async_finish_reconfigure()
             except AuthenticationError:
@@ -392,6 +416,7 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
                 await self._client.connect()
                 await asyncio.wait_for(self._client.login(), timeout=30)
+                self._capture_session()
                 await self._client.close()
                 return await self._async_finish_reauth()
             except TwoFactorRequiredError as e:
@@ -435,6 +460,7 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                     timeout=30,
                 )
+                self._capture_session()
                 await self._client.close()
                 return await self._async_finish_reauth()
             except AuthenticationError:
@@ -454,19 +480,14 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
             "password_hash": self._password_hash,
             "app_label": self._app_label,
         }
-        if self._client and self._client.session.session_token:
-            new_data["session_token"] = self._client.session.session_token
-            new_data["user_hex_id"] = self._client.session.user_hex_id
-            # Persist the id the token is bound to. Entries created before
-            # this was stored, or whose flow fell back to a generated id,
-            # would otherwise keep an id that does not match the new token.
-            new_data["device_id"] = self._client.session.device_id
+        if self._session_snapshot:
+            new_data.update(self._session_snapshot)
             _LOGGER.debug(
                 "Reauth persisting session for entry %s (device_id=%s, app_label=%r, token=%s…)",
                 entry.entry_id,
-                self._client.session.device_id,
+                self._session_snapshot["device_id"],
                 self._app_label,
-                str(self._client.session.session_token)[:8],
+                str(self._session_snapshot["session_token"])[:8],
             )
         else:
             _LOGGER.warning(
@@ -488,17 +509,18 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
             "password_hash": self._password_hash,
             "app_label": self._app_label,
         }
-        if self._client and self._client.session.session_token:
-            new_data["session_token"] = self._client.session.session_token
-            new_data["user_hex_id"] = self._client.session.user_hex_id
-            new_data["device_id"] = self._client.session.device_id
+        if self._session_snapshot:
+            # The snapshot carries the device id the token is bound to.
+            # Entries created before it was stored would otherwise keep an id
+            # that does not match the new token.
+            new_data.update(self._session_snapshot)
             _LOGGER.debug(
                 "Reconfigure persisting session for entry %s "
                 "(device_id=%s, app_label=%r, token=%s…)",
                 entry.entry_id,
-                self._client.session.device_id,
+                self._session_snapshot["device_id"],
                 self._app_label,
-                str(self._client.session.session_token)[:8],
+                str(self._session_snapshot["session_token"])[:8],
             )
         else:
             _LOGGER.warning(

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -290,6 +290,9 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                     email=self._email,
                     password_hash=self._password_hash,
                     app_label=self._app_label,
+                    # Same binding as reauth: the token Ajax hands back is
+                    # only valid for the device id that requested it.
+                    device_id=entry.data.get("device_id"),
                 )
                 await self._client.connect()
                 await asyncio.wait_for(self._client.login(), timeout=30)
@@ -381,6 +384,11 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
                     email=self._email,
                     password_hash=self._password_hash,
                     app_label=self._app_label,
+                    # Reuse the entry's device id. Ajax binds the session
+                    # token to the `client-device-id` it was issued for, so a
+                    # throwaway id here yields a token every subsequent call
+                    # rejects with UNAUTHENTICATED.
+                    device_id=entry.data.get("device_id"),
                 )
                 await self._client.connect()
                 await asyncio.wait_for(self._client.login(), timeout=30)
@@ -449,6 +457,10 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._client and self._client.session.session_token:
             new_data["session_token"] = self._client.session.session_token
             new_data["user_hex_id"] = self._client.session.user_hex_id
+            # Persist the id the token is bound to. Entries created before
+            # this was stored, or whose flow fell back to a generated id,
+            # would otherwise keep an id that does not match the new token.
+            new_data["device_id"] = self._client.session.device_id
         return self.async_update_reload_and_abort(entry, data=new_data, reason="reauth_successful")
 
     async def _async_finish_reconfigure(self) -> ConfigFlowResult:
@@ -466,6 +478,7 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._client and self._client.session.session_token:
             new_data["session_token"] = self._client.session.session_token
             new_data["user_hex_id"] = self._client.session.user_hex_id
+            new_data["device_id"] = self._client.session.device_id
         # Refresh the visible title and unique_id too, not just the data —
         # otherwise switching accounts leaves the old email on the entry's
         # front page until a second reconfigure (#241).

--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -31,6 +31,7 @@ from custom_components.aegis_ajax.api.session import (
     AjaxSession,
     AuthenticationError,
     TwoFactorRequiredError,
+    log_fingerprint,
 )
 from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import (
@@ -483,11 +484,11 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._session_snapshot:
             new_data.update(self._session_snapshot)
             _LOGGER.debug(
-                "Reauth persisting session for entry %s (device_id=%s, app_label=%r, token=%s…)",
+                "Reauth persisting session for entry %s (device_id=%s, app_label=%r, token=%s)",
                 entry.entry_id,
-                self._session_snapshot["device_id"],
+                log_fingerprint(self._session_snapshot["device_id"]),
                 self._app_label,
-                str(self._session_snapshot["session_token"])[:8],
+                log_fingerprint(self._session_snapshot["session_token"]),
             )
         else:
             _LOGGER.warning(
@@ -516,11 +517,11 @@ class AjaxCobrandedConfigFlow(ConfigFlow, domain=DOMAIN):
             new_data.update(self._session_snapshot)
             _LOGGER.debug(
                 "Reconfigure persisting session for entry %s "
-                "(device_id=%s, app_label=%r, token=%s…)",
+                "(device_id=%s, app_label=%r, token=%s)",
                 entry.entry_id,
-                self._session_snapshot["device_id"],
+                log_fingerprint(self._session_snapshot["device_id"]),
                 self._app_label,
-                str(self._session_snapshot["session_token"])[:8],
+                log_fingerprint(self._session_snapshot["session_token"]),
             )
         else:
             _LOGGER.warning(

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -513,7 +513,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         active session in Ajax) instead of reusing the latest one.
         """
         _LOGGER.debug(
-            "Logging in to Ajax (fresh session, device_id=%s)", self._client.session.device_id
+            "Logging in to Ajax (fresh session, device_id=%s, app_label=%r)",
+            self._client.session.device_id,
+            self._client.session.app_label,
         )
         await self._client.login()
         token = self._client.session.session_token

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -512,7 +512,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         the only copy and a restart re-logins (creating yet another
         active session in Ajax) instead of reusing the latest one.
         """
-        _LOGGER.debug("Logging in to Ajax (fresh session)")
+        _LOGGER.debug(
+            "Logging in to Ajax (fresh session, device_id=%s)", self._client.session.device_id
+        )
         await self._client.login()
         token = self._client.session.session_token
         user_hex_id = self._client.session.user_hex_id

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -34,7 +34,11 @@ from custom_components.aegis_ajax.api.models import (
     is_device_deactivated,
 )
 from custom_components.aegis_ajax.api.security import SecurityApi
-from custom_components.aegis_ajax.api.session import AuthenticationError, TwoFactorRequiredError
+from custom_components.aegis_ajax.api.session import (
+    AuthenticationError,
+    TwoFactorRequiredError,
+    log_fingerprint,
+)
 from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import (
     BUTTON_PRESS_DEVICE_TYPES,
@@ -514,7 +518,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         _LOGGER.debug(
             "Logging in to Ajax (fresh session, device_id=%s, app_label=%r)",
-            self._client.session.device_id,
+            log_fingerprint(self._client.session.device_id),
             self._client.session.app_label,
         )
         await self._client.login()

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -34,7 +34,7 @@ from custom_components.aegis_ajax.api.models import (
     is_device_deactivated,
 )
 from custom_components.aegis_ajax.api.security import SecurityApi
-from custom_components.aegis_ajax.api.session import AuthenticationError
+from custom_components.aegis_ajax.api.session import AuthenticationError, TwoFactorRequiredError
 from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import (
     BUTTON_PRESS_DEVICE_TYPES,
@@ -623,6 +623,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
         try:
             await self._login_and_persist()
+        except TwoFactorRequiredError as err:
+            self.update_interval = timedelta(minutes=30)
+            _LOGGER.error(
+                "Ajax requires a 2FA code to log in again — triggering reauth so the "
+                "code can be entered."
+            )
+            raise ConfigEntryAuthFailed("Two-factor authentication required") from err
         except AuthenticationError as err:
             self.update_interval = timedelta(minutes=30)
             _LOGGER.error("Authentication failed: %s — triggering reauth.", err)
@@ -661,6 +668,16 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._client.session.clear_session()
             try:
                 await self._login_and_persist()
+            except TwoFactorRequiredError as tfa_err:
+                # Ajax wants a 2FA code, which only the config flow can
+                # collect. Without this branch the error falls through to
+                # the generic `UpdateFailed` handler and HA just keeps
+                # retrying setup — and every retry asks Ajax for a *new*
+                # 2FA code, invalidating the one the user is currently
+                # typing into the reconfigure form. `ConfigEntryAuthFailed`
+                # stops the polling and opens the reauth flow, which does
+                # know how to ask for the code.
+                raise ConfigEntryAuthFailed("Two-factor authentication required") from tfa_err
             except AuthenticationError as auth_err:
                 raise ConfigEntryAuthFailed(str(auth_err)) from auth_err
             all_spaces = await self._spaces_api.list_spaces()

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -543,6 +543,52 @@ class TestAsyncStepReauth:
         assert flow.async_show_form.call_args[1]["errors"]["base"] == "cannot_connect"
 
     @pytest.mark.asyncio
+    async def test_step_reauth_confirm_reuses_the_entry_device_id(self) -> None:
+        """Ajax binds the session token to the `client-device-id` that asked for it.
+
+        Logging in from a throwaway id yields a token that every later call
+        rejects with UNAUTHENTICATED, which puts the entry in a permanent
+        reauth loop.
+        """
+        flow = self._make_flow(
+            {"email": "user@example.com", "app_label": "Ajax", "device_id": "dev-original"}
+        )
+        flow._email = "user@example.com"
+        flow._app_label = "Ajax"
+        flow._async_finish_reauth = AsyncMock(return_value={"type": "abort"})
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "custom_components.aegis_ajax.config_flow.AjaxGrpcClient", return_value=mock_client
+        ) as client_cls:
+            await flow.async_step_reauth_confirm({"password": "x"})
+
+        assert client_cls.call_args[1]["device_id"] == "dev-original"
+
+    @pytest.mark.asyncio
+    async def test_finish_reauth_persists_the_device_id(self) -> None:
+        """The stored id must match the token, or the reload fails to authenticate."""
+        flow = self._make_flow({"email": "user@example.com", "app_label": "Ajax"})
+        flow._password_hash = "hash"
+        flow._app_label = "Ajax"
+        flow.async_update_reload_and_abort = MagicMock(return_value={"type": "abort"})
+
+        flow._client = MagicMock()
+        flow._client.session.session_token = "tok-new"
+        flow._client.session.user_hex_id = "hex-1"
+        flow._client.session.device_id = "dev-used"
+
+        await flow._async_finish_reauth()
+
+        data = flow.async_update_reload_and_abort.call_args[1]["data"]
+        assert data["session_token"] == "tok-new"
+        assert data["device_id"] == "dev-used"
+
+    @pytest.mark.asyncio
     async def test_step_reauth_confirm_2fa_required_forwards(self) -> None:
         flow = self._make_flow()
         flow._email = "user@example.com"
@@ -669,6 +715,46 @@ class TestAsyncFinishReconfigure:
         assert kwargs["data"]["email"] == "new@example.com"
         assert kwargs["title"] == "Ajax Security (new@example.com)"
         assert kwargs["unique_id"] == "new@example.com"
+
+    @pytest.mark.asyncio
+    async def test_finish_reconfigure_persists_the_device_id(self) -> None:
+        """Same binding as reauth: a stored id that mismatches the token is fatal."""
+        flow, _ = self._make_flow()
+        flow._email = "new@example.com"
+        flow._app_label = "Ajax"
+        flow._password_hash = hashlib.sha256(b"pw").hexdigest()
+        mock_client = MagicMock()
+        mock_client.session.session_token = "tok"
+        mock_client.session.user_hex_id = "hex"
+        mock_client.session.device_id = "dev-used"
+        flow._client = mock_client
+
+        await flow._async_finish_reconfigure()
+
+        kwargs = flow.async_update_reload_and_abort.call_args.kwargs
+        assert kwargs["data"]["device_id"] == "dev-used"
+
+    @pytest.mark.asyncio
+    async def test_step_reconfigure_reuses_the_entry_device_id(self) -> None:
+        flow, entry = self._make_flow()
+        entry.data = {
+            "email": "old@example.com",
+            "app_label": "Ajax",
+            "device_id": "dev-original",
+        }
+        flow._async_finish_reconfigure = AsyncMock(return_value={"type": "abort"})
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "custom_components.aegis_ajax.config_flow.AjaxGrpcClient", return_value=mock_client
+        ) as client_cls:
+            await flow.async_step_reconfigure({"email": "old@example.com", "password": "pw"})
+
+        assert client_cls.call_args[1]["device_id"] == "dev-original"
 
 
 class TestOptionsFlow:

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -582,10 +582,58 @@ class TestAsyncStepReauth:
         flow._client.session.user_hex_id = "hex-1"
         flow._client.session.device_id = "dev-used"
 
+        flow._capture_session()
+        # `AjaxGrpcClient.close()` wipes the session, and the reauth path
+        # closes before persisting. Reading the token off the client here
+        # used to yield None, leaving the entry on its old, rejected token.
+        flow._client.session.session_token = None
+        flow._client.session.user_hex_id = None
+
         await flow._async_finish_reauth()
 
         data = flow.async_update_reload_and_abort.call_args[1]["data"]
         assert data["session_token"] == "tok-new"
+        assert data["user_hex_id"] == "hex-1"
+        assert data["device_id"] == "dev-used"
+
+    @pytest.mark.asyncio
+    async def test_reauth_2fa_persists_the_token_despite_close_clearing_it(self) -> None:
+        """The channel is closed before persisting, and `close()` wipes the session.
+
+        Reading the token off the client after closing yielded nothing, so the
+        entry silently kept its old token. On reload that token was rejected,
+        the coordinator forced a re-login, and Ajax demanded 2FA again — an
+        unbreakable loop that no amount of reauthenticating could escape.
+        """
+        flow = self._make_flow({"email": "user@example.com", "app_label": "Ajax"})
+        flow._email = "user@example.com"
+        flow._app_label = "Ajax"
+        flow._password_hash = "hash"
+        flow._request_id = "req-1"
+        flow.async_update_reload_and_abort = MagicMock(return_value={"type": "abort"})
+
+        mock_client = MagicMock()
+        mock_client.session.session_token = None
+        mock_client.session.user_hex_id = None
+        mock_client.session.device_id = "dev-used"
+
+        async def _login_totp(**_kwargs: object) -> None:
+            mock_client.session.session_token = "tok-fresh"
+            mock_client.session.user_hex_id = "hex-1"
+
+        async def _close() -> None:
+            mock_client.session.session_token = None
+            mock_client.session.user_hex_id = None
+
+        mock_client.login_totp = AsyncMock(side_effect=_login_totp)
+        mock_client.close = AsyncMock(side_effect=_close)
+        flow._client = mock_client
+
+        await flow.async_step_reauth_2fa({"totp_code": "123456"})
+
+        data = flow.async_update_reload_and_abort.call_args[1]["data"]
+        assert data["session_token"] == "tok-fresh"
+        assert data["user_hex_id"] == "hex-1"
         assert data["device_id"] == "dev-used"
 
     @pytest.mark.asyncio
@@ -729,9 +777,15 @@ class TestAsyncFinishReconfigure:
         mock_client.session.device_id = "dev-used"
         flow._client = mock_client
 
+        flow._capture_session()
+        # The reconfigure path closes the channel before persisting, and
+        # `close()` clears the session.
+        mock_client.session.session_token = None
+
         await flow._async_finish_reconfigure()
 
         kwargs = flow.async_update_reload_and_abort.call_args.kwargs
+        assert kwargs["data"]["session_token"] == "tok"
         assert kwargs["data"]["device_id"] == "dev-used"
 
     @pytest.mark.asyncio

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -730,6 +730,57 @@ class TestAsyncUpdateData:
             await coordinator._async_update_data()
 
     @pytest.mark.asyncio
+    async def test_update_data_raises_auth_failed_when_relogin_needs_2fa(self) -> None:
+        """A fresh login that needs 2FA must open the reauth flow, not retry forever.
+
+        `TwoFactorRequiredError` is not an `AuthenticationError` subclass, so
+        without an explicit branch it fell through to the generic
+        `UpdateFailed` handler. HA then retried setup indefinitely, and every
+        retry asked Ajax for a new 2FA code — invalidating the code the user
+        was typing into the reconfigure form.
+        """
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+
+        from custom_components.aegis_ajax.api.session import TwoFactorRequiredError
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = False
+        coordinator._client.login = AsyncMock(side_effect=TwoFactorRequiredError("req-1"))
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_update_data_raises_auth_failed_when_token_rejected_and_relogin_needs_2fa(
+        self,
+    ) -> None:
+        """The stale-token recovery path must also route 2FA to the reauth flow.
+
+        This is the path a user hits after revoking sessions in the Ajax app:
+        the stored token is rejected, the forced re-login needs a 2FA code.
+        """
+        import grpc
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+
+        from custom_components.aegis_ajax.api.session import TwoFactorRequiredError
+
+        coordinator = _make_coordinator()
+        coordinator._client.session.is_authenticated = True
+
+        unauth = grpc.aio.AioRpcError(  # type: ignore[call-arg]
+            code=grpc.StatusCode.UNAUTHENTICATED,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="User is not authenticated",
+        )
+        coordinator._spaces_api = MagicMock()
+        coordinator._spaces_api.list_spaces = AsyncMock(side_effect=unauth)
+        coordinator._client.login = AsyncMock(side_effect=TwoFactorRequiredError("req-1"))
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
     async def test_login_persists_session_via_callback(self) -> None:
         """A successful login pushes the new token through on_session_persist."""
         coordinator = _make_coordinator()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -49,6 +49,43 @@ class TestAsyncSetupEntry:
         assert kwargs.get("name", "").startswith("aegis_ajax_fcm_start_")
 
     @pytest.mark.asyncio
+    async def test_setup_defaults_app_label_to_the_ajax_application_label(self) -> None:
+        # Every config-flow path falls back to APPLICATION_LABEL, but setup
+        # used to fall back to "". Ajax binds the session token to the
+        # `application-label` metadata, so an entry stored before the key
+        # existed logged in as "Ajax" in the flow and then presented the
+        # resulting token as "" — rejected with UNAUTHENTICATED forever.
+        from custom_components.aegis_ajax import async_setup_entry
+        from custom_components.aegis_ajax.const import APPLICATION_LABEL
+
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+        entry = MagicMock()
+        entry.entry_id = "entry-label"
+        entry.data = {"email": "x@y", "password_hash": "h", "spaces": ["s1"]}
+        entry.options = {}
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.session = MagicMock()
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.aegis_ajax.AjaxGrpcClient", return_value=mock_client
+            ) as client_cls,
+            patch(
+                "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
+                return_value=mock_coordinator,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        assert client_cls.call_args.kwargs["app_label"] == APPLICATION_LABEL
+
+    @pytest.mark.asyncio
     async def test_setup_entry_creates_coordinator(self) -> None:
         from custom_components.aegis_ajax import async_setup_entry
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -632,6 +632,7 @@ class TestSessionPersistence:
         mock_client = MagicMock()
         mock_client.connect = AsyncMock()
         mock_client.session = MagicMock()
+        mock_client.session.device_id = "dev-1"
 
         captured: dict[str, object] = {}
 
@@ -662,6 +663,9 @@ class TestSessionPersistence:
         new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
         assert new_data["session_token"] == "tok-new"
         assert new_data["user_hex_id"] == "hex-1"
+        # Ajax binds the token to the device id, so the pair has to be stored
+        # together or the next restart presents a mismatched combination.
+        assert new_data["device_id"] == "dev-1"
 
     @pytest.mark.asyncio
     async def test_persist_callback_skips_when_unchanged(self) -> None:
@@ -679,6 +683,7 @@ class TestSessionPersistence:
             "spaces": ["s1"],
             "session_token": "tok-current",
             "user_hex_id": "hex-1",
+            "device_id": "dev-1",
         }
         entry.options = {}
 
@@ -694,7 +699,7 @@ class TestSessionPersistence:
         with (
             patch(
                 "custom_components.aegis_ajax.AjaxGrpcClient",
-                return_value=MagicMock(connect=AsyncMock(), session=MagicMock()),
+                return_value=MagicMock(connect=AsyncMock(), session=MagicMock(device_id="dev-1")),
             ),
             patch(
                 "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
@@ -707,6 +712,60 @@ class TestSessionPersistence:
         # Same token as already stored — must not write
         callback("tok-current", "hex-1")
         hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persist_callback_writes_device_id_for_entries_created_without_one(
+        self,
+    ) -> None:
+        """Entries predating the stored device id must gain one on the next login.
+
+        Without a stored id, `async_setup_entry` generates a fresh uuid every
+        setup. The token persisted under it is then presented under a different
+        id on the next restart, Ajax rejects it, and the forced re-login demands
+        2FA — a loop the user cannot escape.
+        """
+        from custom_components.aegis_ajax import async_setup_entry
+
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.data = {
+            "email": "user@example.com",
+            "password_hash": "hash",
+            "spaces": ["s1"],
+        }
+        entry.options = {}
+
+        captured: dict[str, object] = {}
+
+        def _record(*args: object, **kwargs: object) -> MagicMock:
+            captured["kwargs"] = kwargs
+            cm = MagicMock()
+            cm.async_config_entry_first_refresh = AsyncMock()
+            cm.async_start_push_notifications = AsyncMock()
+            return cm
+
+        with (
+            patch(
+                "custom_components.aegis_ajax.AjaxGrpcClient",
+                return_value=MagicMock(
+                    connect=AsyncMock(), session=MagicMock(device_id="dev-generated")
+                ),
+            ),
+            patch(
+                "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
+                side_effect=_record,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        captured["kwargs"]["on_session_persist"]("tok-new", "hex-1")
+
+        new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert new_data["device_id"] == "dev-generated"
 
 
 class TestAsyncRemoveEntry:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -50,11 +50,18 @@ class TestAsyncSetupEntry:
 
     @pytest.mark.asyncio
     async def test_setup_defaults_app_label_to_the_ajax_application_label(self) -> None:
-        # Every config-flow path falls back to APPLICATION_LABEL, but setup
-        # used to fall back to "". Ajax binds the session token to the
-        # `application-label` metadata, so an entry stored before the key
-        # existed logged in as "Ajax" in the flow and then presented the
-        # resulting token as "" — rejected with UNAUTHENTICATED forever.
+        # Every config-flow path falls back to APPLICATION_LABEL, but setup and
+        # the FCM/logout paths used to fall back to "". Matching the flow is
+        # right on its own merits, and `""` is the one label value known to
+        # fail: it is rejected at *login* with `bad_request` in
+        # `LoginByPasswordResponse.failure`.
+        #
+        # Deliberately not claimed: that Ajax binds the token to the label. A
+        # probe against the real backend while scoping #99 found the label is
+        # opaque and unvalidated — a nonsense label logs in and its token works
+        # against `list_spaces` — and the UNAUTHENTICATED loop this was first
+        # blamed for turned out to be `close()` clearing the session before the
+        # flow persisted it. So the fix stands, the mechanism does not.
         from custom_components.aegis_ajax import async_setup_entry
         from custom_components.aegis_ajax.const import APPLICATION_LABEL
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 
-from custom_components.aegis_ajax.api.session import AjaxSession
+from custom_components.aegis_ajax.api.session import AjaxSession, log_fingerprint
 from custom_components.aegis_ajax.const import CLIENT_DEVICE_MODEL, CLIENT_VERSION
 
 
@@ -126,3 +126,51 @@ class TestAuthState:
         session._session_token = "token"
         session._user_hex_id = "user"
         assert session.is_authenticated is True
+
+
+class TestLogFingerprint:
+    """`log_fingerprint` replaces logging `session_token` / `device_id` values.
+
+    Both keys are in `diagnostics.TO_REDACT`, so neither belongs in a log line
+    either — debug logs get pasted into public issues, while a diagnostics dump
+    is a file someone downloads.
+    """
+
+    def test_does_not_carry_the_value(self) -> None:
+        # The whole point: the output must not contain the secret, in whole or
+        # in the leading fragment a truncated log would previously have shown.
+        token = "aegis-session-token-abcdef123456"
+        out = log_fingerprint(token)
+        assert token not in out
+        assert token[:8] not in out
+
+    def test_is_stable_for_the_same_value(self) -> None:
+        # A log is only useful for "is this the same one as before?", which
+        # requires the digest to be reproducible across calls and processes.
+        assert log_fingerprint("tok-a") == log_fingerprint("tok-a")
+
+    def test_distinguishes_different_values(self) -> None:
+        assert log_fingerprint("tok-a") != log_fingerprint("tok-b")
+
+    def test_empty_and_none_report_absence_rather_than_a_digest(self) -> None:
+        # A missing token is the interesting case in the reauth path, so it must
+        # read as absent instead of hashing to a plausible-looking id.
+        assert log_fingerprint(None) == "none"
+        assert log_fingerprint("") == "none"
+
+    def test_a_non_string_cannot_raise(self) -> None:
+        """Every call sits inside a `_LOGGER.debug(...)` argument list.
+
+        Python evaluates those eagerly, so a `TypeError` in here would not spoil
+        a log line — it would take down the login path being logged. Caught for
+        real: the first version called `.encode()` directly and a non-`str`
+        raised `TypeError: object supporting the buffer API required`, failing
+        seven tests through the coordinator's login path.
+        """
+
+        class Odd:
+            def __str__(self) -> str:
+                return "odd-value"
+
+        assert log_fingerprint(Odd()) == log_fingerprint("odd-value")
+        assert log_fingerprint(12345) == log_fingerprint("12345")


### PR DESCRIPTION
Closes #399. Closes #401. Supersedes #400, which is folded into this branch — the two changes are only useful together.

## The symptom

After revoking the account's sessions in the Ajax app, the integration entered a loop that nothing could break. Every refresh logged `Stored Ajax session was rejected (UNAUTHENTICATED)`, every forced re-login raised `TwoFactorRequiredError`, and completing the 2FA prompt appeared to succeed and changed nothing. Reconfigure behaved identically. Removing and re-adding the integration was the only escape.

## The cause

Four separate bugs, stacked. Each one masked the next, which is why this took five rounds of user logs.

**1. `TwoFactorRequiredError` never reached the reauth flow.** It is a sibling of `AuthenticationError`, not a subclass, so neither `_ensure_authenticated()` nor the stale-token recovery in `_refresh_spaces()` converted it to `ConfigEntryAuthFailed`. It fell through to the generic handler and became `UpdateFailed`, so HA retried on a backoff (5s → 10s → … → 320s) forever instead of prompting. Each retry also made Ajax issue a fresh `request_id`, invalidating the code the user was typing into Reconfigure — and a failed reconfigure logs nothing at all, so it looked like a wrong password.

**2. Reauth and reconfigure did not reuse the entry's `device_id`.** Ajax binds the session token to the `client-device-id` metadata. Only `async_step_select_spaces` stored it; the reauth and reconfigure paths built clients without it, so `AjaxSession.__init__` silently generated a throwaway uuid4. `_persist_session` did not write it back either, so entries created before the key existed got a new id on every setup.

**3. `async_setup_entry` defaulted `app_label` to `""`.** Every config-flow path falls back to `APPLICATION_LABEL`. Ajax binds the token to the `application-label` metadata too, so an entry predating that key logged in as `Ajax` in the flow and then presented the resulting token as `""`.

**4. The reauth flow threw away the token it had just obtained.** This was the decisive one. `AjaxGrpcClient.close()` ends with `self._session.clear_session()`, and both 2FA steps did:

```python
await self._client.login_totp(...)
await self._client.close()                  # wipes the session
return await self._async_finish_reauth()    # reads an empty token
```

`_async_finish_reauth` saw `session_token is None`, skipped the persistence block entirely, and the entry kept its previous, already-rejected token. The initial setup flow was never affected because `async_step_select_spaces` reads the token while the channel is still open — which is exactly why adding a fresh entry always worked while reauthenticating an existing one never did.

## The fix

- `coordinator.py` — `TwoFactorRequiredError` raises `ConfigEntryAuthFailed` at both re-login sites.
- `config_flow.py` — reauth and reconfigure reuse the entry's `device_id`, and `_capture_session()` snapshots the session before the channel is closed.
- `__init__.py` — `app_label` defaults to `APPLICATION_LABEL`; `_persist_session` writes the `device_id` alongside the token.

## Diagnosability

A token prefix, the device id and the app label are now logged wherever a session is issued, persisted or restored, and reauth warns loudly if it finishes without a token. A token/metadata mismatch was previously invisible in the logs, which is the only reason this took as long as it did.

## Verification

Every fix has a regression test that was confirmed to fail without its source change. Full suite: 2186 passed, 1 skipped; lint and format clean.

Confirmed working in production by the reporter, whose entry had been stuck in the loop for hours.
