### PR TITLE
Keep battery and signal strength across a device snapshot, and make the snapshot observable

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -143,6 +143,45 @@ _TAMPER_SOURCE_KEYS: dict[str, str] = {
 # so a reporter on DEBUG can confirm the semantics on their own hardware.
 _HTS_TAMPER_CANDIDATE_KEYS: tuple[int, ...] = (0x04, 0x0F)
 
+# Per-device *measurements* carried across a full device snapshot that omits
+# them (#403). `_handle_devices_snapshot` rebuilds each device from the snapshot,
+# so a reading the stream does not repeat is gone until that device next sends
+# one — and a battery sitting at 100% has nothing to send, which is why it is the
+# reading that never comes back. @wip3out3r measured 1 of 13 batteries and 1 of
+# 11 signal strengths still empty four hours later, while the only two devices
+# that already had a carry-forward kept their values throughout. That contrast is
+# what identified this function rather than the HTS disconnect handler, which
+# preserves its caches by design.
+#
+# Named, rather than a blanket "merge instead of replace", because most of what
+# rides in `statuses` must NOT survive a snapshot: `lid_opened`, `case_drilling`
+# and `gsm_connected` are operational alerts, and an alert that has cleared has
+# to clear here too. Membership follows the rule the report states better than we
+# had: a snapshot omitting a *measurement* does not make the previous value
+# wrong, only older. Anything whose absence is itself the signal stays out.
+#
+# `temperature` is deliberately NOT here, and that leaves part of #403 unfixed.
+# Seven of his nine temperatures emptied — the light-stream families, which the
+# block below does not cover because it is gated on
+# `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES`. Adding it here fixes those, and it also
+# breaks `test_snapshot_does_not_invent_temperature_for_non_siren`, which pins the
+# opposite on purpose: a family with no per-device temperature source must not end
+# up holding one. Carrying only a value the device previously reported is not
+# "inventing" it, so the two may well be reconcilable — but overturning a pinned
+# decision wants evidence, not a convenient reading, and the warm-start cache
+# (#114) is a real way a bad value could become immortal once it is sticky. Left
+# open on the issue rather than settled here.
+#
+# `tamper` and the siren settings keep their own blocks below — they carry
+# provenance conditions this generic pass has no business reproducing.
+_SNAPSHOT_CARRY_FORWARD_STATUS_KEYS: frozenset[str] = frozenset(
+    {
+        "humidity",
+        "co2",
+        "signal_strength",
+    }
+)
+
 # HTS per-device kv keys that may carry the device's bypass configuration
 # (#338) — read-only probe, nothing is routed off them.
 #
@@ -2192,7 +2231,23 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     def _handle_devices_snapshot(self, devices: list[Device]) -> None:
-        """Handle initial snapshot or full device snapshot update from stream."""
+        """Handle initial snapshot or full device snapshot update from stream.
+
+        Emits one DEBUG line per snapshot, which is the observable this path was
+        missing entirely (#403). @wip3out3r went looking for it and found there
+        was nothing to find at any log level: `Device stream started for space`
+        fires once per coordinator lifetime so an in-task reconnect never emits
+        it, a clean server-side close falls through to the backoff with no line,
+        this function had no logger call of its own, and the base coordinator's
+        `Manually updated aegis_ajax data` fires on every update path and cannot
+        identify a snapshot. So a full snapshot could arrive, replace every
+        device and empty a fleet of readings without leaving a trace — which is
+        exactly what happened to him, three seconds after a transport close, and
+        why the cause of the *invocation* is still open. The line reports what was
+        carried forward so the next occurrence is decisive rather than inferred.
+        """
+        carried_reading_count = 0
+        carried_battery_count = 0
         for device in devices:
             # Per-device temperature (#220, #229) comes from a separate
             # per-device RPC, not this stream, so a fresh snapshot would wipe
@@ -2250,6 +2305,26 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     from dataclasses import replace as dc_replace  # noqa: PLC0415
 
                     device = dc_replace(device, statuses={**device.statuses, **carried})
+            # Measurements the snapshot left out (#403). Last of the carry-forward
+            # blocks on purpose: the specific ones above own their keys, and this
+            # only ever fills what is still missing after them.
+            if existing is not None:
+                from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+                carried_readings = {
+                    key: existing.statuses[key]
+                    for key in _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS
+                    if key not in device.statuses and key in existing.statuses
+                }
+                if carried_readings:
+                    carried_reading_count += len(carried_readings)
+                    device = dc_replace(device, statuses={**device.statuses, **carried_readings})
+                # Battery is a `Device` field rather than a status, so no status
+                # carry can reach it — and it is the worst-affected reading for
+                # exactly the reason it needs its own line here.
+                if device.battery is None and existing.battery is not None:
+                    carried_battery_count += 1
+                    device = dc_replace(device, battery=existing.battery)
             self.devices[device.id] = device
         # `DevicesApi` dedups video-doorbell twins per snapshot, but the merge
         # above only ever *adds* keys — a `motion_cam_video_*` ghost that was
@@ -2259,6 +2334,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Re-run the dedup across the whole device set now that this snapshot
         # may have brought the sibling in.
         self._dedupe_video_doorbells()
+        _LOGGER.debug(
+            "Device snapshot applied: %d device(s) replaced, carried forward "
+            "%d reading(s) and %d battery value(s)",
+            len(devices),
+            carried_reading_count,
+            carried_battery_count,
+        )
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         # Refresh the persisted cache so the next restart can warm-start
         # from real data instead of the previous boot's snapshot (#114).

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -904,6 +904,126 @@ class TestStreamHandlers:
         coordinator._handle_devices_snapshot([updated])
         assert coordinator.devices["d1"] is updated
 
+    # --- #403: measurements must survive a snapshot that omits them -----------
+    #
+    # A snapshot rebuilds each device, so a reading the stream does not repeat was
+    # lost until that device next sent one. @wip3out3r measured 1/13 batteries and
+    # 1/11 signal strengths still empty four hours on, while the only two devices
+    # with an existing carry-forward kept their values the whole time.
+
+    def test_snapshot_carries_battery_forward_when_it_omits_one(self) -> None:
+        """Battery is the worst case: at 100% it has nothing to retransmit."""
+        from custom_components.aegis_ajax.api.models import BatteryInfo
+
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = replace(
+            _make_device("d1"), battery=BatteryInfo(level=100, is_low=False)
+        )
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert coordinator.devices["d1"].battery is not None
+        assert coordinator.devices["d1"].battery.level == 100
+
+    def test_snapshot_carries_signal_strength_forward(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1", statuses={"signal_strength": 3})
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert coordinator.devices["d1"].statuses["signal_strength"] == 3
+
+    def test_temperature_is_deliberately_not_in_the_carry_forward_list(self) -> None:
+        """Records that part of #403 is knowingly unfixed.
+
+        Seven of his nine temperatures emptied — the light-stream families, which
+        the `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES` block does not cover. Adding
+        `temperature` here would fix those and would also break
+        `test_snapshot_does_not_invent_temperature_for_non_siren`, which pins the
+        opposite deliberately. Pinned as a decision so the next person finds the
+        conflict instead of discovering it by breaking that test.
+        """
+        from custom_components.aegis_ajax.coordinator import (
+            _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS,
+        )
+
+        assert "temperature" not in _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS
+
+    def test_snapshot_does_not_carry_an_operational_alert_forward(self) -> None:
+        """The reason the carry list is named rather than a blanket merge.
+
+        `lid_opened` is an alert, not a measurement: its absence from a fresh
+        snapshot is the signal that it has cleared. Carrying it would pin a
+        tamper alert on forever — the failure a "merge instead of replace" would
+        have introduced while fixing the battery.
+        """
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device(
+            "d1", statuses={"lid_opened": True, "signal_strength": 3}
+        )
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert "lid_opened" not in coordinator.devices["d1"].statuses
+        # The measurement alongside it still survives, so this is the allowlist
+        # discriminating rather than the carry-forward simply not running.
+        assert coordinator.devices["d1"].statuses["signal_strength"] == 3
+
+    def test_a_value_in_the_snapshot_wins_over_the_carried_one(self) -> None:
+        """Carry-forward only fills gaps, so #312's live tracking still holds.
+
+        Uses `signal_strength` rather than `temperature` on purpose: temperature
+        is not in the carry list, so this would pass without exercising anything —
+        which is how it was first written, and a mutation that let a carried value
+        override a fresh one did not fail it. Also asserts the battery, since a
+        stale battery overriding a fresh reading is the same defect on the field
+        that has its own carry.
+        """
+        from custom_components.aegis_ajax.api.models import BatteryInfo
+
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = replace(
+            _make_device("d1", statuses={"signal_strength": 1}),
+            battery=BatteryInfo(level=10, is_low=True),
+        )
+
+        coordinator._handle_devices_snapshot(
+            [
+                replace(
+                    _make_device("d1", statuses={"signal_strength": 3}),
+                    battery=BatteryInfo(level=95, is_low=False),
+                )
+            ]
+        )
+
+        assert coordinator.devices["d1"].statuses["signal_strength"] == 3
+        assert coordinator.devices["d1"].battery is not None
+        assert coordinator.devices["d1"].battery.level == 95
+
+    def test_snapshot_logs_what_it_replaced_and_carried(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The observable this path did not have at any log level (#403).
+
+        A full snapshot could replace every device and empty a fleet of readings
+        without leaving a trace, so the cause of the *invocation* could not be
+        investigated. Reported by @wip3out3r, who read the source after failing
+        to find the line I had asked him for.
+        """
+        from custom_components.aegis_ajax.api.models import BatteryInfo
+
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = replace(
+            _make_device("d1", statuses={"signal_strength": 3}),
+            battery=BatteryInfo(level=100, is_low=False),
+        )
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert "Device snapshot applied: 1 device(s) replaced" in caplog.text
+        assert "carried forward 1 reading(s) and 1 battery value(s)" in caplog.text
+
     @staticmethod
     def _make_doorbell(device_id: str, device_type: str, name: str = "Deurbel") -> Device:
         return Device(


### PR DESCRIPTION
Acts on @wip3out3r's measurement in #403, which identified the function by a better route than the one I asked him for.

## What his data settled

The emptying **precedes** the reconnect by three minutes — disconnect at `12:31:20.012`, all thirteen batteries `unknown` between `12:31:23.035` and `.160`, reconnect at `12:34:38.509` — so nothing at or after the reconnect can be the cause, and the HTS disconnect handler (which preserves its caches by design since #146) is exonerated.

What identified the function is which readings *survived*. On his install `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES` is exactly his two StreetSirens; their temperatures never went `unknown` while the other seven and all thirteen batteries did. **The set that survived is the set that had a carry-forward.** That rules out `_maybe_fallback_device_snapshot`, which assigns `self.devices` wholesale with no carry at all — the sirens would have emptied too.

He also closed the obvious objection himself: the sirens' *batteries* did empty, in the same 125 ms window, so their `Device` objects were replaced and temperature alone survived the replacement. And HTS stayed closed for the following 3 m 18 s, so no `0x02` update could have refilled a value and masked an emptying.

## The fix

Battery and `signal_strength` (plus `humidity` and `co2`) now survive a snapshot that omits them. Battery needs its own line because it is a `Device` field rather than a status, so no status merge reaches it — and it is the worst-affected reading for the reason he gives: at 100% it has nothing to retransmit.

**Behind a named allowlist, not a blanket merge**, and that distinction is the whole design. Most of what rides in `statuses` must *not* survive: `lid_opened`, `case_drilling` and `gsm_connected` are alerts, and an alert that has cleared has to clear here too. A "merge instead of replace" would have fixed the battery and pinned a tamper alert on forever. Membership follows his own rule, which states it better than we had: a snapshot omitting a **measurement** does not make the previous value wrong, only older.

## What this deliberately does not fix

`temperature`. Seven of his nine emptied, all light-stream families that the existing gated block does not cover — so part of #403 stays open, and I would rather say so than quietly widen it.

Adding `temperature` to the allowlist also fails `test_snapshot_does_not_invent_temperature_for_non_siren`, which pins the opposite on purpose. Carrying a value the device itself reported is not "inventing" one, so the two are probably reconcilable — but overturning a pinned decision wants evidence, not a convenient reading, and the warm-start cache (#114) is a real way a bad value could become immortal once it is sticky. It is recorded as a decision with its own test, so the next person meets the conflict rather than discovering it by breaking that test.

## The observable that did not exist

He went looking for the `Device stream started for space` line I asked for and found nothing findable at any log level: it fires once per coordinator lifetime so an in-task reconnect never emits it, a clean server-side close falls through to the backoff with no line, `_handle_devices_snapshot` had no logger call of its own, and the base coordinator's generic update line fires on every path and cannot identify a snapshot.

So a full snapshot could replace every device and empty a fleet of readings without leaving a trace. There is now one DEBUG line per snapshot reporting devices replaced and what was carried. **What invokes a full snapshot three seconds after a transport close is still open** — this is what makes the next occurrence decisive instead of inferred.

## Verification

Full gate green: `ruff`, `ruff format`, `mypy`, `vulture`, **2203 passed**, coverage 90.59%.

Five mutations, each tumbling the test that should catch it:

| mutation | fails |
|---|---|
| no battery carry | battery-carry, and the log-line test |
| blanket merge over all of `existing.statuses` | the alert guard, **and** the pre-existing `does_not_invent_temperature` test |
| carried status overrides a fresh one | fresh-wins |
| stale battery overrides a fresh one | fresh-wins |
| drop the DEBUG line | log-line |

One note on method, since it nearly slipped through. The fresh-wins test was first written against `temperature` — which is *not* in the allowlist, so it passed without exercising anything, and the mutation did not fail it. Rewritten against `signal_strength` and battery, it does. A separate mutation of mine also silently hit the siren carry-forward block, which has a byte-identical condition line and appears first; re-targeted, it fails correctly. Worth recording because both looked like green confirmation.

Relates to #403.
