### PR TITLE
feat(motion_cam): Add Motion Cam Outdoor PhoD HTS temperature support

### DIFF
--- a/custom_components/aegis_ajax/api/hts/hub_state.py
+++ b/custom_components/aegis_ajax/api/hts/hub_state.py
@@ -338,6 +338,7 @@ HTS_TEMPERATURE_DEVICE_TYPES: frozenset[str] = frozenset(
         # values on every candidate row (26–29 °C in July), matching the
         # Curtain Outdoor Plus/Base behaviour on the same protocol.
         "motion_protect_outdoor",
+        "motion_cam_outdoor_phod",
         # Sirens (#312, #269). They also expose a gRPC `device_temperature`, but
         # that is the internal *board* temperature (runs hotter than ambient and
         # only refreshes on the slow per-device snapshot). HTS 0x02 is the value

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -187,6 +187,7 @@ HUB_DEVICE_TEMPERATURE_DEVICE_TYPES = frozenset(
         "motion_protect_curtain_outdoor_mini",
         "motion_protect_curtain_outdoor_plus",
         "motion_protect_outdoor",
+        "motion_cam_outdoor_phod",
     }
 )
 

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -808,6 +808,7 @@ class TestParseDeviceTemperatureC:
             "motion_protect_curtain_outdoor_plus",
             "motion_protect_curtain_outdoor_base",
             "motion_protect_outdoor",
+            "motion_cam_outdoor_phod",
             "street_siren",
             "street_siren_plus_g3",
             "street_siren_double_deck",

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -717,9 +717,11 @@ _CONFIRMED_HTS_TEMPERATURE_SAMPLES: dict[str, tuple[bytes, float]] = {
     "home_siren": (b"\x17", 23.0),
     # #375: 0x1f = 31 °C in August for street siren double deck.
     "street_siren_double_deck": (b"\x1f", 31.0),
-    # #412: 0x1d = 29 ⁰C and 0x1e = 30 ⁰C
+    # #412: two units captured on the same hub, 0x1d = 29 °C (308CE402) and
+    # 0x1e = 30 °C (308CB897), both matching the app. One entry per family —
+    # this dict records that the family reports 0x02, and the byte-to-degrees
+    # conversion is family-agnostic and covered once below.
     "motion_cam_outdoor_phod": (b"\x1d", 29.0),
-    "motion_cam_outdoor_phod": (b"\x1e", 30.0),
 }
 
 # Families in the production gate with no recorded byte-level sample. They are

--- a/tests/unit/hts/test_hub_state.py
+++ b/tests/unit/hts/test_hub_state.py
@@ -717,6 +717,9 @@ _CONFIRMED_HTS_TEMPERATURE_SAMPLES: dict[str, tuple[bytes, float]] = {
     "home_siren": (b"\x17", 23.0),
     # #375: 0x1f = 31 °C in August for street siren double deck.
     "street_siren_double_deck": (b"\x1f", 31.0),
+    # #412: 0x1d = 29 ⁰C and 0x1e = 30 ⁰C
+    "motion_cam_outdoor_phod": (b"\x1d", 29.0),
+    "motion_cam_outdoor_phod": (b"\x1e", 30.0),
 }
 
 # Families in the production gate with no recorded byte-level sample. They are


### PR DESCRIPTION
## Summary

This PR adds support for MotionCam Outdoor PhoD devices to the existing HTS-based internal temperature handling path, by including motion_cam_outdoor_phod in the temperature device type sets used by the coordinator.

## Test plan

The modifications were successfully tested on my two motion_cam_outdoor_phod : 308CE402 and 308CB897.

- [x] `make check` passes locally on a freshly built Docker image
- [x] New behaviour covered by unit tests in `tests/unit/`
- [x] Coverage stays at or above the 80% threshold
- [ ] User-facing strings updated in `strings.json` and the 14 translation files
- [ ] `README.md` / `CHANGELOG.md` updated when the change is user-visible

## Notes for the reviewer

I let you add the `motion_cam_outdoor` if you want to infer it. Maintainers edit is open for any type of modifications :)

## Proof

Logs:
```
2026-08-07 00:45:43.402 DEBUG (MainThread) [custom_components.aegis_ajax.api.hts.client] Hub 0029B936: STATUS_BODY non-hub devices (#123 probe): 985ED2D7=[0x01=01,0x02=21,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=00,0x32=01,0x39=01,0x3a=00,0x46=00,0x47=00,0x99=1f,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 4814CF17=[], 00B0BF9A=[0x02=1d,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=01,0x32=00,0x99=1e,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 3213EE90=[], 305918C1=[0x02=1e,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x37=00,0x99=1c,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 308CE402=[0x02=1d,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x34=00,0x42=01,0x4b=03,0x52=00,0x5a=00,0x5b=01,0x5f=00,0x87=00,0x8e=80,0x99=3b,0x9f=00,0xb7=00,0xc2=00,0xc3=01,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 002639CE=[0x02=80,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=01,0x33=00,0x34=00,0x35=00,0x37=00,0x99=8a,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 00000001=[], 3050A2A7=[0x02=1d,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x36=00,0x37=00,0x43=80,0x79=80,0x7d=01,0x99=37,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 00000002=[], 305654EA=[0x02=1e,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=00,0x32=00,0x39=01,0x3a=00,0x46=00,0x47=00,0x99=1e,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 00000003=[], 00000001=[0x02=01,0x18=80], 00000002=[0x02=02], 00ABE560=[0x02=1f,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=01,0x32=00,0x99=1e,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 308CB897=[0x02=1e,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x34=00,0x42=01,0x4b=03,0x52=00,0x5a=00,0x5b=01,0x5f=00,0x87=00,0x8e=80,0x99=3a,0x9f=00,0xb7=00,0xc2=00,0xc3=01,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 307B3179=[0x02=21,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=00,0x32=00,0x39=01,0x3a=00,0x46=00,0x47=00,0x99=1e,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 305AB471=[0x02=80,0x03=80,0x04=80,0x05=0064,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x99=1b,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 304FB6A3=[0x02=1e,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=00,0x32=00,0x39=01,0x3a=00,0x46=00,0x47=00,0x99=1e,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 00000001=[], 5B4CCD2C=[], 432B35C8=[], 730454E3=[], 00000001=[0x06=00,0x08=0000,0x0a=00,0x0b=00,0x0c=0000,0x0e=00,0x23=00,0x26=00], 00000002=[0x06=00,0x08=0000,0x0a=00,0x0b=00,0x0c=0000,0x0e=00,0x23=00,0x26=00], 00000003=[0x06=00,0x08=0000,0x0a=00,0x0b=00,0x0c=0000,0x0e=00,0x23=00,0x26=00], 00000004=[0x06=00,0x08=0000,0x0a=00,0x0b=00,0x0c=0000,0x0e=00,0x23=00,0x26=00], 00000005=[0x06=00,0x08=0000,0x0a=00,0x0b=00,0x0c=0000,0x0e=00,0x23=00,0x26=00], 00000006=[0x06=00,0x08=0000,0x0a=00,0x0b=00,0x0c=0000,0x0e=00,0x23=00,0x26=00], 00000000=[0x02=84,0x03=18,0x04=308ce402,0x05=0084,0x09=00,0x0d=00], 00000001=[0x02=84,0x03=18,0x04=308cb897,0x05=0084,0x09=00,0x0d=00], 00000002=[0x02=01,0x03=7f,0x04=06,0x05=1e,0x06=6a7429e8,0x07=0000000000000004,0x09=00,0x0a=00000000000000000000000000000000,0x0d=00,0xc3=00], 042639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=00,0x34=00,0x3e=e4,0x49=01,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=01,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 012639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=01,0x34=00,0x3e=00,0x49=00,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 022639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=01,0x34=00,0x3e=00,0x49=00,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 032639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=01,0x34=00,0x3e=00,0x49=00,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 052639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=00,0x34=00,0x3e=e4,0x49=01,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=01,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 062639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=01,0x34=00,0x3e=00,0x49=00,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 072639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=00,0x34=00,0x3e=e3,0x49=01,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=01,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 082639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=00,0x34=00,0x3e=df,0x49=01,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 122639CE=[0x02=80,0x03=80,0x04=80,0x05=8000,0x06=8000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=80,0x33=00,0x34=00,0x3e=dd,0x49=01,0x4d=80,0x54=80,0x59=00,0x64=80,0x65=80,0x66=80,0x99=00,0x9f=00,0xb7=01,0xc2=80,0xc3=00,0xc6=80,0xf5=00,0xf7=00,0xf9=80], 30565BC0=[0x02=20,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=00,0x32=00,0x39=01,0x3a=00,0x46=00,0x47=00,0x99=1e,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80], 3056643B=[0x02=1e,0x03=03,0x04=00,0x05=0064,0x06=0000,0x07=80000000,0x0b=01,0x0c=01,0x0e=80,0x0f=00,0x10=00,0x17=00000000,0x2c=01,0x31=00,0x32=00,0x39=01,0x3a=00,0x46=00,0x47=00,0x99=1e,0x9f=00,0xb7=00,0xc2=80,0xc3=00,0xc6=00,0xf5=00,0xf7=00,0xf9=80]
```

Photo for 308CE402
<img width="3072" height="4080" alt="PXL_20260806_223532215" src="https://github.com/user-attachments/assets/e9ca2ccd-7d86-476d-ba31-65b2c502bcdf" />

App for 308CE402
<img width="1080" height="2400" alt="Screenshot_20260807-003144" src="https://github.com/user-attachments/assets/b0f9b556-9d2b-407e-875d-7b62833e65fc" />

Screenshot for 308CE402
<img width="1582" height="742" alt="Capture d&#39;écran 2026-08-07 003118-2" src="https://github.com/user-attachments/assets/e9078be6-d8a6-47a1-9de7-0ad63f80edb4" />

Photo for 308CB897
<img width="3072" height="4080" alt="PXL_20260806_223247563" src="https://github.com/user-attachments/assets/4c5693da-a80c-4fb4-99e9-459210f9291c" />

App for 308CB897
<img width="1080" height="2400" alt="Screenshot_20260807-003007" src="https://github.com/user-attachments/assets/9b5e6cc7-db36-466c-915c-20818414512e" />

Screenshot for 308CB897
<img width="1571" height="837" alt="Capture d&#39;écran 2026-08-07 003028" src="https://github.com/user-attachments/assets/cdc734d9-840f-44d1-8848-0a0a74ec901f" />