### PR TITLE
fix(coordinator): route the polled fallback snapshot through the carry-forwards

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -1336,6 +1336,16 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         (see `_KEEPALIVE_OPTIONS`): a wedged channel surfaces as an error the
         stream's own reconnect recovers from, rather than being detected here.
         This is a cheap no-op whenever a stream task is alive (the common case).
+
+        Applies the snapshot through `_handle_devices_snapshot` rather than
+        replacing `self.devices` wholesale: the wholesale replacement skipped
+        every carry-forward that function accumulated (#220 temperature, #339
+        tamper, #310 siren settings, #403 readings and battery) and left no
+        log line, so with streams down each poll could silently blank the
+        same readings #403 fixed on the stream path — one writer was gated,
+        this one was not (the #406 trap). The one thing kept from the old
+        behavior is removal: this is the resync-from-scratch path, so devices
+        the snapshot no longer reports are dropped before the merge.
         """
         streams_healthy = self._stream_tasks and all(not t.done() for t in self._stream_tasks)
         if streams_healthy:
@@ -1345,7 +1355,16 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             space_devices = await self._devices_api.get_devices_snapshot(space_id)
             for device in space_devices:
                 all_devices[device.id] = device
-        self.devices = all_devices
+        _LOGGER.debug(
+            "No live device stream; applying polled fallback snapshot (%d device(s))",
+            len(all_devices),
+        )
+        self.devices = {
+            device_id: device
+            for device_id, device in self.devices.items()
+            if device_id in all_devices
+        }
+        self._handle_devices_snapshot(list(all_devices.values()), notify_listeners=False)
 
     async def _maybe_restart_hts(self) -> None:
         """Reap a dead HTS task and re-start the client on the next cycle."""
@@ -2309,7 +2328,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.spaces[space_id] = dc_replace(space, chime_status=new_status)
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
-    def _handle_devices_snapshot(self, devices: list[Device]) -> None:
+    def _handle_devices_snapshot(
+        self, devices: list[Device], *, notify_listeners: bool = True
+    ) -> None:
         """Handle initial snapshot or full device snapshot update from stream.
 
         Emits one DEBUG line per snapshot, which is the observable this path was
@@ -2427,7 +2448,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             carried_reading_count,
             carried_battery_count,
         )
-        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+        # The polled fallback runs inside `_async_update_data`, whose return
+        # value the coordinator broadcasts anyway — a second notification
+        # from here would be redundant.
+        if notify_listeners:
+            self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
         # Refresh the persisted cache so the next restart can warm-start
         # from real data instead of the previous boot's snapshot (#114).
         # Debounced — bursts of stream snapshots coalesce into one write.

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -871,6 +871,76 @@ class TestAsyncUpdateData:
         coordinator.async_set_updated_data.assert_called_once()
 
 
+class TestFallbackDeviceSnapshot:
+    """The polled fallback must apply snapshots like the stream does (#403).
+
+    `_maybe_fallback_device_snapshot` used to replace `self.devices`
+    wholesale, bypassing every carry-forward `_handle_devices_snapshot`
+    accumulated (#220 temperature, #339 tamper, #310 siren settings, #403
+    readings and battery) and logging nothing — the same trap #406 hit:
+    guarding one writer does not guard the others. These tests pin that the
+    fallback routes through the same handler, and that it keeps the one
+    behavior the stream path does not have: dropping devices the snapshot
+    no longer reports.
+    """
+
+    def _make_fallback_coordinator(self) -> AjaxCobrandedCoordinator:  # noqa: F821
+        coordinator = _make_coordinator()
+        coordinator.spaces = {"s1": _make_space("s1")}
+        coordinator._stream_tasks = []  # no live stream → fallback runs
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._devices_api = MagicMock()
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_fallback_snapshot_carries_forward_battery_and_readings(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coordinator = self._make_fallback_coordinator()
+        coordinator.devices["d1"] = replace(
+            _make_device("d1", statuses={"signal_strength": 3}), battery=88
+        )
+        # The pathological snapshot from the report: same device, no
+        # battery, no measurements.
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[_make_device("d1")])
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            await coordinator._maybe_fallback_device_snapshot()
+
+        assert coordinator.devices["d1"].battery == 88
+        assert coordinator.devices["d1"].statuses["signal_strength"] == 3
+        # The wholesale replacement was also invisible — the fallback must
+        # leave the same trace the stream path leaves.
+        assert "Device snapshot applied" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_fallback_snapshot_still_drops_absent_devices(self) -> None:
+        # The stream handler only ever adds or replaces; the fallback is the
+        # one resync-from-scratch path, so a device deleted from Ajax while
+        # no stream was alive must not survive it.
+        coordinator = self._make_fallback_coordinator()
+        coordinator.devices["d1"] = _make_device("d1")
+        coordinator.devices["gone"] = _make_device("gone")
+        coordinator._devices_api.get_devices_snapshot = AsyncMock(return_value=[_make_device("d1")])
+
+        await coordinator._maybe_fallback_device_snapshot()
+
+        assert "d1" in coordinator.devices
+        assert "gone" not in coordinator.devices
+
+    @pytest.mark.asyncio
+    async def test_fallback_is_a_noop_while_streams_are_alive(self) -> None:
+        coordinator = self._make_fallback_coordinator()
+        alive = MagicMock()
+        alive.done.return_value = False
+        coordinator._stream_tasks = [alive]
+        coordinator._devices_api.get_devices_snapshot = AsyncMock()
+
+        await coordinator._maybe_fallback_device_snapshot()
+
+        coordinator._devices_api.get_devices_snapshot.assert_not_awaited()
+
+
 class TestStreamHandlers:
     """Tests for coordinator stream callback handlers."""
 


### PR DESCRIPTION
## Context (#403)

While reviewing the snapshot paths after @wip3out3r's drop analysis on #403, one writer turned out to be ungated: `_maybe_fallback_device_snapshot` — the poll-driven resync that runs whenever no device stream task is alive — replaced `self.devices` wholesale.

That bypassed every carry-forward `_handle_devices_snapshot` has accumulated (#220 temperature, #339 tamper, #310 siren settings, #403 readings and battery) and logged nothing, so with streams down each poll could silently blank the same readings #403 just fixed on the stream path. Same lesson as #406: gating one writer does not gate the others.

## Change

- The fallback prunes devices the snapshot no longer reports (the one behavior the stream path doesn't have — this is the resync-from-scratch path), then delegates to `_handle_devices_snapshot`, gaining all carry-forwards and the `Device snapshot applied` debug line.
- A new `No live device stream; applying polled fallback snapshot` debug line marks provenance, so a fallback application is distinguishable from a stream snapshot in a log.
- `notify_listeners=False` on the delegated call: the poll's own return value already broadcasts, so the extra notification would be redundant (and `_handle_devices_snapshot`'s signature stays compatible with the stream callback).

## Verification

- New `TestFallbackDeviceSnapshot` pins the carry-forward, the removal semantics, and the streams-alive no-op. The carry-forward test was written first and failed against the old code (battery `None` after fallback).
- `make check` green in the dev container: 2242 passed, lint/format/mypy/vulture clean.

Related to #403 (does not close it — the temperature question and the drop-cause investigation stay open there).