### PR TITLE
fix(bypass): carry deactivation across a degraded snapshot the hub disagrees with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Retired two leftovers of the #338 investigation, now that the fix is hardware-confirmed. The `HTS bypass probe` debug line answered its question — the hub's `0xB6`/`0xB7` status keys carry the deactivation *state*, now first-class on the bypass switch — and the one thing it could still do is mislead: on a transition it pairs a fresh byte with a deactivation state read from a model no HTS branch writes, so the two halves can briefly disagree. Also removed is the `1.16.0` error message saying a deactivation could not be cleared from Home Assistant, which `1.16.1` made unreachable.
 
+### Fixed
+- **The Bypass switch no longer silently flips to "protecting" when a degraded snapshot omits the deactivation state (#419).** A full device snapshot whose rows arrive without their usual detail — the same kind of event that emptied battery readings in #403 — also cleared the deactivation state, so a device the panel had deactivated read as protecting: on the reporting install, three deactivated sensors showed as active for over four hours. That is the wrong direction for a security integration to fail in, and a cleared switch cannot be told apart from a genuine reactivation.
+
+  The hub itself reports each device's bypass state on the status channel the integration already listens to (the read validated on hardware in #338), so a snapshot's silence is now corroborated against it: still reported engaged — the deactivation is carried forward; reported lifted, too old to trust, or not reported at all — the clear goes through exactly as before. If the hub later reports the bypass lifted while the carried state is the only one in force, the carry is withdrawn on the spot. No additional requests to Ajax are made anywhere in this — the corroborating value already arrives on the existing stream. Found, measured and dated by @wip3out3r in #403.
+
 ## [1.16.1] - 2026-08-08
 
 Consolidates `1.16.1-beta.1`, hardware-confirmed in both directions by @wip3out3r.

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -209,6 +209,20 @@ _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS: frozenset[str] = frozenset(
     }
 )
 
+# HTS per-device kv key carrying the hub's own report of a device's engaged
+# bypass modes (#419). Hardware-validated in #338: `01` ⇔ the panel has the
+# device deactivated, `00` ⇔ protecting, 1:1 across every device that reports
+# it at rest. It rides the STATUS_BODY the client already requests every 60 s,
+# so consuming it adds no Ajax API traffic.
+_HTS_BYPASS_STATE_KEY = 0xB7
+
+# How long the last 0xB7 report may be trusted to corroborate a snapshot's
+# silence (#419). STATUS_BODY refreshes every 60 s, so 15 minutes is ~15
+# missed refreshes — generous against the longest observed drop-to-reconnect
+# (3m24s, #403) while refusing to let an hours-stale report overrule a
+# snapshot after HTS has been down long enough for the world to have moved.
+_HTS_BYPASS_STATE_TRUST_WINDOW = 15 * 60.0
+
 # HTS per-device kv keys that may carry a Button's last-activity timestamp
 # (#348) — read-only probe, nothing is routed off them.
 #
@@ -487,6 +501,14 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # HTS client for hub network data (ethernet, wifi, gsm, power)
         self._hts_client: HtsClient | None = None
         self._hts_task: asyncio.Task[None] | None = None
+        # Last hub-reported bypass state per device (#419): HTS 0xB7 as
+        # (deactivated, monotonic seen-at). Gates the deactivation
+        # carry-forward across gRPC snapshots; never creates state.
+        self._hts_bypass_state: dict[str, tuple[bool, float]] = {}
+        # Devices whose deactivation statuses exist ONLY because the
+        # corroborated carry preserved them (#419). Membership licenses the
+        # withdraw-on-0xB7=00 path; anything gRPC-fresh clears membership.
+        self._hts_carried_deactivation_ids: set[str] = set()
         # Monotonic timestamp of the last user-triggered STATUS_BODY
         # refresh per hub. Read by `async_request_manual_refresh` to
         # rate-limit successive presses to `MANUAL_REFRESH_INTERVAL`.
@@ -1492,6 +1514,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # signal only on the status stream. Runs before anything that can
         # return early so every device family is covered.
         self._maybe_apply_hts_device_tamper(device_id_hex, device, kv)
+        # The hub's own bypass state, 0xB7 (#419) — tracked before anything
+        # that can return early so every reporting family feeds the
+        # deactivation carry-forward gate.
+        self._maybe_track_hts_bypass_state(device_id_hex, device, kv)
         # A modeled SpaceControl's settings row (#311) — read-only, logged
         # before anything that can return early: this hub class never reaches
         # the keyfob path, so this is the only place its row is ever visible.
@@ -1572,6 +1598,57 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             self.request_security_snapshot_refresh()
         return True
+
+    def _maybe_track_hts_bypass_state(
+        self, device_id_hex: str, device: Device, kv: dict[int, bytes]
+    ) -> None:
+        """Track the hub's per-device bypass state, HTS `0xB7` (#419).
+
+        Read-mostly by design. The stored value gates the deactivation
+        carry-forward in `_handle_devices_snapshot` — see the carry there for
+        why a gRPC snapshot's silence is ambiguous. The one write this method
+        performs is a WITHDRAWAL: when the hub reports the bypass lifted
+        (`00`) for a device whose deactivation statuses exist only because
+        that carry preserved them, the carry is taken back on the spot, so it
+        can never outlive the hub's own word by more than one status refresh.
+        It never creates deactivation state — a `01` for a device the model
+        shows as protecting stores the observation and does nothing else
+        (#406's lesson: withdraw at the gate that applied the value).
+        """
+        raw = kv.get(_HTS_BYPASS_STATE_KEY)
+        if raw is None:
+            return
+        deactivated = any(byte != 0 for byte in raw)
+        self._hts_bypass_state[device_id_hex] = (deactivated, time.monotonic())
+        if deactivated or device_id_hex not in self._hts_carried_deactivation_ids:
+            return
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        self._hts_carried_deactivation_ids.discard(device_id_hex)
+        # Re-fetch: an earlier handler in this same kv pass (the #339 tamper
+        # apply) may have replaced the model object the caller handed us.
+        current = self.devices.get(device_id_hex, device)
+        stripped = {
+            key: value
+            for key, value in current.statuses.items()
+            if key not in DEACTIVATION_STATUS_KEYS and key != DEACTIVATED_KEY
+        }
+        self.devices[device_id_hex] = dc_replace(current, statuses=stripped, bypassed=False)
+        _LOGGER.debug(
+            "Withdrew carried deactivation for %s — the hub reports the bypass lifted",
+            device_id_hex,
+        )
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
+    def _hts_confirms_deactivation(self, device_id: str) -> bool:
+        """True when a fresh HTS `0xB7` report says the bypass is engaged (#419)."""
+        entry = self._hts_bypass_state.get(device_id)
+        if entry is None:
+            return False
+        deactivated, seen_at = entry
+        if not deactivated:
+            return False
+        return (time.monotonic() - seen_at) <= _HTS_BYPASS_STATE_TRUST_WINDOW
 
     def _log_hts_space_control_settings(
         self, device_id_hex: str, device: Device, kv: dict[int, bytes]
@@ -2308,6 +2385,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         carried_reading_count = 0
         carried_battery_count = 0
+        carried_deactivation_count = 0
         for device in devices:
             # Per-device temperature (#220, #229) comes from a separate
             # per-device RPC, not this stream, so a fresh snapshot would wipe
@@ -2392,6 +2470,44 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if device.battery is None and existing.battery is not None:
                     carried_battery_count += 1
                     device = dc_replace(device, battery=existing.battery)
+                # Deactivation statuses are deliberately NOT in the blanket
+                # carry list above: on the update path a genuine reactivation
+                # arrives as an explicit REMOVE op, but here absence is the
+                # only signal there is — and #403 measured a degraded snapshot
+                # whose silence meant nothing (three deactivated sensors read
+                # as protecting for four hours, #419). The hub's own bypass
+                # state (HTS 0xB7, hardware-validated in #338) disambiguates:
+                # carry only while a fresh report says the bypass is still
+                # engaged. A genuine reactivation reads `00` there and the
+                # clear goes through unchanged, as it does for devices with no
+                # report at all (family doesn't send it / HTS quiet beyond the
+                # trust window). `_maybe_track_hts_bypass_state` withdraws the
+                # carry the moment the hub reports the bypass lifted.
+                if not any(key in device.statuses for key in DEACTIVATION_STATUS_KEYS):
+                    had_deactivation = existing.bypassed or any(
+                        existing.statuses.get(key) for key in DEACTIVATION_STATUS_KEYS
+                    )
+                    if had_deactivation and self._hts_confirms_deactivation(device.id):
+                        carried_deactivation = {
+                            key: existing.statuses[key]
+                            for key in (*DEACTIVATION_STATUS_KEYS, DEACTIVATED_KEY)
+                            if key in existing.statuses
+                        }
+                        device = dc_replace(
+                            device,
+                            statuses={**device.statuses, **carried_deactivation},
+                            bypassed=existing.bypassed or device.bypassed,
+                        )
+                        self._hts_carried_deactivation_ids.add(device.id)
+                        carried_deactivation_count += 1
+                    else:
+                        # Cleared (or nothing to clear) — any earlier carry is
+                        # no longer what the model's state rests on.
+                        self._hts_carried_deactivation_ids.discard(device.id)
+                else:
+                    # The snapshot itself reports deactivation — gRPC-fresh,
+                    # so an earlier carry is superseded.
+                    self._hts_carried_deactivation_ids.discard(device.id)
             self.devices[device.id] = device
         # `DevicesApi` dedups video-doorbell twins per snapshot, but the merge
         # above only ever *adds* keys — a `motion_cam_video_*` ghost that was
@@ -2408,6 +2524,14 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             carried_reading_count,
             carried_battery_count,
         )
+        # Separate line on purpose — the one above is grepped by field
+        # instrumentation (#403) and its shape must stay stable.
+        if carried_deactivation_count:
+            _LOGGER.debug(
+                "Deactivation state carried across snapshot for %d device(s) "
+                "on the hub's own bypass report (#419)",
+                carried_deactivation_count,
+            )
         # The polled fallback runs inside `_async_update_data`, whose return
         # value the coordinator broadcasts anyway — a second notification
         # from here would be redundant.
@@ -2515,6 +2639,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     new_statuses.pop(DEACTIVATED_KEY, None)
             else:
                 new_statuses[DEACTIVATED_KEY] = True
+            # gRPC-fresh deactivation info — the model's state no longer
+            # rests on a #419 snapshot carry, so the withdraw path must
+            # not touch it.
+            self._hts_carried_deactivation_ids.discard(device.id)
 
         updated = DeviceModel(
             id=device.id,

--- a/custom_components/aegis_ajax/manifest.json
+++ b/custom_components/aegis_ajax/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/bvis/aegis-hass/issues",
     "requirements": ["grpcio>=1.75.1", "protobuf>=6.31.1", "firebase-messaging>=0.4.5", "pycryptodome>=3.20"],
-    "version": "1.16.1"
+    "version": "1.16.2-beta.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aegis-ajax-hass"
 # Mirror of manifest.json's version (the source of truth HA reads). Kept in
 # sync by tests/unit/test_version_consistency.py — bump both when releasing.
-version = "1.16.1"
+version = "1.16.2-beta.1"
 description = "Home Assistant integration for Ajax Security Systems (co-branded) via gRPC"
 requires-python = ">=3.12"
 license = "MIT"

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1039,6 +1039,113 @@ class TestStreamHandlers:
         # discriminating rather than the carry-forward simply not running.
         assert coordinator.devices["d1"].statuses["signal_strength"] == 3
 
+    # --- #419: deactivation must survive a degraded snapshot the hub disagrees with
+
+    def _deactivated_device(self, device_id: str = "d1") -> Device:
+        return _make_device(
+            device_id,
+            statuses={"temporary_deactivation_whole": True, "deactivated": True},
+        )
+
+    def _hub_says(
+        self,
+        coordinator: AjaxCobrandedCoordinator,  # noqa: F821
+        device_id: str,
+        *,
+        deactivated: bool,
+        age: float = 0.0,
+    ) -> None:
+        import time
+
+        coordinator._hts_bypass_state[device_id] = (deactivated, time.monotonic() - age)
+
+    def test_snapshot_clears_deactivation_without_hub_corroboration(self) -> None:
+        """Pins the pre-#419 behavior for families that never report 0xB7:
+        absence in the snapshot stays the clearing signal."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = self._deactivated_device()
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert "deactivated" not in coordinator.devices["d1"].statuses
+        assert "temporary_deactivation_whole" not in coordinator.devices["d1"].statuses
+
+    def test_snapshot_carries_deactivation_while_the_hub_reports_it_engaged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The #403 measurement: a degraded snapshot's silence, corroborated
+        against the hub's own bypass report, is a degraded row — not a
+        reactivation."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = self._deactivated_device()
+        self._hub_says(coordinator, "d1", deactivated=True)
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert coordinator.devices["d1"].statuses["deactivated"] is True
+        assert coordinator.devices["d1"].statuses["temporary_deactivation_whole"] is True
+        assert "d1" in coordinator._hts_carried_deactivation_ids
+        assert "Deactivation state carried across snapshot" in caplog.text
+
+    def test_snapshot_clears_deactivation_when_the_hub_reports_it_lifted(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = self._deactivated_device()
+        self._hub_says(coordinator, "d1", deactivated=False)
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert "deactivated" not in coordinator.devices["d1"].statuses
+        assert "d1" not in coordinator._hts_carried_deactivation_ids
+
+    def test_a_stale_hub_report_does_not_corroborate(self) -> None:
+        """Beyond the trust window the hub's word is too old to overrule a
+        snapshot — HTS may have been down long enough for the world to move."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = self._deactivated_device()
+        self._hub_says(coordinator, "d1", deactivated=True, age=16 * 60)
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert "deactivated" not in coordinator.devices["d1"].statuses
+
+    def test_deactivation_in_the_snapshot_wins_over_the_carry(self) -> None:
+        """A snapshot that itself reports deactivation is gRPC-fresh: applied
+        as-is and the carried-marker dropped, so the withdraw path can never
+        touch state the server vouched for."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = self._deactivated_device()
+        coordinator._hts_carried_deactivation_ids.add("d1")
+        self._hub_says(coordinator, "d1", deactivated=True)
+
+        coordinator._handle_devices_snapshot([self._deactivated_device()])
+
+        assert coordinator.devices["d1"].statuses["deactivated"] is True
+        assert "d1" not in coordinator._hts_carried_deactivation_ids
+
+    def test_carry_does_not_invent_deactivation(self) -> None:
+        """0xB7=01 for a device the model shows as protecting stores the
+        observation and nothing else — the carry preserves, never creates."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+        self._hub_says(coordinator, "d1", deactivated=True)
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert "deactivated" not in coordinator.devices["d1"].statuses
+        assert "d1" not in coordinator._hts_carried_deactivation_ids
+
+    def test_bypassed_field_is_carried_with_the_corroboration(self) -> None:
+        """`is_device_deactivated` reads `bypassed` as an independent source,
+        so the carry must preserve it too."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = replace(_make_device("d1"), bypassed=True)
+        self._hub_says(coordinator, "d1", deactivated=True)
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert coordinator.devices["d1"].bypassed is True
+
     def test_a_value_in_the_snapshot_wins_over_the_carried_one(self) -> None:
         """Carry-forward only fills gaps, so #312's live tracking still holds.
 
@@ -2490,6 +2597,88 @@ class TestHtsTamperProbeLogging:
             coordinator._on_hts_device_kv("002B1A51", "003AE89B", {0x42: b"\x00\x28"})
 
         assert "HTS tamper probe" not in caplog.text
+
+
+class TestHtsBypassStateTracking:
+    """HTS `0xB7` as the corroborator for the deactivation carry (#419).
+
+    The key is hardware-validated (#338): `01` ⇔ deactivated, `00` ⇔
+    protecting, 1:1 at rest across every reporting device. Tracking it is
+    read-mostly: the single write-back allowed is withdrawing a carry this
+    coordinator itself applied, the moment the hub reports the bypass lifted.
+    """
+
+    def test_kv_row_records_the_hub_bypass_state(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.devices["003AE89B"] = _make_device("003AE89B")
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("002B1A51", "003AE89B", {0xB7: b"\x01"})
+        assert coordinator._hts_bypass_state["003AE89B"][0] is True
+
+        coordinator._on_hts_device_kv("002B1A51", "003AE89B", {0xB7: b"\x00"})
+        assert coordinator._hts_bypass_state["003AE89B"][0] is False
+
+    def test_hub_lift_withdraws_a_carried_deactivation(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The carry can never outlive the hub's own word by more than one
+        status refresh — `00` takes it back on the spot."""
+        coordinator = _make_coordinator()
+        coordinator.devices["003AE89B"] = replace(
+            _make_device(
+                "003AE89B",
+                statuses={
+                    "temporary_deactivation_whole": True,
+                    "deactivated": True,
+                    "signal_strength": 3,
+                },
+            ),
+            bypassed=True,
+        )
+        coordinator._hts_carried_deactivation_ids.add("003AE89B")
+        coordinator.async_set_updated_data = MagicMock()
+
+        with caplog.at_level("DEBUG", logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("002B1A51", "003AE89B", {0xB7: b"\x00"})
+
+        device = coordinator.devices["003AE89B"]
+        assert "deactivated" not in device.statuses
+        assert "temporary_deactivation_whole" not in device.statuses
+        assert device.bypassed is False
+        # A measurement alongside survives the strip.
+        assert device.statuses["signal_strength"] == 3
+        assert "003AE89B" not in coordinator._hts_carried_deactivation_ids
+        coordinator.async_set_updated_data.assert_called_once()
+        assert "Withdrew carried deactivation" in caplog.text
+
+    def test_hub_lift_leaves_grpc_fresh_deactivation_alone(self) -> None:
+        """Withdrawal is licensed only for state that exists because of the
+        carry — deactivation the server itself reported is not ours to clear."""
+        coordinator = _make_coordinator()
+        coordinator.devices["003AE89B"] = _make_device(
+            "003AE89B",
+            statuses={"temporary_deactivation_whole": True, "deactivated": True},
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("002B1A51", "003AE89B", {0xB7: b"\x00"})
+
+        assert coordinator.devices["003AE89B"].statuses["deactivated"] is True
+
+    def test_hub_report_engaged_never_writes(self) -> None:
+        """`01` for a protecting device stores the observation and nothing
+        else — routing a wrong byte onto the switch would misreport whether a
+        sensor is protecting."""
+        coordinator = _make_coordinator()
+        original = _make_device("003AE89B")
+        coordinator.devices["003AE89B"] = original
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("002B1A51", "003AE89B", {0xB7: b"\x01"})
+
+        assert coordinator.devices["003AE89B"] is original
+        assert coordinator.devices["003AE89B"].statuses == {}
 
 
 class TestHtsButtonActivityProbe:


### PR DESCRIPTION
Fixes the defect in #419, found and measured by @wip3out3r in #403: a degraded device snapshot cleared the deactivation statuses along with the readings, so the Bypass switch read **protecting** for devices the panel had deactivated — 4 h 06 m on the measuring install — and a cleared switch cannot be told apart from a genuine reactivation.

**The fix.** The snapshot's silence is now corroborated against the hub's own per-device bypass report (HTS `0xB7`, hardware-validated in #338), which rides the STATUS_BODY the client already requests every 60 s:

- still reported **engaged** → the deactivation statuses (and `bypassed`) are carried forward, and a DEBUG line records it — on its own line, so the `Device snapshot applied` line field instrumentation greps stays byte-stable;
- reported **lifted**, **stale** beyond a 15-minute trust window, or **never reported** (family/firmware doesn't send it) → the clear goes through exactly as before.

**The carry can never outlive the hub's word.** If a fresh `0xB7=00` arrives while the model's deactivation exists only because of this carry, it is withdrawn on the spot. Withdrawal is licensed only for carried state — deactivation the server itself reported is never touched. And the carry never *creates* state: `0xB7=01` for a protecting device stores the observation and does nothing (#406's lesson, both directions).

**Zero additional Ajax API traffic** — the corroborating value already arrives on the existing status stream; this is local bookkeeping only.

11 new tests: the three gate outcomes, staleness, snapshot-wins-over-carry, no-invention, `bypassed` field carry, tracking, withdraw, withdraw-not-licensed, and engaged-never-writes. The corroboration gate and the withdraw were both mutation-checked (each mutation caught by exactly the tests that pin it). Bumps `1.16.2-beta.1` with the CHANGELOG entry.

Refs #419, #403.