### PR TITLE
fix(diagnostics): name the device oneof cases we do not model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Thanks to @Taknok, who owns a Double Deck, found both device-type lists, worked out why there are two, and tested the change on the real siren — the confirmation this needed and that could not be produced without the hardware.
 
 ### Fixed
+- **A device family our copy of the protocol doesn't describe no longer disappears without trace (#408).** When the hub reports a device in a shape we don't model, the data is discarded before the integration ever sees it — silently, at every log level. "This family is missing from our definitions" and "this device reports nothing" therefore produced identical logs, so each affected family had to be diagnosed from scratch by whoever owned the hardware, which is how the same underlying gap came to be fixed four separate times (#229, #339, #354, #383).
+
+  The debug probes on the rich per-device read now report the wire number of the case that was dropped, which identifies the family exactly. Diagnostics only — no entity behaviour changes. Found by @wip3out3r, who measured 8 of his 13 devices reading as empty on that endpoint and named all five missing families.
+
 - **The Bypass switch now explains itself when it cannot put a device back into protection (#338).** Turning the switch *off* never worked, on any install: the command went out carrying a value the Ajax hub rejects outright, and the attempt failed with a raw protocol error that named nothing you could act on. The hub's command vocabulary has no value that clears a deactivation — it can only name which kind to apply — so Home Assistant now says exactly that, in all supported languages, and points you at the Ajax app instead of failing obscurely.
 
   Deactivating a device from Home Assistant is unchanged, and so is what the switch reads: it still shows `on` for a device deactivated by anyone, including from the Ajax app or by an installer. Found by @wip3out3r, who measured the rejected command on his own hub and flagged it as a separate fault from the one #338 is about.

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -156,10 +156,11 @@ def _log_empty_siren_settings(hub_device_id: str, hub_device: Any) -> None:  # n
             has_siren_part = None
     _LOGGER.debug(
         "StreamHubDevice (siren settings) for %s carried no settings; "
-        "HubDevice oneof case=%r common_siren_part=%s",
+        "HubDevice oneof case=%r common_siren_part=%s unmodelled_case_numbers=%s",
         hub_device_id,
         case,
         has_siren_part,
+        devices_parser.unmodelled_device_case_numbers(hub_device),
     )
 
 
@@ -330,15 +331,23 @@ class DevicesApi:
                         # `device_temperature`), the value silently vanishes. Log
                         # the actual case so we can extend the proto from a real
                         # device's response (cf. #206).
+                        #
+                        # `case=None` on its own cannot say whether the family is
+                        # missing from our definitions or the device simply sent
+                        # nothing, so report the unknown-field numbers alongside
+                        # it: an unmodelled case leaves its wire number there and
+                        # names itself (#408).
                         case = (
                             hub_device.WhichOneof("device")
                             if hasattr(hub_device, "WhichOneof")
                             else None
                         )
                         _LOGGER.debug(
-                            "StreamHubDevice for %s: no temperature; HubDevice oneof case=%r",
+                            "StreamHubDevice for %s: no temperature; "
+                            "HubDevice oneof case=%r unmodelled_case_numbers=%s",
                             hub_device_id,
                             case,
+                            devices_parser.unmodelled_device_case_numbers(hub_device),
                         )
                     return temperature
             elif msg.HasField("failure"):

--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -682,6 +682,33 @@ def parse_device(proto_light_device: Any) -> Device | None:  # noqa: ANN401
     return None
 
 
+def unmodelled_device_case_numbers(hub_device: object) -> list[int]:
+    """Wire field numbers on a `HubDevice` that our `device` oneof omits (#408).
+
+    Our vendored definitions model a subset of the device families the hub
+    actually sends. A case we don't model is not an error: protobuf moves it
+    to the unknown-field set, `WhichOneof("device")` returns `None`, and
+    nothing is logged at any level — so "this family is missing from our
+    definitions" and "this device carries no data" look identical from a log.
+    The field number survives in the unknown-field set and names the case
+    exactly, which is the difference between a silent gap and a one-line fix.
+
+    Takes `object` and never raises: the result feeds a `_LOGGER.debug()`
+    argument list, and those arguments are evaluated eagerly whether or not
+    debug logging is enabled.
+    """
+    try:
+        from google.protobuf.unknown_fields import UnknownFieldSet  # noqa: PLC0415
+
+        # protobuf types `UnknownFieldSet` after its pure-Python implementation,
+        # which declares neither `__iter__` nor an `object` argument; the upb
+        # build Home Assistant runs on provides both.
+        unknown: Any = UnknownFieldSet(hub_device)  # type: ignore[arg-type]
+        return sorted({field.field_number for field in unknown})
+    except (AttributeError, ImportError, KeyError, RuntimeError, TypeError, ValueError):
+        return []
+
+
 def parse_hub_device_temperature(hub_device: Any) -> float | None:  # noqa: ANN401
     """Pull the internal temperature out of a rich `HubDevice` proto (#220).
 

--- a/tests/unit/test_unmodelled_device_case.py
+++ b/tests/unit/test_unmodelled_device_case.py
@@ -1,0 +1,135 @@
+"""Tests for naming the `HubDevice.device` oneof cases we do not model (#408).
+
+An unmodelled case is dropped into protobuf's unknown-field set, so
+`WhichOneof("device")` returns `None` and nothing is logged at any level:
+"this family is not in our definitions" and "this device reports nothing"
+are indistinguishable. The retained wire field number tells them apart.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Wire up the proto search path before any `systems.*` import.
+from custom_components.aegis_ajax.api import _proto_path as _proto_path  # noqa: E402, F401
+from custom_components.aegis_ajax.api.devices import DevicesApi  # noqa: E402
+from custom_components.aegis_ajax.api.devices_parser import (  # noqa: E402
+    unmodelled_device_case_numbers,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from google.protobuf.message import Message
+
+
+def _hub_device_with_case(field_number: int) -> Message:
+    """Parse a `HubDevice` off the wire carrying only `field_number` as a
+    length-delimited (message) field, exactly as the hub would send a family
+    we do not model."""
+    from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import hub_device_pb2
+
+    tag = (field_number << 3) | 2  # wire type 2 = length-delimited
+    raw = bytearray()
+    while tag > 0x7F:
+        raw.append((tag & 0x7F) | 0x80)
+        tag >>= 7
+    raw.append(tag)
+    raw.append(0x00)  # zero-length body
+
+    device = hub_device_pb2.HubDevice()
+    device.ParseFromString(bytes(raw))
+    return device
+
+
+class TestUnmodelledDeviceCaseNumbers:
+    def test_reports_the_wire_number_of_an_unmodelled_case(self) -> None:
+        # 40 is `motion_protect_curtain` (the indoor variant) — one of the five
+        # families @wip3out3r measured as unreadable.
+        device = _hub_device_with_case(40)
+
+        assert device.WhichOneof("device") is None, "precondition: case must be unmodelled"
+        assert unmodelled_device_case_numbers(device) == [40]
+
+    def test_reports_a_case_number_above_one_byte_of_varint(self) -> None:
+        """Numbers past 15 push the tag into a multi-byte varint; the highest
+        modelled case is already 68, so the diagnostic must survive that."""
+        device = _hub_device_with_case(116)
+
+        assert device.WhichOneof("device") is None
+        assert unmodelled_device_case_numbers(device) == [116]
+
+    def test_returns_empty_for_a_modelled_case(self) -> None:
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import (
+            hub_device_pb2,
+            street_siren_pb2,
+        )
+
+        device = hub_device_pb2.HubDevice(street_siren=street_siren_pb2.StreetSiren())
+
+        assert device.WhichOneof("device") == "street_siren"
+        assert unmodelled_device_case_numbers(device) == []
+
+    def test_returns_empty_for_an_empty_message(self) -> None:
+        from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import hub_device_pb2
+
+        assert unmodelled_device_case_numbers(hub_device_pb2.HubDevice()) == []
+
+    # The helper feeds a `_LOGGER.debug()` argument list, which Python
+    # evaluates eagerly — so it must swallow every shape surprise rather than
+    # take the calling path down with it.
+    def test_never_raises_on_a_non_message(self) -> None:
+        assert unmodelled_device_case_numbers(None) == []
+        assert unmodelled_device_case_numbers(object()) == []
+        assert unmodelled_device_case_numbers("not a proto") == []
+
+
+class TestProbeReportsTheCaseNumber:
+    """The number has to reach the log, not just the helper — the whole point
+    of #408 is that the existing `case=None` line says nothing actionable."""
+
+    @pytest.mark.asyncio
+    async def test_temperature_probe_logs_the_unmodelled_case_number(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = MagicMock()
+        client._get_channel.return_value = MagicMock()
+        client._session.get_call_metadata.return_value = []
+        api = DevicesApi(client)
+
+        msg = MagicMock()
+        msg.HasField.side_effect = lambda field: field == "success"
+        msg.success.WhichOneof.return_value = "snapshot"
+        msg.success.snapshot.hub_device = _hub_device_with_case(93)  # space_control
+
+        async def _aiter(*args: object, **kwargs: object) -> AsyncGenerator[MagicMock, None]:
+            yield msg
+
+        stub_instance = MagicMock()
+        stub_instance.execute.return_value = _aiter()
+        mock_request_pb2 = MagicMock()
+        stub_class = MagicMock(return_value=stub_instance)
+        mock_grpc_module = MagicMock(StreamHubDeviceServiceStub=stub_class)
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "v3.mobilegwsvc.service.stream_hub_device.endpoint_pb2_grpc": mock_grpc_module,
+                    "v3.mobilegwsvc.service.stream_hub_device.request_pb2": mock_request_pb2,
+                    "v3.mobilegwsvc.service.stream_hub_device": MagicMock(
+                        endpoint_pb2_grpc=mock_grpc_module,
+                        request_pb2=mock_request_pb2,
+                    ),
+                },
+            ),
+            caplog.at_level(logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"),
+        ):
+            result = await api.get_hub_device_temperature("hub-1", "dev-1")
+
+        assert result is None
+        assert "unmodelled_case_numbers=[93]" in caplog.text


### PR DESCRIPTION
Item 4 of #408 — "make the failure visible" — which the issue calls out as worth doing regardless of when the definitions are refreshed.

## The problem

When the hub reports a device whose `HubDevice.device` oneof case our vendored definitions don't model, nothing anywhere says so. protobuf moves the field into the unknown-field set, `WhichOneof("device")` returns `None`, and the existing probes log `case=None` — which is equally consistent with "this device carries no data". That ambiguity is why the same underlying gap was diagnosed and fixed four separate times, once per family (#229, #339, #354, #383), each costing a reporter with the hardware a capture and several restarts.

## The fix

The wire field number survives in the unknown-field set and names the case exactly. `unmodelled_device_case_numbers()` reports it, and both rich per-device probes now log it next to `case=None`:

```
StreamHubDevice for XXXXXXXX: no temperature; HubDevice oneof case=None unmodelled_case_numbers=[93]
```

That `93` is `space_control` — one of the five families @wip3out3r measured as unreadable. A number is enough to act on and does not rot: protobuf field numbers are append-only.

The helper takes `object` and swallows every shape surprise on purpose — it feeds a `_LOGGER.debug()` argument list, and those arguments are evaluated eagerly whether or not debug logging is enabled.

## Tests

Six, all against real protos parsed off the wire rather than mocks:

- an unmodelled case reports its number, with `WhichOneof("device") is None` asserted as a precondition;
- a case number past one varint byte (116), since the highest modelled case is already 68;
- a modelled case reports nothing — the negative control;
- an empty message reports nothing;
- `None` / `object()` / a plain string do not raise;
- the probe **log line** actually carries the number, mutation-checked: removing the field from the temperature probe (and only that probe — the siren probe carries a near-identical line) makes exactly that test fail.

Diagnostics only — no entity, state or attribute changes. Full pipeline green locally (2220 passed, 90.62% coverage, lint/format/typecheck/vulture clean).

Refs #408.