### PR TITLE
fix(bypass): send the enum value that matches the intent (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - unreleased
+
+### Fixed
+- **The Bypass switch now actually deactivates a device, and can put it back into protection (#338).** Deactivating from Home Assistant has never worked: the hub accepted every request and did nothing. The cause was the command's own vocabulary reading backwards — the value we sent to deactivate a device is in fact the one that *clears* a deactivation, so the hub was being asked to remove a bypass the device did not have, correctly reported that as done, and changed nothing. Turning the switch back off was then blocked outright in `1.16.0` on the conclusion that no clear value existed, when that value was the one we had been misusing all along.
+
+  Both directions now send the right value, so the switch deactivates and reactivates like the Ajax app does. A device deactivated from the app still shows up here exactly as before, and the read-back that warns when the hub accepts a write without acting is unchanged — a success response is still not treated as proof the hardware moved. Found by @wip3out3r, whose measurements ruled out every other explanation and whose test of a second value is what made the pattern legible.
+
 ## [1.16.0] - 2026-08-08
 
 Consolidates the `1.16.0-beta.1` … `-beta.12` series.

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -918,33 +918,37 @@ class DevicesApi:
         )
 
     async def _device_bypass(self, command: DeviceCommand) -> None:
-        """Deactivate (bypass) a device via DeviceCommandDeviceBypass.
+        """Deactivate / reactivate a device via DeviceCommandDeviceBypass (#338).
 
-        `bypass_enable=True` → permanent (engineering) whole-device
-        deactivation, matching the `bypassed` flag the snapshot reports.
+        ⚠️ The enum names read backwards, and taking them at face value is the
+        whole of #338. `BYPASS_ENGINEERING_DISABLE` disables the **bypass** —
+        it reactivates the device. It does not engineering-disable the device.
+        The triple is {clear, sensor-bypass, tamper-bypass}, not {whole,
+        sensor, tamper}. So:
 
-        There is no clear value to send. The request's `Bypass` enum names
-        only kinds — engineering/one-time × whole/sensor/tamper — and
-        `BYPASS_UNSPECIFIED` (0) going out as a command value was measured on
-        a reporter's hub to fail with `INVALID_ARGUMENT: Can't get the number
-        of an unknown enum value` (#338). Fail here with a reason the entity
-        layer translates, rather than surfacing that gRPC error to the user,
-        and leave reactivation to the Ajax app until the lever the app itself
-        uses is known.
+            deactivate  -> BYPASS_ENGINEERING_SENSOR   (2)
+            reactivate  -> BYPASS_ENGINEERING_DISABLE  (1)
+
+        Sending value 1 to deactivate is why every write was accepted and
+        nothing happened: the hub was asked to clear a bypass the device did
+        not have, which is a legitimate no-op it correctly reports as success.
+        The same reading explains the reporter's `BYPASS_ONE_TIME_DISABLE`
+        test, inert for the same reason, and why an app-side deactivation
+        surfaces as `ENABLED_ENGINEER_BYPASS` (the app sends value 2).
+
+        Because a success response is *not* evidence the hub acted, the caller
+        still schedules an independent read-back — see `schedule_bypass_confirm`.
         """
-        if not command.bypass_enable:
-            raise DeviceCommandError(
-                "bypass: the hub accepts no clear value for this command; "
-                "reactivate the device from the Ajax app",
-                reason="bypass_clear_unsupported",
-            )
-
         from v3.mobilegwsvc.service.device_command_device_bypass import (  # noqa: PLC0415
             endpoint_pb2_grpc,
             request_pb2,
         )
 
-        bypass_type = request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_ENGINEERING_DISABLE
+        bypass_type = (
+            request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_ENGINEERING_SENSOR
+            if command.bypass_enable
+            else request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_ENGINEERING_DISABLE
+        )
         channel = self._client._get_channel()
         metadata = self._client._session.get_call_metadata()
         stub = endpoint_pb2_grpc.DeviceCommandDeviceBypassServiceStub(channel)

--- a/custom_components/aegis_ajax/switch.py
+++ b/custom_components/aegis_ajax/switch.py
@@ -286,12 +286,11 @@ class AjaxBypassSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity
     the snapshot's `bypassed` flag False (#338). Reading only that flag showed
     a disabled sensor as live protection.
 
-    Writing still goes out as the permanent ("engineering") deactivation; the
+    Writing goes out as the permanent ("engineering") deactivation; the
     granular mode in force is exposed as the `deactivation_kinds` attribute.
-    Turning the switch *off* cannot be honoured — the hub's bypass command has
-    no value that clears a deactivation — so it raises a translated error
-    pointing at the Ajax app rather than sending a value the server rejects
-    (#338).
+    **Both directions are honoured** — see `DevicesApi._device_bypass` for why
+    the enum value that clears a deactivation is not the one its name suggests,
+    and why sending the wrong one looked like the hub ignoring us (#338).
     """
 
     _attr_has_entity_name = True

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -2294,7 +2294,15 @@ class TestDeviceBypassCommand:
         return DevicesApi(client)
 
     @pytest.mark.asyncio
-    async def test_enable_sends_engineering_disable(self) -> None:
+    async def test_enable_sends_engineering_sensor(self) -> None:
+        """Deactivating sends `BYPASS_ENGINEERING_SENSOR`, not `..._DISABLE` (#338).
+
+        The enum names read backwards: `BYPASS_ENGINEERING_DISABLE` disables the
+        *bypass* (i.e. reactivates the device), it does not engineering-disable
+        the device. Sending it to deactivate is why every write was accepted and
+        did nothing — the hub was being asked to clear a bypass that was not
+        there, which is a legitimate no-op it correctly reports as success.
+        """
         from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
         from v3.mobilegwsvc.service.device_command_device_bypass import (
             endpoint_pb2_grpc,
@@ -2328,48 +2336,88 @@ class TestDeviceBypassCommand:
         assert req.object_type.WhichOneof("type") == "door_protect"
         assert (
             req.bypass_type
-            == request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_ENGINEERING_DISABLE
+            == request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_ENGINEERING_SENSOR
         )
 
     @pytest.mark.asyncio
-    async def test_disable_raises_without_sending(self) -> None:
-        """Clearing a deactivation must fail locally, not on the wire (#338).
+    async def test_disable_sends_engineering_disable(self) -> None:
+        """Reactivating sends `BYPASS_ENGINEERING_DISABLE` — the clear lever (#338).
 
-        The `Bypass` enum has no "clear" value — 1..6 are the engineering and
-        one-time kinds. Sending `BYPASS_UNSPECIFIED` (0) as a command value was
-        measured on a reporter's hub to fail with
-        `INVALID_ARGUMENT: Can't get the number of an unknown enum value`, an
-        opaque gRPC error the user cannot act on. Fail before the call with a
-        reason the UI can translate instead.
+        `1.16.0-beta.8` refused this locally on the reading that the enum had no
+        clear value. That was backwards: value 1 *is* the clear, and refusing it
+        left reactivation impossible from Home Assistant for no reason.
         """
-        from v3.mobilegwsvc.service.device_command_device_bypass import endpoint_pb2_grpc
-
-        from custom_components.aegis_ajax.api.devices import DeviceCommandError
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_device_bypass import (
+            endpoint_pb2_grpc,
+            request_pb2,
+            response_pb2,
+        )
 
         api = self._make_api()
         captured: list = []
+        ok = response_pb2.DeviceCommandDeviceBypassResponse(success=common_response_pb2.Success())
 
         class _StubFactory:
             def __init__(self, channel: object) -> None:
                 async def _execute(req: object, **_: object) -> object:
                     captured.append(req)
-                    return None
+                    return ok
 
                 self.execute = AsyncMock(side_effect=_execute)
 
-        with (
-            patch.object(endpoint_pb2_grpc, "DeviceCommandDeviceBypassServiceStub", _StubFactory),
-            pytest.raises(DeviceCommandError) as excinfo,
-        ):
+        with patch.object(endpoint_pb2_grpc, "DeviceCommandDeviceBypassServiceStub", _StubFactory):
             await api.send_command(
                 DeviceCommand.bypass(
                     hub_id="hub-1", device_id="dev-1", device_type="door_protect", enable=False
                 )
             )
 
-        assert excinfo.value.reason == "bypass_clear_unsupported"
-        # Nothing may reach the hub: the value the server rejects is never sent.
-        assert captured == []
+        assert len(captured) == 1
+        assert (
+            captured[0].bypass_type
+            == request_pb2.DeviceCommandDeviceBypassRequest.BYPASS_ENGINEERING_DISABLE
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_two_directions_send_different_values(self) -> None:
+        """The whole bug in one assertion: on and off must not be the same value.
+
+        Before the fix both directions resolved to `BYPASS_ENGINEERING_DISABLE`
+        (one by sending it, one by refusing to send anything), so no pair of
+        per-direction assertions could catch a mapping that collapsed them again.
+        """
+        from v3.mobilegwsvc.commonmodels.response import response_pb2 as common_response_pb2
+        from v3.mobilegwsvc.service.device_command_device_bypass import (
+            endpoint_pb2_grpc,
+            response_pb2,
+        )
+
+        api = self._make_api()
+        captured: list = []
+        ok = response_pb2.DeviceCommandDeviceBypassResponse(success=common_response_pb2.Success())
+
+        class _StubFactory:
+            def __init__(self, channel: object) -> None:
+                async def _execute(req: object, **_: object) -> object:
+                    captured.append(req)
+                    return ok
+
+                self.execute = AsyncMock(side_effect=_execute)
+
+        with patch.object(endpoint_pb2_grpc, "DeviceCommandDeviceBypassServiceStub", _StubFactory):
+            for enable in (True, False):
+                await api.send_command(
+                    DeviceCommand.bypass(
+                        hub_id="hub-1",
+                        device_id="dev-1",
+                        device_type="door_protect",
+                        enable=enable,
+                    )
+                )
+
+        assert len(captured) == 2
+        assert captured[0].bypass_type != captured[1].bypass_type
 
     @pytest.mark.asyncio
     async def test_bypass_failure_raises(self) -> None:


### PR DESCRIPTION
## What #338 turned out to be

The bypass command's enum names read backwards, and taking them at face value is the entire bug.

`BYPASS_ENGINEERING_DISABLE` disables the **bypass** — it puts a device back into protection. It is not an engineering-disable *of the device*. The triple is {clear, sensor-bypass, tamper-bypass}, not {whole, sensor, tamper}.

So every deactivation we sent was really a request to *clear* a bypass the device did not have. The hub did exactly as asked, changed nothing, and correctly reported success — which is precisely the accept-but-inert behaviour reported in the issue.

That single correction accounts for every measurement collected there, which is the main reason to believe it:

- deactivation accepted and inert — we sent the clear value;
- @wip3out3r's `BYPASS_ONE_TIME_DISABLE` test, accepted and inert too — the same value in its one-time flavour;
- an app-side deactivation surfacing as `ENABLED_ENGINEER_BYPASS` — consistent with the value we were *not* sending;
- and `1.16.0-beta.8` blocking turn-off on the conclusion that the enum had no clear value, when value 1 was that value all along.

## The change

| intent | before | after |
|---|---|---|
| deactivate | `BYPASS_ENGINEERING_DISABLE` (1) | `BYPASS_ENGINEERING_SENSOR` (2) |
| reactivate | refused locally | `BYPASS_ENGINEERING_DISABLE` (1) |

The independent read-back after a write is deliberately untouched: a `Success` response is still not treated as proof the hub acted, and the warning still fires if the state disagrees. That is what keeps the hardware test below meaningful rather than circular.

## What is still unverified

**Nothing here is a hardware test**, and this command's whole failure mode is returning success without acting — so a green response proves nothing. A real device has to show the switch and the Ajax app agreeing, in both directions, before this goes to stable.

`make check` green (2243 tests), including a test pinning that the two directions cannot collapse onto the same value again. The `bypass_clear_unsupported` translation is left in place in all 14 locales rather than removed: it costs nothing, and if the hardware test contradicts this we will want that message back.

Related to #338 — not closing it until a device confirms.