### PR TITLE
fix(devices): honor the stream's device REMOVE and resync membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A device deleted in the Ajax app is now deleted in Home Assistant too (#422).** The device stream announces a deletion explicitly, carrying a stripped residual record of the deleted device. The integration ignored the deletion marker and treated the notice as a regular update — so instead of removing the device it merged the residual back in, which also overwrote the device's name with the empty one the residual carries. That is the reporter's "Unnamed device": a ghost kept alive by the very message that should have removed it, surviving reloads through the warm-start cache, and undeletable by hand because Home Assistant only offers "Delete device" when the integration implements the removal hook. Three changes, none of them adding a single request to Ajax:
+  - The deletion notice now removes the device everywhere — entities, device registry card, warm-start cache — the moment it arrives.
+  - The complete device list the hub sends on every stream reconnect now resyncs membership: devices the hub no longer reports (deleted while Home Assistant was offline, or ghosts predating this fix) stop claiming state. Their leftover card is deliberately not auto-deleted — absence is weaker evidence than an explicit deletion notice, and a wrong delete would cost the card's area and name customizations.
+  - "Delete device" now appears on the integration's device pages, and works for any device the hub no longer reports. Devices still alive on the hub are refused, and a wrongly deleted card re-creates itself from the next snapshot.
+
 ## [1.16.2] - 2026-08-09
 
 Consolidates `1.16.2-beta.1`. The status-channel signal the fix leans on was validated on hardware in both directions by @wip3out3r, whose baseline measurements also pinned the fix's bounds; #419 stays open as a watch until a real degraded snapshot exercises the carry.

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -81,6 +81,7 @@ from custom_components.aegis_ajax.repairs import async_check_grpcio_version  # n
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
+    from homeassistant.helpers.device_registry import DeviceEntry
 
 _FCM_KEYS = {"fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id"}
 
@@ -638,6 +639,31 @@ async def async_unload_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntr
         coordinator: AjaxCobrandedCoordinator = entry.runtime_data
         await coordinator.async_shutdown()
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    entry: AjaxCobrandedConfigEntry,
+    device_entry: DeviceEntry,
+) -> bool:
+    """Let the user delete a device the hub no longer reports (#422).
+
+    HA only offers "Delete device" when the integration defines this hook.
+    Anything the coordinator still tracks (the hub, live devices,
+    runtime-discovered keyfobs) is refused; a device the hub stopped
+    reporting may go. If the hub in fact still reports it, the next
+    snapshot legitimately re-creates it — a wrong deletion self-heals.
+    """
+    coordinator: AjaxCobrandedCoordinator | None = getattr(entry, "runtime_data", None)
+    if coordinator is None:
+        # Entry not running — nothing can vouch for the device either way;
+        # allow, for the same self-healing reason.
+        return True
+    our_ids = {id_ for domain, id_ in device_entry.identifiers if domain == DOMAIN}
+    return not any(
+        device_id in coordinator.devices or device_id in coordinator.keyfobs
+        for device_id in our_ids
+    )
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry) -> None:

--- a/custom_components/aegis_ajax/api/devices.py
+++ b/custom_components/aegis_ajax/api/devices.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from custom_components.aegis_ajax.api import devices_parser
 from custom_components.aegis_ajax.api.devices_parser import (
@@ -39,6 +39,24 @@ _PROBE_CLIENT_VERSION = "3.60"
 # SmartLockType enum values (common.space.smartlock.SmartLockType).
 _SMART_LOCK_TYPE_ASSA_ABLOY = 1
 _SMART_LOCK_TYPE_ASSA_ABLOY_NA = 2
+
+# `SnapshotUpdate.update_type` value marking a device deletion
+# (mobilegwsvc.commonmodels.response.UpdateType.UPDATE_TYPE_REMOVE). The app
+# drops the row on this signal; merging the residual record instead is what
+# left ghost "Unnamed" devices behind after a panel-side delete (#422).
+_UPDATE_TYPE_REMOVE = 3
+
+
+class _DevicesSnapshotHandler(Protocol):
+    """Receiver for parsed device snapshots off the stream.
+
+    `complete=True` marks the space's complete device list (the stream's
+    leading snapshot on every (re)connect); single-device refreshes leave it
+    False so the consumer never treats them as authoritative for membership
+    (#422).
+    """
+
+    def __call__(self, devices: list[Device], *, complete: bool = ...) -> None: ...
 
 
 def _override_client_version(
@@ -569,14 +587,21 @@ class DevicesApi:
     def _handle_update(
         self,
         update: Any,  # noqa: ANN401
-        on_devices_snapshot: Callable[[list[Device]], None],
+        on_devices_snapshot: _DevicesSnapshotHandler,
         on_status_update: Callable[[str, str, dict[str, Any]], None],
+        on_device_removed: Callable[[str], None] | None = None,
     ) -> None:
         """Dispatch a single LightDeviceUpdate.
 
         Extracted out of the stream loop so the caller can wrap each
         update in try/except — one bad update must not kill the inner
         async-for loop (#119).
+
+        A `snapshot_update` carrying `update_type=REMOVE` is a device
+        deletion (#422): it goes to `on_device_removed` and is never merged.
+        With no removal handler wired the update is dropped, not merged —
+        merging the stripped residual record is what produced ghost
+        "Unnamed" devices.
         """
         update_kind = update.WhichOneof("update")
         if update_kind == "status_update":
@@ -683,9 +708,44 @@ class DevicesApi:
 
             on_status_update(device_id, status_name, payload)
         elif update_kind == "snapshot_update":
+            if int(update.snapshot_update.update_type) == _UPDATE_TYPE_REMOVE:
+                self._dispatch_device_removed(update, on_device_removed)
+                return
             device = self.parse_device(update.snapshot_update.light_device)
             if device is not None:
                 on_devices_snapshot([device])
+
+    def _dispatch_device_removed(
+        self,
+        update: Any,  # noqa: ANN401
+        on_device_removed: Callable[[str], None] | None,
+    ) -> None:
+        """Resolve a snapshot REMOVE's device id and hand it over (#422).
+
+        The envelope `device_id` is authoritative; the residual
+        `light_device` record is the fallback (it still carries its own id).
+        The record itself is never merged — it arrives stripped server-side.
+        """
+        try:
+            device_id = str(update.device_id.hub_light_device_id.device_id)
+        except AttributeError:
+            device_id = ""
+        if not device_id:
+            try:
+                parsed = self.parse_device(update.snapshot_update.light_device)
+            except Exception:  # noqa: BLE001
+                parsed = None
+            device_id = parsed.id if parsed is not None else ""
+        if not device_id:
+            _LOGGER.debug("Snapshot REMOVE carried no resolvable device id — dropped")
+            return
+        if on_device_removed is None:
+            _LOGGER.debug(
+                "Snapshot REMOVE for device %s with no removal handler wired — dropped",
+                device_id,
+            )
+            return
+        on_device_removed(device_id)
 
     # A dead stream that has stayed quiet at least this long (seconds) before
     # erroring looks like a network idle-timeout drop rather than a reset during
@@ -725,19 +785,24 @@ class DevicesApi:
     async def start_device_stream(
         self,
         space_id: str,
-        on_devices_snapshot: Callable[[list[Device]], None],
+        on_devices_snapshot: _DevicesSnapshotHandler,
         on_status_update: Callable[[str, str, dict[str, Any]], None],
+        on_device_removed: Callable[[str], None] | None = None,
     ) -> asyncio.Task[None]:
         """Start persistent gRPC stream for real-time device updates.
 
         Returns a background asyncio.Task that keeps the stream open indefinitely,
         reconnecting with exponential backoff on errors.
 
-        on_devices_snapshot(devices) is called with the initial snapshot and on
-        full snapshot_update events.
+        on_devices_snapshot(devices) is called with the initial snapshot
+        (`complete=True` — the space's complete device list) and on full
+        snapshot_update events (`complete=False` — a single-device refresh).
 
         on_status_update(device_id, status_name, data) is called for each status
         change, where data contains {"op": int} (1=ADD, 2=UPDATE, 3=REMOVE).
+
+        on_device_removed(device_id) is called when the stream reports a
+        device deletion (`snapshot_update` with `update_type=REMOVE`, #422).
         """
 
         async def _run_stream() -> None:
@@ -784,7 +849,9 @@ class DevicesApi:
                                         continue
                                     if device is not None:
                                         devices.append(device)
-                                on_devices_snapshot(self._dedupe_and_track_aliases(devices))
+                                on_devices_snapshot(
+                                    self._dedupe_and_track_aliases(devices), complete=True
+                                )
                                 # Reset backoff after successful snapshot
                                 backoff = 5.0
                             elif which == "updates":
@@ -795,7 +862,10 @@ class DevicesApi:
                                     # See #119 hardening notes.
                                     try:
                                         self._handle_update(
-                                            update, on_devices_snapshot, on_status_update
+                                            update,
+                                            on_devices_snapshot,
+                                            on_status_update,
+                                            on_device_removed,
                                         )
                                     except Exception:  # noqa: BLE001
                                         _LOGGER.warning(

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -2259,11 +2259,26 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _start_device_streams(self) -> None:
         """Start persistent device streams for all spaces."""
         for space_id in self._space_ids:
+
+            def _on_snapshot(
+                devices: list[Device],
+                *,
+                complete: bool = False,
+                _space_id: str = space_id,
+            ) -> None:
+                # The stream's leading snapshot is the space's complete
+                # device list — the one moment membership can be resynced
+                # (#422). Single-device refreshes pass complete=False.
+                self._handle_devices_snapshot(
+                    devices, complete_for_space=_space_id if complete else None
+                )
+
             try:
                 task = await self._devices_api.start_device_stream(
                     space_id,
-                    on_devices_snapshot=self._handle_devices_snapshot,
+                    on_devices_snapshot=_on_snapshot,
                     on_status_update=self._handle_status_update,
+                    on_device_removed=self._handle_device_removed,
                 )
                 self._stream_tasks.append(task)
                 _LOGGER.debug("Device stream started for space %s", space_id)
@@ -2366,9 +2381,18 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     def _handle_devices_snapshot(
-        self, devices: list[Device], *, notify_listeners: bool = True
+        self,
+        devices: list[Device],
+        *,
+        notify_listeners: bool = True,
+        complete_for_space: str | None = None,
     ) -> None:
         """Handle initial snapshot or full device snapshot update from stream.
+
+        When `complete_for_space` names a space, `devices` is that space's
+        complete device list and membership is resynced after the merge:
+        devices of that hub the list no longer contains are dropped from
+        tracking (#422).
 
         Emits one DEBUG line per snapshot, which is the observable this path was
         missing entirely (#403). @wip3out3r went looking for it and found there
@@ -2509,6 +2533,45 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     # so an earlier carry is superseded.
                     self._hts_carried_deactivation_ids.discard(device.id)
             self.devices[device.id] = device
+        # A complete per-space snapshot is authoritative for membership: a
+        # device of this hub the list no longer contains was deleted
+        # panel-side, possibly while we were away (#422). Drop it from
+        # tracking so its entities stop claiming state and its registry card
+        # becomes deletable via `async_remove_config_entry_device`. The
+        # registry entry is deliberately NOT removed here: absence is weaker
+        # evidence than the stream's explicit REMOVE — a parse-skip absents a
+        # live device (#383) — and a wrong registry delete costs the user's
+        # area/name customizations. The hub itself never rides on absence,
+        # whatever the list says.
+        if complete_for_space is not None:
+            space = self.spaces.get(complete_for_space)
+            hub_id = space.hub_id if space is not None else None
+            if hub_id:
+                snapshot_ids = {device.id for device in devices}
+                stale_ids = [
+                    device_id
+                    for device_id, device in self.devices.items()
+                    if device.hub_id == hub_id
+                    and device_id not in snapshot_ids
+                    and not device.device_type.startswith("hub")
+                ]
+                for device_id in stale_ids:
+                    del self.devices[device_id]
+                    self._hts_carried_deactivation_ids.discard(device_id)
+                if stale_ids:
+                    _LOGGER.info(
+                        "%d device(s) no longer in the hub's device list for "
+                        "space %s; dropped from tracking — their Home Assistant "
+                        "device entries can now be deleted from the device page "
+                        "(#422)",
+                        len(stale_ids),
+                        complete_for_space,
+                    )
+            else:
+                _LOGGER.debug(
+                    "Complete snapshot for unknown space %s — membership resync skipped",
+                    complete_for_space,
+                )
         # `DevicesApi` dedups video-doorbell twins per snapshot, but the merge
         # above only ever *adds* keys — a `motion_cam_video_*` ghost that was
         # warm-started from the cache before its `video_edge_*` sibling
@@ -2575,6 +2638,35 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     ghost.device_type,
                 )
                 device_reg.async_remove_device(reg_device.id)
+
+    def _handle_device_removed(self, device_id: str) -> None:
+        """Handle the stream's explicit device REMOVE (#422).
+
+        Deleting a device in the Ajax app arrives as a `snapshot_update`
+        with `update_type=REMOVE`. That is an affirmative server statement —
+        unlike absence from a possibly-degraded snapshot (#419) — so it is
+        the one signal trusted to delete the device everywhere: coordinator
+        state, the warm-start cache, and the HA device registry (HA cascades
+        the entity-registry cleanup). If it ever fired wrongly, the next
+        snapshot re-adds the device and its entities return on reload.
+        """
+        device = self.devices.pop(device_id, None)
+        self._hts_carried_deactivation_ids.discard(device_id)
+        device_reg = dr.async_get(self.hass)
+        reg_device = device_reg.async_get_device(identifiers={(DOMAIN, device_id)})
+        if reg_device is not None:
+            device_reg.async_remove_device(reg_device.id)
+        if device is None and reg_device is None:
+            _LOGGER.debug("Stream REMOVE for untracked device %s — nothing to drop", device_id)
+            return
+        _LOGGER.info(
+            "Device %s (%s) was removed on the panel side; removed from Home Assistant (#422)",
+            device_id,
+            device.device_type if device is not None else "not tracked",
+        )
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+        if self._devices_cache is not None:
+            self._devices_cache.async_schedule_save(self.devices)
 
     def _handle_status_update(self, device_id: str, status_name: str, data: dict[str, Any]) -> None:
         """Handle real-time status update from the persistent stream.

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1270,6 +1270,95 @@ class TestStreamHandlers:
         assert "310A8DF4" not in coordinator.devices
         device_reg.async_remove_device.assert_not_called()
 
+    def test_handle_device_removed_evicts_device_registry_and_cache(self) -> None:
+        """#422 — the stream's explicit REMOVE (a device deleted in the Ajax
+        app) deletes the device everywhere: coordinator state, HA device
+        registry, warm-start cache."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1")
+        coordinator._hts_carried_deactivation_ids.add("d1")
+        coordinator._devices_cache = MagicMock()
+
+        reg_device = MagicMock()
+        reg_device.id = "reg-d1"
+        device_reg = MagicMock()
+        device_reg.async_get_device.return_value = reg_device
+
+        with patch(
+            "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg
+        ):
+            coordinator._handle_device_removed("d1")
+
+        assert "d1" not in coordinator.devices
+        assert "d1" not in coordinator._hts_carried_deactivation_ids
+        device_reg.async_remove_device.assert_called_once_with("reg-d1")
+        coordinator.async_set_updated_data.assert_called_once()
+        coordinator._devices_cache.async_schedule_save.assert_called_once()
+
+    def test_handle_device_removed_unknown_id_is_quiet(self) -> None:
+        """A REMOVE for a device we never tracked (and with no registry
+        entry) must not notify listeners or rewrite the cache."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator._devices_cache = MagicMock()
+        device_reg = MagicMock()
+        device_reg.async_get_device.return_value = None
+
+        with patch(
+            "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg
+        ):
+            coordinator._handle_device_removed("never-seen")
+
+        device_reg.async_remove_device.assert_not_called()
+        coordinator.async_set_updated_data.assert_not_called()
+        coordinator._devices_cache.async_schedule_save.assert_not_called()
+
+    def test_complete_snapshot_drops_absent_devices_of_its_hub(self) -> None:
+        """#422 — a complete per-space snapshot is authoritative for
+        membership: devices of that hub missing from the list are dropped
+        from tracking. The hub itself and other hubs' devices are untouched,
+        and the registry entry is deliberately NOT auto-removed — absence is
+        weaker evidence than the explicit REMOVE (#419, #383)."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.spaces = {"s1": _make_space("s1")}  # hub-1
+        present = _make_device("d1")
+        stale = _make_device("d2")
+        hub = replace(_make_device("hub-1"), device_type="hub_2")
+        other_hub_device = replace(_make_device("d9"), hub_id="hub-2")
+        for device in (present, stale, hub, other_hub_device):
+            coordinator.devices[device.id] = device
+        coordinator._hts_carried_deactivation_ids.add("d2")
+
+        device_reg = MagicMock()
+        with patch(
+            "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg
+        ):
+            # The hub is deliberately absent from the list too — it must
+            # survive on its device_type guard, whatever the list says.
+            coordinator._handle_devices_snapshot([present], complete_for_space="s1")
+
+        assert set(coordinator.devices) == {"d1", "hub-1", "d9"}
+        assert "d2" not in coordinator._hts_carried_deactivation_ids
+        device_reg.async_remove_device.assert_not_called()
+
+    def test_complete_snapshot_for_unknown_space_drops_nothing(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d2"] = _make_device("d2")
+
+        coordinator._handle_devices_snapshot([_make_device("d1")], complete_for_space="ghost-space")
+
+        assert set(coordinator.devices) == {"d1", "d2"}
+
+    def test_single_device_snapshot_never_drops_others(self) -> None:
+        """A `snapshot_update` refresh of one device (complete_for_space
+        unset) must never resync membership."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.spaces = {"s1": _make_space("s1")}
+        coordinator.devices["d2"] = _make_device("d2")
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert set(coordinator.devices) == {"d1", "d2"}
+
     def test_handle_status_update_add_sets_status_true(self) -> None:
         coordinator = self._make_coordinator_with_stream()
         coordinator.devices["d1"] = _make_device("d1")
@@ -1850,11 +1939,19 @@ class TestStreamHandlers:
 
         result = await coordinator._async_update_data()
 
-        coordinator._devices_api.start_device_stream.assert_called_once_with(
-            "s1",
-            on_devices_snapshot=coordinator._handle_devices_snapshot,
-            on_status_update=coordinator._handle_status_update,
-        )
+        coordinator._devices_api.start_device_stream.assert_called_once()
+        call = coordinator._devices_api.start_device_stream.call_args
+        assert call.args == ("s1",)
+        # The snapshot handler is a per-space closure that threads the
+        # `complete` flag into the membership resync (#422).
+        assert callable(call.kwargs["on_devices_snapshot"])
+        assert call.kwargs["on_status_update"] == coordinator._handle_status_update
+        assert call.kwargs["on_device_removed"] == coordinator._handle_device_removed
+        coordinator._handle_devices_snapshot = MagicMock()
+        call.kwargs["on_devices_snapshot"]([], complete=True)
+        coordinator._handle_devices_snapshot.assert_called_with([], complete_for_space="s1")
+        call.kwargs["on_devices_snapshot"]([])
+        coordinator._handle_devices_snapshot.assert_called_with([], complete_for_space=None)
         assert coordinator._streams_started is True
         assert mock_task in coordinator._stream_tasks
         assert "spaces" in result

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -24,6 +24,22 @@ from custom_components.aegis_ajax.api.models import Device, DeviceCommand
 from custom_components.aegis_ajax.const import DeviceState
 
 
+def _make_light_device_mock(device_id: str = "dev-1") -> MagicMock:
+    mock_light_device = MagicMock()
+    mock_light_device.WhichOneof.return_value = "hub_device"
+    mock_light_device.hub_device.common_device.profile.id = device_id
+    mock_light_device.hub_device.common_device.profile.name = "Sensor"
+    mock_light_device.hub_device.common_device.profile.room_id = ""
+    mock_light_device.hub_device.common_device.profile.group_id = ""
+    mock_light_device.hub_device.common_device.profile.malfunctions = 0
+    mock_light_device.hub_device.common_device.profile.bypassed = False
+    mock_light_device.hub_device.common_device.profile.states = []
+    mock_light_device.hub_device.common_device.profile.statuses = []
+    mock_light_device.hub_device.common_device.hub_id = "hub-1"
+    mock_light_device.hub_device.common_device.object_type.WhichOneof.return_value = "door_protect"
+    return mock_light_device
+
+
 class TestParseDevice:
     def test_parse_hub_device(self) -> None:
         proto_device = MagicMock()
@@ -247,6 +263,105 @@ class TestParseDevice:
 
         assert captured["status_name"] == "lock_control_status"
         assert captured["payload"]["value"] == "unlocked"
+
+    def test_handle_update_snapshot_remove_routes_to_on_device_removed(self) -> None:
+        """A `snapshot_update` with `update_type=REMOVE` is a device deletion
+        (#422), not a refresh. The residual record must NOT be merged back —
+        it arrives stripped server-side, and merging it is what wiped device
+        names into "Unnamed device" — and the removal handler gets the id.
+        """
+        from v3.mobilegwsvc.service.stream_light_devices import (  # noqa: PLC0415
+            response_pb2,
+        )
+
+        update = response_pb2.StreamLightDevicesResponse.Success.Update()
+        update.device_id.hub_light_device_id.device_id = "30427616"
+        update.snapshot_update.update_type = 3  # UPDATE_TYPE_REMOVE
+        # `light_device` deliberately left unset — the tombstone shape.
+
+        snapshots: list[list[Any]] = []
+        removed: list[str] = []
+
+        api = DevicesApi(MagicMock())
+        api._handle_update(
+            update,
+            on_devices_snapshot=lambda devices, **_kw: snapshots.append(devices),
+            on_status_update=lambda _d, _s, _p: None,
+            on_device_removed=removed.append,
+        )
+
+        assert removed == ["30427616"]
+        assert snapshots == []
+
+    def test_handle_update_snapshot_remove_falls_back_to_record_id(self) -> None:
+        """A REMOVE whose envelope `device_id` is empty still resolves the
+        device through the residual record's own id."""
+        update = MagicMock()
+        update.WhichOneof.return_value = "snapshot_update"
+        update.device_id.hub_light_device_id.device_id = ""
+        update.snapshot_update.update_type = 3  # UPDATE_TYPE_REMOVE
+        update.snapshot_update.light_device = _make_light_device_mock("dev-55")
+
+        removed: list[str] = []
+        api = DevicesApi(MagicMock())
+        api._handle_update(
+            update,
+            on_devices_snapshot=lambda _devices, **_kw: pytest.fail("REMOVE must not merge"),
+            on_status_update=lambda _d, _s, _p: None,
+            on_device_removed=removed.append,
+        )
+
+        assert removed == ["dev-55"]
+
+    def test_handle_update_snapshot_remove_without_any_id_is_dropped(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No envelope id and an unparseable residual record: the update is
+        dropped without merging, leaving a DEBUG trace."""
+        import logging as _logging  # noqa: PLC0415
+
+        from v3.mobilegwsvc.service.stream_light_devices import (  # noqa: PLC0415
+            response_pb2,
+        )
+
+        update = response_pb2.StreamLightDevicesResponse.Success.Update()
+        update.snapshot_update.update_type = 3  # oneof selected, all else unset
+
+        calls: list[Any] = []
+        api = DevicesApi(MagicMock())
+        with caplog.at_level(_logging.DEBUG, logger="custom_components.aegis_ajax.api.devices"):
+            api._handle_update(
+                update,
+                on_devices_snapshot=lambda devices, **_kw: calls.append(devices),
+                on_status_update=lambda _d, _s, _p: None,
+                on_device_removed=calls.append,
+            )
+
+        assert calls == []
+        assert any("REMOVE" in record.message for record in caplog.records)
+
+    def test_handle_update_snapshot_add_and_update_still_merge(self) -> None:
+        """`update_type` ADD/UPDATE keeps today's merge path untouched."""
+        for update_type in (1, 2):
+            self._assert_snapshot_update_merges(update_type)
+
+    def _assert_snapshot_update_merges(self, update_type: int) -> None:
+        update = MagicMock()
+        update.WhichOneof.return_value = "snapshot_update"
+        update.snapshot_update.update_type = update_type
+        update.snapshot_update.light_device = _make_light_device_mock("dev-77")
+
+        snapshots: list[list[Any]] = []
+        api = DevicesApi(MagicMock())
+        api._handle_update(
+            update,
+            on_devices_snapshot=lambda devices, **_kw: snapshots.append(devices),
+            on_status_update=lambda _d, _s, _p: None,
+            on_device_removed=lambda _id: pytest.fail("ADD/UPDATE must not remove"),
+        )
+
+        assert len(snapshots) == 1, f"update_type={update_type}"
+        assert snapshots[0][0].id == "dev-77"
 
     def test_parse_unsupported_oneof_with_empty_proto_logs_nothing(
         self, caplog: pytest.LogCaptureFixture
@@ -2805,28 +2920,11 @@ class TestStartDeviceStream:
         mock_client._session.get_call_metadata.return_value = []
         return DevicesApi(mock_client)
 
-    def _make_light_device_mock(self, device_id: str = "dev-1") -> MagicMock:
-        mock_light_device = MagicMock()
-        mock_light_device.WhichOneof.return_value = "hub_device"
-        mock_light_device.hub_device.common_device.profile.id = device_id
-        mock_light_device.hub_device.common_device.profile.name = "Sensor"
-        mock_light_device.hub_device.common_device.profile.room_id = ""
-        mock_light_device.hub_device.common_device.profile.group_id = ""
-        mock_light_device.hub_device.common_device.profile.malfunctions = 0
-        mock_light_device.hub_device.common_device.profile.bypassed = False
-        mock_light_device.hub_device.common_device.profile.states = []
-        mock_light_device.hub_device.common_device.profile.statuses = []
-        mock_light_device.hub_device.common_device.hub_id = "hub-1"
-        mock_light_device.hub_device.common_device.object_type.WhichOneof.return_value = (
-            "door_protect"
-        )
-        return mock_light_device
-
     @pytest.mark.asyncio
     async def test_snapshot_calls_on_devices_snapshot(self) -> None:
         """Initial snapshot triggers on_devices_snapshot callback."""
         api = self._make_api()
-        mock_light_device = self._make_light_device_mock("dev-1")
+        mock_light_device = _make_light_device_mock("dev-1")
 
         mock_msg = MagicMock()
         mock_msg.HasField.side_effect = lambda field: field == "success"
@@ -2837,11 +2935,11 @@ class TestStartDeviceStream:
         async def _aiter() -> AsyncGenerator[MagicMock, None]:
             yield mock_msg
 
-        snapshot_received: list[list[Device]] = []
+        snapshot_received: list[tuple[list[Device], bool]] = []
         status_received: list[tuple[str, str, dict]] = []
 
-        def on_snap(devices: list) -> None:
-            snapshot_received.append(devices)
+        def on_snap(devices: list, *, complete: bool = False) -> None:
+            snapshot_received.append((devices, complete))
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
             status_received.append((device_id, status_name, data))
@@ -2856,8 +2954,12 @@ class TestStartDeviceStream:
                 await asyncio.wait_for(task, timeout=2.0)
 
         assert len(snapshot_received) == 1
-        assert len(snapshot_received[0]) == 1
-        assert snapshot_received[0][0].id == "dev-1"
+        devices, complete = snapshot_received[0]
+        assert len(devices) == 1
+        assert devices[0].id == "dev-1"
+        # The stream's leading snapshot is the space's complete device list —
+        # the flag the coordinator's membership resync keys off (#422).
+        assert complete is True
         assert status_received == []
 
     @pytest.mark.asyncio
@@ -2882,7 +2984,7 @@ class TestStartDeviceStream:
 
         status_received: list[tuple[str, str, dict]] = []
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             pass
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -2925,7 +3027,7 @@ class TestStartDeviceStream:
 
         status_received: list[tuple[str, str, dict]] = []
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             pass
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -2967,7 +3069,7 @@ class TestStartDeviceStream:
 
         status_received: list[tuple[str, str, dict]] = []
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             pass
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -3011,7 +3113,7 @@ class TestStartDeviceStream:
 
         status_received: list[tuple[str, str, dict]] = []
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             pass
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -3037,7 +3139,7 @@ class TestStartDeviceStream:
     async def test_snapshot_update_calls_on_devices_snapshot(self) -> None:
         """snapshot_update in Updates triggers on_devices_snapshot."""
         api = self._make_api()
-        mock_light_device = self._make_light_device_mock("dev-77")
+        mock_light_device = _make_light_device_mock("dev-77")
 
         update_msg = MagicMock()
         update_msg.HasField.side_effect = lambda field: field == "success"
@@ -3045,6 +3147,7 @@ class TestStartDeviceStream:
 
         single_update = MagicMock()
         single_update.WhichOneof.return_value = "snapshot_update"
+        single_update.snapshot_update.update_type = 2  # UPDATE
         single_update.snapshot_update.light_device = mock_light_device
 
         update_msg.success.updates.updates = [single_update]
@@ -3052,10 +3155,10 @@ class TestStartDeviceStream:
         async def _aiter() -> AsyncGenerator[MagicMock, None]:
             yield update_msg
 
-        snapshot_received: list[list] = []
+        snapshot_received: list[tuple[list, bool]] = []
 
-        def on_snap(devices: list) -> None:
-            snapshot_received.append(devices)
+        def on_snap(devices: list, *, complete: bool = False) -> None:
+            snapshot_received.append((devices, complete))
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
             pass
@@ -3070,7 +3173,53 @@ class TestStartDeviceStream:
                 await asyncio.wait_for(task, timeout=2.0)
 
         assert len(snapshot_received) == 1
-        assert snapshot_received[0][0].id == "dev-77"
+        devices, complete = snapshot_received[0]
+        assert devices[0].id == "dev-77"
+        # A single-device refresh is NOT a complete space list — it must never
+        # trigger the coordinator's membership resync (#422).
+        assert complete is False
+
+    @pytest.mark.asyncio
+    async def test_snapshot_update_remove_reaches_on_device_removed(self) -> None:
+        """The stream loop threads `on_device_removed` through to
+        `_handle_update`: a REMOVE update ends in the removal callback,
+        not in a merge (#422)."""
+        api = self._make_api()
+
+        update_msg = MagicMock()
+        update_msg.HasField.side_effect = lambda field: field == "success"
+        update_msg.success.WhichOneof.return_value = "updates"
+
+        single_update = MagicMock()
+        single_update.WhichOneof.return_value = "snapshot_update"
+        single_update.snapshot_update.update_type = 3  # UPDATE_TYPE_REMOVE
+        single_update.device_id.hub_light_device_id.device_id = "dev-gone"
+
+        update_msg.success.updates.updates = [single_update]
+
+        async def _aiter() -> AsyncGenerator[MagicMock, None]:
+            yield update_msg
+
+        removed: list[str] = []
+
+        def on_snap(devices: list, *, complete: bool = False) -> None:
+            pytest.fail("REMOVE must not merge")
+
+        def on_status(device_id: str, status_name: str, data: dict) -> None:
+            pytest.fail("REMOVE is not a status update")
+
+        with (
+            patch.dict("sys.modules", _make_stream_patch_modules(_aiter)),
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            mock_sleep.side_effect = asyncio.CancelledError()
+            task = await api.start_device_stream(
+                "space-1", on_snap, on_status, on_device_removed=removed.append
+            )
+            with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+                await asyncio.wait_for(task, timeout=2.0)
+
+        assert removed == ["dev-gone"]
 
     @pytest.mark.asyncio
     async def test_failure_message_reconnects(self) -> None:
@@ -3087,7 +3236,7 @@ class TestStartDeviceStream:
             call_count += 1
             yield failure_msg
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             pass
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -3116,7 +3265,7 @@ class TestStartDeviceStream:
             return
             yield  # make this an async generator
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             pass
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -3147,9 +3296,9 @@ class TestStartDeviceStream:
         same connection).
         """
         api = self._make_api()
-        good_a = self._make_light_device_mock("dev-good-a")
-        bad = self._make_light_device_mock("dev-bad")
-        good_b = self._make_light_device_mock("dev-good-b")
+        good_a = _make_light_device_mock("dev-good-a")
+        bad = _make_light_device_mock("dev-bad")
+        good_b = _make_light_device_mock("dev-good-b")
 
         # Make `bad` raise during parsing. Using WhichOneof so the failure
         # mirrors a real proto-shape mismatch surfaced at attribute access.
@@ -3167,7 +3316,7 @@ class TestStartDeviceStream:
 
         snapshot_received: list[list[Device]] = []
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             snapshot_received.append(devices)
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -3228,7 +3377,7 @@ class TestStartDeviceStream:
 
         status_received: list[tuple[str, str, dict]] = []
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             pass
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -3250,7 +3399,7 @@ class TestStartDeviceStream:
     async def test_snapshot_update_parse_exception_is_isolated(self) -> None:
         """A bad snapshot_update is dropped without crashing the stream."""
         api = self._make_api()
-        bad = self._make_light_device_mock("dev-bad")
+        bad = _make_light_device_mock("dev-bad")
         bad.WhichOneof.side_effect = TypeError("boom")
 
         update_msg = MagicMock()
@@ -3268,7 +3417,7 @@ class TestStartDeviceStream:
 
         snapshot_received: list[list] = []
 
-        def on_snap(devices: list) -> None:
+        def on_snap(devices: list, *, complete: bool = False) -> None:
             snapshot_received.append(devices)
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:
@@ -3412,7 +3561,7 @@ class TestSnapshotReplay:
 
         devices_seen: list[Device] = []
 
-        def on_snap(devices: list[Device]) -> None:
+        def on_snap(devices: list[Device], *, complete: bool = False) -> None:
             devices_seen.extend(devices)
 
         def on_status(device_id: str, status_name: str, data: dict) -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -927,3 +927,68 @@ class TestSetPhotoOnDemandModeHandler:
             await _async_handle_set_photo_on_demand_mode(hass, self._make_call({"user": True}))
 
         coordinator.devices_api.set_photo_on_demand_mode.assert_not_called()
+
+
+class TestAsyncRemoveConfigEntryDevice:
+    """#422 — the HA-standard manual-delete hook. HA only offers "Delete"
+    on a device page when the integration defines it."""
+
+    def _device_entry(self, *identifiers: tuple[str, str]) -> MagicMock:
+        device_entry = MagicMock()
+        device_entry.identifiers = set(identifiers)
+        return device_entry
+
+    def _entry(self) -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.devices = {"d1": MagicMock(), "hub-1": MagicMock()}
+        coordinator.keyfobs = {"kf1": MagicMock()}
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        return entry
+
+    @pytest.mark.asyncio
+    async def test_devices_the_hub_still_reports_stay(self) -> None:
+        from custom_components.aegis_ajax import async_remove_config_entry_device
+        from custom_components.aegis_ajax.const import DOMAIN
+
+        entry = self._entry()
+        hass = MagicMock()
+
+        assert not await async_remove_config_entry_device(
+            hass, entry, self._device_entry((DOMAIN, "d1"))
+        )
+        # The hub device is always tracked, so it is protected by the same gate.
+        assert not await async_remove_config_entry_device(
+            hass, entry, self._device_entry((DOMAIN, "hub-1"))
+        )
+        # Runtime-discovered keyfobs live outside coordinator.devices but are
+        # just as alive.
+        assert not await async_remove_config_entry_device(
+            hass, entry, self._device_entry((DOMAIN, "kf1"))
+        )
+
+    @pytest.mark.asyncio
+    async def test_devices_the_hub_no_longer_reports_may_go(self) -> None:
+        from custom_components.aegis_ajax import async_remove_config_entry_device
+        from custom_components.aegis_ajax.const import DOMAIN
+
+        entry = self._entry()
+        hass = MagicMock()
+
+        assert await async_remove_config_entry_device(
+            hass, entry, self._device_entry((DOMAIN, "ghost"))
+        )
+
+    @pytest.mark.asyncio
+    async def test_unloaded_entry_allows_removal(self) -> None:
+        """With no coordinator running nothing can vouch for the device;
+        deleting is allowed — a wrong delete self-heals on next setup."""
+        from custom_components.aegis_ajax import async_remove_config_entry_device
+        from custom_components.aegis_ajax.const import DOMAIN
+
+        entry = MagicMock(spec=[])  # no runtime_data attribute at all
+        hass = MagicMock()
+
+        assert await async_remove_config_entry_device(
+            hass, entry, self._device_entry((DOMAIN, "d1"))
+        )


### PR DESCRIPTION
## Summary

Deleting a device in the Ajax app never removed it from Home Assistant, and the leftover turned into an "Unnamed device" (#422). Both symptoms have one cause: the device stream announces a deletion as a `snapshot_update` with `update_type=REMOVE`, carrying a stripped residual record — and `_handle_update` ignored the `update_type`, merging the residual back in as if it were a refresh. The device never died, and the residual's empty name overwrote the real one. Reloads resurrected the ghost from the warm-start cache, and HA offers no "Delete device" button unless the integration implements the removal hook.

Three changes, zero added API traffic (every signal already arrives on the existing streams):

- **REMOVE honored**: the deletion notice now removes the device everywhere — coordinator state, device registry (entities cascade), warm-start cache. An affirmative server statement, so it is trusted to delete (unlike absence, per #419).
- **Membership resync on complete snapshots**: the stream's leading snapshot on every (re)connect is the space's complete device list; devices of that hub missing from it are dropped from tracking (covers deletions made while HA was offline, and ghosts predating this fix). Their registry card is deliberately NOT auto-removed — absence is weaker evidence than the explicit REMOVE (a parse-skip absents a live device, #383) and a wrong delete costs the user's area/name customizations. The hub itself is excluded by device type, whatever the list says.
- **`async_remove_config_entry_device`**: "Delete device" now appears on the integration's device pages and works for anything the hub no longer reports; live devices (hub, sensors, runtime-discovered keyfobs) are refused, and a wrongly deleted card re-creates itself from the next snapshot.

Relates to #422.

## Test plan

- [x] `make check` passes locally on a freshly built Docker image
- [x] New behaviour covered by unit tests in `tests/unit/` (13 new/updated tests, written first and verified failing before the fix)
- [x] Coverage stays at or above the 80% threshold (90.67%)
- [ ] User-facing strings updated in `strings.json` and the 14 translation files — N/A, no new strings (the delete confirmation is HA-core UI)
- [x] `README.md` / `CHANGELOG.md` updated when the change is user-visible (CHANGELOG under `[Unreleased]`)

## Notes for the reviewer

- The REMOVE's device id is resolved envelope-first (`update.device_id`), falling back to the residual record's own id; with neither, the update is dropped with a DEBUG line — a REMOVE must never merge.
- `on_devices_snapshot` gained a keyword-only `complete` flag (Protocol-typed) so only the leading per-space snapshot can trigger the membership resync; single-device `snapshot_update` refreshes cannot.
- The membership resync drops from tracking only. Full registry eviction rides exclusively on the explicit REMOVE — the #419/#383 lesson about acting on absence, applied to membership.