### PR TITLE
fix(coordinator): carry temperature across device snapshots that omit it

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -187,17 +187,20 @@ _HTS_TAMPER_ROUTED_DEVICE_TYPES: frozenset[str] = frozenset(
 # had: a snapshot omitting a *measurement* does not make the previous value
 # wrong, only older. Anything whose absence is itself the signal stays out.
 #
-# `temperature` is deliberately NOT here, and that leaves part of #403 unfixed.
-# Seven of his nine temperatures emptied — the light-stream families, which the
-# block below does not cover because it is gated on
-# `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES`. Adding it here fixes those, and it also
-# breaks `test_snapshot_does_not_invent_temperature_for_non_siren`, which pins the
-# opposite on purpose: a family with no per-device temperature source must not end
-# up holding one. Carrying only a value the device previously reported is not
-# "inventing" it, so the two may well be reconcilable — but overturning a pinned
-# decision wants evidence, not a convenient reading, and the warm-start cache
-# (#114) is a real way a bad value could become immortal once it is sticky. Left
-# open on the issue rather than settled here.
+# `temperature` was excluded here at first and #403 stayed open for it: the
+# worry was that a carry would leave a family with no per-device temperature
+# source holding one. It cannot — this pass only fills a key already present in
+# the existing statuses, so a device that never reported a temperature never
+# gains one (pinned by
+# `test_snapshot_does_not_invent_temperature_the_device_never_reported`). The
+# staleness/immortality risk is exactly the one already accepted for the four
+# keys above: a carried value is overwritten by the next row that reports one,
+# and seven of the nine temperatures that emptied in #403 were light-stream
+# families no siren-gated carry could reach. For the
+# `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES` families the value arrives from a
+# separate per-device RPC (#220, #229), so EVERY light snapshot omits it — for
+# them this carry is what keeps the sensor valued between timer fires, a job a
+# siren-gated block used to do before this entry subsumed it.
 #
 # `tamper` and the siren settings keep their own blocks below — they carry
 # provenance conditions this generic pass has no business reproducing.
@@ -206,6 +209,7 @@ _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS: frozenset[str] = frozenset(
         "humidity",
         "co2",
         "signal_strength",
+        "temperature",
     }
 )
 
@@ -2411,28 +2415,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         carried_battery_count = 0
         carried_deactivation_count = 0
         for device in devices:
-            # Per-device temperature (#220, #229) comes from a separate
-            # per-device RPC, not this stream, so a fresh snapshot would wipe
-            # the value we merged in `_async_refresh_hub_device_temperatures`
-            # and leave the sensor `unknown` until the next timer fire. Carry the
-            # previously-merged temperature forward (it's slow-moving; the
-            # periodic refresh still updates it).
             existing = self.devices.get(device.id)
-            if (
-                existing is not None
-                and device.device_type in HUB_DEVICE_TEMPERATURE_DEVICE_TYPES
-                and "temperature" not in device.statuses
-                and "temperature" in existing.statuses
-            ):
-                from dataclasses import replace as dc_replace  # noqa: PLC0415
-
-                device = dc_replace(
-                    device,
-                    statuses={
-                        **device.statuses,
-                        "temperature": existing.statuses["temperature"],
-                    },
-                )
             # An HTS-sourced case tamper (#339) has no counterpart in this
             # stream — on the hubs that need it the snapshot carries no tamper
             # field at all — so a fresh snapshot would drop the sensor back to

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1003,21 +1003,45 @@ class TestStreamHandlers:
 
         assert coordinator.devices["d1"].statuses["signal_strength"] == 3
 
-    def test_temperature_is_deliberately_not_in_the_carry_forward_list(self) -> None:
-        """Records that part of #403 is knowingly unfixed.
+    def test_temperature_is_in_the_carry_forward_list(self) -> None:
+        """Records that the temperature exclusion was deliberately overturned.
 
-        Seven of his nine temperatures emptied — the light-stream families, which
-        the `HUB_DEVICE_TEMPERATURE_DEVICE_TYPES` block does not cover. Adding
-        `temperature` here would fix those and would also break
-        `test_snapshot_does_not_invent_temperature_for_non_siren`, which pins the
-        opposite deliberately. Pinned as a decision so the next person finds the
-        conflict instead of discovering it by breaking that test.
+        The exclusion pinned a worry that carrying temperature would "invent"
+        one for families with no per-device temperature source. It cannot: the
+        carry only fills a key already present in the existing statuses, so a
+        device that never reported a temperature never gains one — pinned by
+        `test_snapshot_does_not_invent_temperature_the_device_never_reported`.
+        Meanwhile seven of the nine temperatures that emptied in #403 were
+        light-stream families the siren-gated carry never covered.
         """
         from custom_components.aegis_ajax.coordinator import (
             _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS,
         )
 
-        assert "temperature" not in _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS
+        assert "temperature" in _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS
+
+    def test_snapshot_carries_temperature_forward_for_light_stream_family(self) -> None:
+        """A door_protect is not a siren: only the generic carry can reach it."""
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1", statuses={"temperature": 18.0})
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert coordinator.devices["d1"].statuses["temperature"] == 18.0
+
+    def test_snapshot_does_not_invent_temperature_the_device_never_reported(self) -> None:
+        """The half of the old exclusion worth keeping: a carry is not an invention.
+
+        A family with no per-device temperature source never has one in its
+        existing statuses, so there is nothing to fill and no device ends up
+        holding a temperature it never reported.
+        """
+        coordinator = self._make_coordinator_with_stream()
+        coordinator.devices["d1"] = _make_device("d1", statuses={"signal_strength": 3})
+
+        coordinator._handle_devices_snapshot([_make_device("d1")])
+
+        assert "temperature" not in coordinator.devices["d1"].statuses
 
     def test_snapshot_does_not_carry_an_operational_alert_forward(self) -> None:
         """The reason the carry list is named rather than a blanket merge.
@@ -3768,17 +3792,6 @@ class TestHubDeviceTemperatureRefresh:
         coordinator._handle_devices_snapshot([_make_siren("s1d")])
 
         assert coordinator.devices["s1d"].statuses["temperature"] == 22.0
-
-    def test_snapshot_does_not_invent_temperature_for_non_siren(self) -> None:
-        coordinator = _make_coordinator()
-        coordinator._devices_cache = None
-        coordinator.async_set_updated_data = MagicMock()
-        coordinator.devices = {"d1": replace(_make_device("d1"), statuses={"temperature": 18.0})}
-
-        # A door_protect is not in the siren set; carry-forward must not apply.
-        coordinator._handle_devices_snapshot([_make_device("d1")])
-
-        assert "temperature" not in coordinator.devices["d1"].statuses
 
 
 class TestSirenSettingsRefresh:


### PR DESCRIPTION
## What

Adds `temperature` to `_SNAPSHOT_CARRY_FORWARD_STATUS_KEYS`, the named measurement allowlist a full device snapshot carries forward when it omits a value (#403). The siren-gated temperature block in `_handle_devices_snapshot` is removed — the generic pass is a strict superset of its condition — and siren temperature carries now show up in the per-snapshot debug line instead of riding along uncounted.

## Why

This is the last engineering item on #403. Seven of the nine temperatures that emptied in the reported drop were light-stream families, which the siren-gated carry could not reach. The principle already accepted for battery/signal/humidity/co2 applies unchanged: a snapshot omitting a *measurement* makes the previous value older, not wrong.

## The overturned pin

`test_snapshot_does_not_invent_temperature_for_non_siren` pinned the exclusion deliberately, guarding against a family with no per-device temperature source ending up holding one. The carry cannot do that: it only fills a key already present in the device's existing statuses. That half of the pin survives as `test_snapshot_does_not_invent_temperature_the_device_never_reported`; the membership pin is flipped and records the decision.

## Ajax API-call delta

Zero — in-memory snapshot handling only; no request is added or changed.

Refs #403