### PR TITLE
Stop the SpaceControl probe logging once a minute, and watch the activation-flag candidates

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -211,6 +211,31 @@ _HTS_SPACE_CONTROL_SETTINGS_KEYS: dict[int, str] = {
     0x35: "false_press_filter",
     0xC3: "subtype",
 }
+# `0xC3` cannot gate the settings probe: it rides the 60 s STATUS_BODY row as
+# well as the settings row, so gating on the whole dict above left `present`
+# permanently non-empty and the probe logged once a minute forever — measured by
+# @wip3out3r on a modeled SpaceControl, five of six lines carrying nothing but
+# `subtype` (#311). The other five keys appear only on the settings row, so
+# requiring one of *them* is what makes the early-out do what it claims.
+# `subtype` still rides along in the output when it is present.
+_HTS_SPACE_CONTROL_GATING_KEYS: frozenset[int] = frozenset(
+    _HTS_SPACE_CONTROL_SETTINGS_KEYS.keys() - {0xC3}
+)
+# The `0x0b..0x0e` quartet that the HTS-only keyfob path reads its experimental
+# `Active` flag from (`keyfobs.KEYFOB_ACTIVE_SUBKEY` is `0x0b`). Tracked here
+# because @wip3out3r found `0x0b` present on a *modeled* SpaceControl's status
+# row reading `01` (#311). The reasoning until then was that a modeled
+# SpaceControl never reaches the keyfob path, so the flag was unavailable on this
+# class of hub; if this is the same byte, such a hub can supply the deactivated
+# sample after all, from a row we already parse.
+#
+# Whether it IS the same byte is exactly what a deactivated capture would settle,
+# and it is not assumed: the `0x40` precedent — a 4-byte epoch on one family, a
+# 1-byte counter on another — is why a sub-key number matching across families is
+# not evidence on its own. These live on the status row, which is why they are
+# logged on *change* rather than on the settings gate above; the two rows are
+# disjoint in the keys that matter.
+_HTS_SPACE_CONTROL_FLAG_CANDIDATE_KEYS: tuple[int, ...] = (0x0B, 0x0C, 0x0D, 0x0E)
 # The two `ObjectType` cases a keyfob arrives as when the snapshot models it.
 _SPACE_CONTROL_DEVICE_TYPES: frozenset[str] = frozenset({"space_control", "space_control_s"})
 
@@ -437,6 +462,14 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # key lives only in deltas, and there its first sighting IS the event
         # rather than a baseline to swallow (#348).
         self._hts_button_activity_bodies_seen: set[str] = set()
+        # Last-seen value of each SpaceControl activation-flag candidate (#311),
+        # keyed by `(device_id_hex, kv_key)`. Same change-only contract as the
+        # Button cache above and for a sharper reason: the flag is expected to
+        # read `01` on every active keyfob, so a value-per-poll log would say
+        # nothing while a *transition* is the one sample this issue has always
+        # lacked. An active keyfob therefore stays silent indefinitely and the
+        # line appears at the moment a CRA admin deactivates one.
+        self._hts_space_control_flags: dict[tuple[str, int], str] = {}
         # One-shot guard for the #206 Bug-B SmartLock id probe (DEBUG-only).
         self._smart_lock_probe_done = False
         # Per-space monotonic timestamp of when the hub first reported
@@ -1356,6 +1389,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # placement rationale as the bypass probe: this hub class never reaches
         # the keyfob path, so this is the only place its row is ever visible.
         self._log_hts_space_control_settings(device_id_hex, device, kv)
+        # The same device's activation-flag candidates (#311), which ride the
+        # status row rather than the settings row — disjoint from the keys above,
+        # hence a separate probe with a change-only contract.
+        self._log_hts_space_control_flag_transitions(device_id_hex, device, kv)
         # Button activity-timestamp candidate keys (#348) — read-only, same
         # placement rationale as the bypass probe above: every device family
         # gets probed, and the keys are Button-specific in every capture so far.
@@ -1473,18 +1510,23 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         list (numbers only, no values) rides along so a capture shows whether
         the row's shape moved, without putting any field's contents in a log.
 
-        Silent when the row carries none of the settings keys, so the 60 s
-        status rows for the same device add no noise.
+        Gated on `_HTS_SPACE_CONTROL_GATING_KEYS` — the settings keys *minus*
+        `0xC3`. Gating on the full set did not deliver the silence this docstring
+        used to claim: `subtype` rides the 60 s status row too, so `present` was
+        never empty and the probe logged a line a minute indefinitely, five of
+        every six carrying nothing but `subtype` (measured by @wip3out3r, #311).
+        The remaining five keys are settings-row-only, so a status row now
+        returns early while a settings row still logs every field it carries.
         """
         if device.device_type not in _SPACE_CONTROL_DEVICE_TYPES:
+            return
+        if not any(key in kv for key in _HTS_SPACE_CONTROL_GATING_KEYS):
             return
         present = {
             name: kv[key].hex()
             for key, name in _HTS_SPACE_CONTROL_SETTINGS_KEYS.items()
             if key in kv
         }
-        if not present:
-            return
         _LOGGER.debug(
             "HTS SpaceControl probe: device=%s type=%s settings=%s row_keys=%s "
             "deactivated=%s kinds=%s",
@@ -1495,6 +1537,55 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             is_device_deactivated(device),
             device_deactivation_kinds(device),
         )
+
+    def _log_hts_space_control_flag_transitions(
+        self, device_id_hex: str, device: Device, kv: dict[int, bytes]
+    ) -> None:
+        """DEBUG-log a modeled SpaceControl's activation-flag candidates on change (#311).
+
+        Read-only, and change-only by design — see
+        `_HTS_SPACE_CONTROL_FLAG_CANDIDATE_KEYS` for why these four keys are
+        worth watching on a device class that never reaches the keyfob path.
+
+        The change-only contract is what makes this cost nothing. Every keyfob
+        observed so far reads `0x0b == 0x01`, so logging the value on each 60 s
+        status row would repeat a constant forever — the same noise this probe's
+        sibling was just fixed for. A transition is the sample #311 has always
+        lacked: no `inactive` capture exists, because only a CRA admin can
+        deactivate a keyfob and we have never had a log spanning one. So an
+        active keyfob stays silent indefinitely, and the line appears at the
+        exact moment the flag moves.
+
+        A first sighting is recorded silently. The status row re-reports the same
+        constant at every poll and after every restart, so treating a first
+        sighting as an event would announce a deactivation that never happened —
+        the same trap `_maybe_fire_button_press` guards against.
+
+        Runs on the event loop (HTS listen task).
+        """
+        if device.device_type not in _SPACE_CONTROL_DEVICE_TYPES:
+            return
+        for key in _HTS_SPACE_CONTROL_FLAG_CANDIDATE_KEYS:
+            value = kv.get(key)
+            if value is None:
+                continue
+            current = value.hex()
+            cache_key = (device_id_hex, key)
+            previous = self._hts_space_control_flags.get(cache_key)
+            self._hts_space_control_flags[cache_key] = current
+            if previous is None or previous == current:
+                continue
+            _LOGGER.debug(
+                "HTS SpaceControl flag probe: device=%s type=%s key=0x%02X %s -> %s "
+                "deactivated=%s kinds=%s",
+                device_id_hex,
+                device.device_type,
+                key,
+                previous,
+                current,
+                is_device_deactivated(device),
+                device_deactivation_kinds(device),
+            )
 
     def _log_hts_button_activity_candidates(
         self, device_id_hex: str, device: Device, kv: dict[int, bytes], *, from_body: bool = False

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -29,6 +29,7 @@ from custom_components.aegis_ajax.const import (
     DeviceState,
     SecurityState,
 )
+from custom_components.aegis_ajax.coordinator import _HTS_SPACE_CONTROL_GATING_KEYS
 
 
 def _make_space(space_id: str = "s1") -> Space:
@@ -3895,6 +3896,30 @@ _MODELED_SPACE_CONTROL_ROW_KEYS = (
 )  # fmt: skip
 
 
+# The *other* row the same device emits (#311): the 22-key STATUS_BODY row,
+# arriving every 60 s. Unlike the settings row above these are @wip3out3r's real
+# bytes, which he pasted in full — device flags and counters, nothing user-typed.
+#
+# Two things make this fixture worth having rather than an invented status row.
+# `0xC3` is on it, which is what defeated the settings probe's early-out; a
+# hand-written status row omitted `0xC3` and so the suite reported silence the
+# real hardware never had. And `0x0b` is on it reading `01` — the same sub-key
+# the HTS-only keyfob path reads its experimental `Active` flag from.
+_MODELED_SPACE_CONTROL_STATUS_ROW: dict[int, bytes] = {
+    0x02: b"\x80", 0x03: b"\x03", 0x04: b"\x80", 0x05: b"\x00\x64",
+    0x06: b"\x00\x00", 0x07: b"\x80\x00\x00\x00", 0x0B: b"\x01", 0x0C: b"\x01",
+    0x0E: b"\x80", 0x0F: b"\x00", 0x10: b"\x00", 0x17: b"\x00\x00\x00\x00",
+    0x2C: b"\x01", 0x99: b"\x19", 0x9F: b"\x00", 0xB7: b"\x00",
+    0xC2: b"\x80", 0xC3: b"\x00", 0xC6: b"\x00", 0xF5: b"\x00",
+    0xF7: b"\x00", 0xF9: b"\x80",
+}  # fmt: skip
+
+
+def _modeled_space_control_status_kv() -> dict[int, bytes]:
+    """The 60 s STATUS_BODY row for a modeled SpaceControl, as captured (#311)."""
+    return dict(_MODELED_SPACE_CONTROL_STATUS_ROW)
+
+
 def _modeled_space_control_kv() -> dict[int, bytes]:
     """A modeled SpaceControl's SETTINGS_BODY row, in @wip3out3r's shape (#311)."""
     row = {key: b"\x00" for key in _MODELED_SPACE_CONTROL_ROW_KEYS}
@@ -4012,6 +4037,140 @@ class TestModeledSpaceControlIsNotAKeyfobRow:
             coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", {0x04: b"\x00", 0x06: b"\x01"})
 
         assert "HTS SpaceControl probe" not in caplog.text
+
+    def test_the_real_status_row_carries_subtype_so_it_cannot_gate_the_probe(self) -> None:
+        # Provenance for the gate. `0xC3` is on *both* rows, which is why gating
+        # on the full settings dict could never go silent — and why the row above
+        # this one, written by hand without `0xC3`, reported a silence the
+        # hardware never had.
+        status = _modeled_space_control_status_kv()
+        settings = _modeled_space_control_kv()
+        assert 0xC3 in status
+        assert 0xC3 in settings
+        assert _HTS_SPACE_CONTROL_GATING_KEYS.isdisjoint(status)
+        assert 0xC3 not in _HTS_SPACE_CONTROL_GATING_KEYS
+
+    def test_probe_is_silent_for_the_real_60s_status_row(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The regression @wip3out3r measured: a line a minute, indefinitely (#311).
+
+        His hub emitted six probe lines in four minutes, the last four exactly
+        60 s apart, five of the six carrying nothing but `subtype`. This is that
+        row verbatim, so the assertion fails against the old gate.
+        """
+        coordinator = _make_coordinator()
+        coordinator.devices["2ACCB91C"] = self._make_space_control()
+        coordinator.async_set_updated_data = MagicMock()
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv(
+                "002B1A51", "2ACCB91C", _modeled_space_control_status_kv()
+            )
+
+        assert "HTS SpaceControl probe" not in caplog.text
+
+
+class TestModeledSpaceControlFlagTransitions:
+    """#311: the activation-flag candidates on a modeled SpaceControl's status row.
+
+    @wip3out3r found `0x0b` reading `01` on a gRPC-modeled SpaceControl — the
+    same sub-key the HTS-only keyfob path reads its experimental `Active` flag
+    from. If it is the same byte, this hub class can supply the deactivated
+    sample #311 has always needed, from a row already parsed. These tests pin the
+    change-only contract, not the interpretation: whether the two are the same
+    byte is what a deactivated capture would settle, and the `0x40` precedent is
+    why a matching sub-key number is not treated as evidence on its own.
+    """
+
+    def _make_space_control(self, device_type: str = "space_control") -> Device:
+        return Device(
+            id="2ACCB91C",
+            hub_id="hub-1",
+            name="Keyfob",
+            device_type=device_type,
+            room_id=None,
+            group_id="g1",
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    def _feed(self, coordinator: AjaxCobrandedCoordinator, kv: dict[int, bytes]) -> None:  # noqa: F821
+        coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", kv)
+
+    def test_first_sighting_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        # The status row re-reports the same constant at every poll and after
+        # every restart, so a first sighting must not be announced as a change.
+        coordinator = _make_coordinator()
+        coordinator.devices["2ACCB91C"] = self._make_space_control()
+        coordinator.async_set_updated_data = MagicMock()
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            self._feed(coordinator, _modeled_space_control_status_kv())
+
+        assert "HTS SpaceControl flag probe" not in caplog.text
+
+    def test_an_unchanged_flag_stays_silent_across_polls(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The point of the change-only contract: an active keyfob reads 01
+        # forever, so repeated polls must add nothing.
+        coordinator = _make_coordinator()
+        coordinator.devices["2ACCB91C"] = self._make_space_control()
+        coordinator.async_set_updated_data = MagicMock()
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            for _ in range(5):
+                self._feed(coordinator, _modeled_space_control_status_kv())
+
+        assert "HTS SpaceControl flag probe" not in caplog.text
+
+    def test_a_flag_transition_is_logged_with_the_deactivation_state(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The one event this probe exists for: `0x0b` moving off `01`."""
+        coordinator = _make_coordinator()
+        coordinator.devices["2ACCB91C"] = self._make_space_control()
+        coordinator.async_set_updated_data = MagicMock()
+        self._feed(coordinator, _modeled_space_control_status_kv())
+
+        deactivated = _modeled_space_control_status_kv()
+        deactivated[0x0B] = b"\x00"
+        coordinator.devices["2ACCB91C"] = replace(
+            self._make_space_control(),
+            statuses={"temporary_deactivation_whole": True, "deactivated": True},
+        )
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            self._feed(coordinator, deactivated)
+
+        assert "HTS SpaceControl flag probe" in caplog.text
+        assert "key=0x0B 01 -> 00" in caplog.text
+        # Without the deactivation state alongside it, a transition cannot be
+        # told apart from an unrelated flag flip — same pairing as the bypass
+        # and settings probes.
+        assert "deactivated=True" in caplog.text
+
+    def test_probe_is_silent_for_other_device_families(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # `0x0b..0x0e` carry unrelated things on other families, so this stays
+        # gated by device type rather than by shape.
+        coordinator = _make_coordinator()
+        coordinator.devices["003AE89B"] = _make_device(device_id="003AE89B")
+        coordinator.async_set_updated_data = MagicMock()
+
+        row = _modeled_space_control_status_kv()
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("002B1A51", "003AE89B", row)
+            moved = dict(row)
+            moved[0x0B] = b"\x00"
+            coordinator._on_hts_device_kv("002B1A51", "003AE89B", moved)
+
+        assert "HTS SpaceControl flag probe" not in caplog.text
 
 
 class TestOnHtsDeviceKvSpaceSecurity:


### PR DESCRIPTION
Both halves reported by @wip3out3r on `1.16.0-beta.6` in #311, after he answered the yes/no question the probe was built for.

## The noise

The probe was gated on all six SpaceControl settings keys, but `0xC3` (`subtype`) rides the 60 s `STATUS_BODY` row as well as the settings row. So `present` was never empty, the early-out never fired, and the probe logged a line a minute indefinitely — five of every six carrying nothing but `subtype`. He measured six lines in four minutes, the last four exactly 60 s apart, rather than inferring it.

It now gates on the five settings-row-only keys. `subtype` still rides along in the output when it is present, so no capture loses anything.

**The docstring already claimed this silence,** and the old test agreed with it — because the test's status row was written by hand and happened to omit `0xC3`. The real 22-key row is now a fixture, so the suite fails against the old gate. That is the second time an invented fixture has hidden a shape collision that a real capture would have caught.

## The lead that came with it

`0x0b` is present on that status row reading `01`. That is the sub-key the HTS-only keyfob path reads its experimental `Active` flag from (`KEYFOB_ACTIVE_SUBKEY`), on a device class the reasoning so far held could never supply it — a modeled SpaceControl never reaches the keyfob path, which is why his install has the bypass switch and no `Active` entity.

If it is the same byte, then a hub of this class can supply the deactivated sample #311 has been blocked on since it opened, from a row we already parse. That would widen the pool from "someone with an HTS-only keyfob and a monitoring company" to "anyone with a SpaceControl and a monitoring company".

**It is not assumed to be the same byte.** His own caution is the right one and I have kept it in the code: the `0x40` precedent — a 4-byte epoch on one family, a 1-byte counter on another — is why a sub-key number matching across families is not evidence on its own. A deactivated capture is what would settle it, and that is exactly what this probe now makes collectable.

So the quartet `0x0b..0x0e` is logged **on change only**, which is what makes it cost nothing:

- Every keyfob observed reads `0x0b == 01`, so a value-per-poll log would repeat a constant forever — the noise just fixed above.
- A first sighting is silent, so a restart cannot be mistaken for a deactivation. Same trap `_maybe_fire_button_press` guards against.
- An active keyfob therefore stays silent indefinitely, and a line appears at the moment a CRA admin deactivates one.

The deactivation state rides on the transition line, for the same reason the bypass and settings probes pair it: a flag flip on its own cannot be told apart from an unrelated one.

## Tests

Six new, each verified to fail against a specific break rather than just passing:

| Break | What fails |
|---|---|
| `0xC3` back in the gating set | the real-status-row silence test, and the provenance test asserting `0xC3` is on both rows |
| flag probe logs first sighting | first-sighting-silent, unchanged-across-5-polls |
| flag probe unwired from the kv path | the transition test |

Full local gate green: `ruff`, `ruff format`, `mypy`, `vulture`, 2183 passed, coverage 90.42%.

Read-only throughout — no entity, state, or command path is touched. Relates to #311.
