### PR TITLE
feat(alarm): derive the panel's triggered state from the intrusion push

### DIFF
--- a/custom_components/aegis_ajax/alarm_control_panel.py
+++ b/custom_components/aegis_ajax/alarm_control_panel.py
@@ -396,6 +396,16 @@ class AjaxAlarmControlPanel(_AjaxAlarmPanelBase):
         space = self._space
         if space is None:
             return None
+        # Intrusion alarm overlay (#426): the served security_state has no
+        # alarm value, so `triggered` is derived from the intrusion push and
+        # shown over any armed state. The disarmed guard is what makes a
+        # disarm reflect instantly — including our own optimistic write —
+        # even before the coordinator drops the overlay entry.
+        if space.id in self.coordinator.alarmed_space_ids and space.security_state not in (
+            SecurityState.DISARMED,
+            SecurityState.NONE,
+        ):
+            return AlarmControlPanelState.TRIGGERED
         # In group mode the server reports PARTIALLY_ARMED while night mode
         # is active — identical to "some groups armed" in the lite state.
         # `night_mode_enabled` (snapshot + push events) disambiguates (#284).
@@ -483,6 +493,12 @@ class AjaxAlarmControlPanel(_AjaxAlarmPanelBase):
             )
         except TypeError:
             return  # space is not a real dataclass (e.g., during tests)
+        # The user's own disarm is the clearest acknowledgment an intrusion
+        # alarm can get (#426) — drop the overlay here rather than waiting for
+        # a poll to observe the disarm, which the 10 s optimistic window can
+        # outlast when the server briefly serves stale state.
+        if new_state == SecurityState.DISARMED:
+            self.coordinator.alarmed_space_ids.discard(self._space_id)
         expiry = asyncio.get_running_loop().time() + 10
         self.coordinator._optimistic_space_states[self._space_id] = (expiry, new_state)
         if self.hass is not None:

--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -482,6 +482,18 @@ RAW_TAG_TO_GROUP_SECURITY_STATE: dict[str, SecurityState] = {
     "space_group_duress_disarmed": SecurityState.DISARMED,
 }
 
+# Push raw_tags that mean an intrusion alarm is FIRING in the space (#426).
+# The served `SecurityState` enum has no alarm value — Ajax models arming
+# state and alarm events separately — so the panel's `triggered` can only be
+# derived client-side from the alarm push itself (the same way SIA panels
+# synthesize it from the alarm event), held until the space is next seen
+# DISARMED. A named allowlist on purpose: `panic`/`fire`/`tamper` map to HA
+# events too, but which of those should drive the panel state is a scope
+# decision, not a default.
+INTRUSION_ALARM_RAW_TAGS: frozenset[str] = frozenset(
+    {"intrusion_alarm", "intrusion_alarm_confirmed"}
+)
+
 # HA event types that signal a security-state change. Used by the FCM event
 # path to nudge the snapshot-backed re-read (#284/#287): a push tells (at
 # most) one group's new state, while a scenario / keypad / fob action can

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -453,6 +453,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.last_photo_urls: dict[str, str] = {}
         # space_id -> (expiry_time, security_state)
         self._optimistic_space_states: dict[str, tuple[float, Any]] = {}
+        # Spaces with an intrusion alarm push not yet acknowledged by an
+        # observed DISARMED (#426). Drives the panel's `triggered` overlay —
+        # the served SecurityState cannot express "alarm firing". In memory
+        # only, on purpose: never persisted or restored, so a reload/restart
+        # cannot resurrect a stale alarm.
+        self.alarmed_space_ids: set[str] = set()
         # SIM info is mostly static — cache and refresh once per hour
         self._sim_info_last_fetch: float = 0.0
         # Rooms rarely change — cache and refresh once per hour. None means
@@ -703,6 +709,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             await self._ensure_authenticated()
             self.spaces = await self._refresh_spaces()
+            self._drop_cleared_alarms()
             self._prune_manual_refresh()
             now = asyncio.get_running_loop().time()
             self._update_hub_offline_repairs(now)
@@ -2309,6 +2316,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         space = self.spaces.get(space_id)
         if space is None:
             return
+        # A push DISARM acknowledges any live intrusion alarm (#426) —
+        # dropped before the no-change/optimistic early returns below, so a
+        # disarm that races our own optimistic write still clears it.
+        if new_state in (SecurityState.DISARMED, SecurityState.NONE):
+            self.alarmed_space_ids.discard(space_id)
         # `time.monotonic()` is the same source `asyncio.BaseEventLoop.time()`
         # uses for the optimistic-state expiry stored from arm/disarm callsites.
         now = time.monotonic()
@@ -2361,6 +2373,41 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.spaces[space_id] = dc_replace(space, groups=new_groups)
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
+    def note_intrusion_alarm(self, space_id: str) -> None:
+        """Mark a space as in-alarm from an intrusion push (#426).
+
+        The served `SecurityState` cannot express "alarm firing", so the
+        panel's `triggered` is a client-side overlay: set here from the
+        `intrusion_alarm` / `intrusion_alarm_confirmed` push, shown while the
+        space is in any armed state, and held until the space is next seen
+        DISARMED — via the push path (`apply_push_security_state`), an
+        HA-initiated disarm, or any poll re-read (`_drop_cleared_alarms`).
+        Runs on the event loop (marshalled from the FCM worker thread by the
+        caller). Unknown spaces are ignored — a push for a space this entry
+        doesn't manage must not create state.
+        """
+        if space_id not in self.spaces:
+            return
+        self.alarmed_space_ids.add(space_id)
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
+    def _drop_cleared_alarms(self) -> None:
+        """Drop the `triggered` overlay for spaces now seen DISARMED (#426).
+
+        Called after every full spaces rebuild so any server observation of a
+        disarm — polled or nudged — acknowledges the alarm. A space that is
+        no longer tracked has nothing to overlay either.
+        """
+        from custom_components.aegis_ajax.const import SecurityState  # noqa: PLC0415
+
+        for space_id in list(self.alarmed_space_ids):
+            space = self.spaces.get(space_id)
+            if space is None or space.security_state in (
+                SecurityState.DISARMED,
+                SecurityState.NONE,
+            ):
+                self.alarmed_space_ids.discard(space_id)
 
     def set_chime_optimistic(self, space_id: str, *, enable: bool) -> None:
         """Optimistically reflect a hub Chime toggle we just issued (#239).

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -94,6 +94,10 @@ async def async_get_config_entry_diagnostics(
             sid: {
                 "name_length": len(s.name or ""),
                 "security_state": s.security_state.name,
+                # The panel's `triggered` is a client-side overlay (#426), not
+                # part of the served security_state above — a dump that hides
+                # it can't explain a panel showing (or missing) an alarm.
+                "intrusion_alarm_active": sid in coordinator.alarmed_space_ids,
                 "online": s.is_online,
                 "malfunctions": s.malfunctions_count,
                 "group_mode_enabled": s.group_mode_enabled,

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -17,6 +17,7 @@ from custom_components.aegis_ajax.const import (
     DOMAIN,
     DOORBELL_DEVICE_TYPES,
     DOORBELL_EVENT_TYPE,
+    INTRUSION_ALARM_RAW_TAGS,
     MOTION_EVENT_TYPE,
     RAW_TAG_TO_GROUP_SECURITY_STATE,
     RAW_TAG_TO_SECURITY_STATE,
@@ -1192,6 +1193,15 @@ class AjaxNotificationListener:
         if not isinstance(raw_tag, str):
             return
         if not (self._hass.loop and self._hass.loop.is_running()):
+            return
+        # An intrusion alarm implies no arm-state transition — the space stays
+        # armed while the siren fires — so it marks the space in-alarm (#426)
+        # instead of writing a security_state.
+        if raw_tag in INTRUSION_ALARM_RAW_TAGS:
+            self._hass.loop.call_soon_threadsafe(
+                self._coordinator.note_intrusion_alarm,
+                space_id,
+            )
             return
         group_state = RAW_TAG_TO_GROUP_SECURITY_STATE.get(raw_tag)
         group_id = event_data.get("group_id")

--- a/tests/unit/test_alarm_control_panel.py
+++ b/tests/unit/test_alarm_control_panel.py
@@ -191,6 +191,42 @@ class TestAlarmControlPanel:
         panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
         assert panel.alarm_state is None
 
+    # --- #426: `triggered` overlay from the intrusion push -------------------
+
+    def test_alarm_state_triggered_while_armed_and_alarm_active(self) -> None:
+        from homeassistant.components.alarm_control_panel import (
+            AlarmControlPanelState,  # type: ignore[attr-defined]
+        )
+
+        coordinator = MagicMock()
+        coordinator.spaces = {"s1": self._make_space(SecurityState.ARMED)}
+        coordinator.alarmed_space_ids = {"s1"}
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        assert panel.alarm_state == AlarmControlPanelState.TRIGGERED
+
+    def test_alarm_state_triggered_overrides_night_mode(self) -> None:
+        from homeassistant.components.alarm_control_panel import (
+            AlarmControlPanelState,  # type: ignore[attr-defined]
+        )
+
+        coordinator = MagicMock()
+        coordinator.spaces = {"s1": self._make_space(SecurityState.NIGHT_MODE)}
+        coordinator.alarmed_space_ids = {"s1"}
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        assert panel.alarm_state == AlarmControlPanelState.TRIGGERED
+
+    def test_alarm_state_not_triggered_once_disarmed(self) -> None:
+        """A stale overlay entry must never show through a disarmed panel."""
+        from homeassistant.components.alarm_control_panel import (
+            AlarmControlPanelState,  # type: ignore[attr-defined]
+        )
+
+        coordinator = MagicMock()
+        coordinator.spaces = {"s1": self._make_space(SecurityState.DISARMED)}
+        coordinator.alarmed_space_ids = {"s1"}
+        panel = AjaxAlarmControlPanel(coordinator=coordinator, space_id="s1")
+        assert panel.alarm_state == AlarmControlPanelState.DISARMED
+
     def test_alarm_state_partially_armed_with_night_mode_is_armed_night(self) -> None:
         # In group mode the server reports PARTIALLY_ARMED while night mode
         # is active; `night_mode_enabled` is the discriminator (#284).

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -3794,6 +3794,101 @@ class TestHubDeviceTemperatureRefresh:
         assert coordinator.devices["s1d"].statuses["temperature"] == 22.0
 
 
+class TestIntrusionAlarmOverlay:
+    """#426: `triggered` derived from the intrusion push, held until DISARMED.
+
+    The served `SecurityState` has no alarm value, so the overlay lives
+    client-side, in memory only — a reload/restart must never resurrect a
+    stale alarm.
+    """
+
+    def _make_space(self, state):  # noqa: ANN001, ANN202
+        from custom_components.aegis_ajax.api.models import Space
+        from custom_components.aegis_ajax.const import ConnectionStatus
+
+        return Space(
+            id="s1",
+            hub_id="h1",
+            name="Home",
+            security_state=state,
+            connection_status=ConnectionStatus.ONLINE,
+            malfunctions_count=0,
+        )
+
+    def _armed_coordinator(self):  # noqa: ANN202
+        from custom_components.aegis_ajax.const import SecurityState
+
+        coordinator = _make_coordinator()
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.spaces = {"s1": self._make_space(SecurityState.ARMED)}
+        return coordinator
+
+    def test_note_intrusion_alarm_marks_known_space(self) -> None:
+        coordinator = self._armed_coordinator()
+
+        coordinator.note_intrusion_alarm("s1")
+
+        assert "s1" in coordinator.alarmed_space_ids
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_note_intrusion_alarm_ignores_unknown_space(self) -> None:
+        coordinator = self._armed_coordinator()
+
+        coordinator.note_intrusion_alarm("ghost")
+
+        assert "ghost" not in coordinator.alarmed_space_ids
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_push_disarm_clears_the_overlay(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        coordinator = self._armed_coordinator()
+        coordinator.note_intrusion_alarm("s1")
+
+        coordinator.apply_push_security_state("s1", SecurityState.DISARMED)
+
+        assert "s1" not in coordinator.alarmed_space_ids
+
+    def test_push_mode_switch_keeps_the_overlay(self) -> None:
+        """Only DISARMED acknowledges the alarm; an armed-mode change does not."""
+        from custom_components.aegis_ajax.const import SecurityState
+
+        coordinator = self._armed_coordinator()
+        coordinator.note_intrusion_alarm("s1")
+
+        coordinator.apply_push_security_state("s1", SecurityState.NIGHT_MODE)
+
+        assert "s1" in coordinator.alarmed_space_ids
+
+    def test_poll_observing_disarm_drops_the_overlay(self) -> None:
+        from custom_components.aegis_ajax.const import SecurityState
+
+        coordinator = self._armed_coordinator()
+        coordinator.note_intrusion_alarm("s1")
+        coordinator.spaces["s1"] = self._make_space(SecurityState.DISARMED)
+
+        coordinator._drop_cleared_alarms()
+
+        assert "s1" not in coordinator.alarmed_space_ids
+
+    def test_drop_clears_a_space_no_longer_tracked(self) -> None:
+        coordinator = self._armed_coordinator()
+        coordinator.note_intrusion_alarm("s1")
+        coordinator.spaces = {}
+
+        coordinator._drop_cleared_alarms()
+
+        assert "s1" not in coordinator.alarmed_space_ids
+
+    def test_drop_keeps_an_armed_space_in_alarm(self) -> None:
+        coordinator = self._armed_coordinator()
+        coordinator.note_intrusion_alarm("s1")
+
+        coordinator._drop_cleared_alarms()
+
+        assert "s1" in coordinator.alarmed_space_ids
+
+
 class TestSirenSettingsRefresh:
     """Timer-driven merge of siren settings from StreamHubDevice (#310)."""
 

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1864,11 +1864,35 @@ class TestApplySecurityStateFromEvent:
         hass.loop.call_soon_threadsafe.assert_not_called()
 
     def test_unmapped_tag_does_not_dispatch(self) -> None:
+        # `battery_low` fires an HA event but implies no security-state change
+        # and is not an intrusion alarm — nothing to dispatch.
         listener, hass, _ = self._make_listener()
+
+        listener._apply_security_state_from_event("space-1", {"raw_tag": "battery_low"})
+
+        hass.loop.call_soon_threadsafe.assert_not_called()
+
+    def test_intrusion_alarm_tag_dispatches_alarm_overlay(self) -> None:
+        # #426: the served SecurityState has no alarm value, so the intrusion
+        # push marks the space in-alarm instead of writing a state.
+        listener, hass, coordinator = self._make_listener()
 
         listener._apply_security_state_from_event("space-1", {"raw_tag": "intrusion_alarm"})
 
-        hass.loop.call_soon_threadsafe.assert_not_called()
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.note_intrusion_alarm, "space-1"
+        )
+
+    def test_intrusion_alarm_confirmed_tag_dispatches_alarm_overlay(self) -> None:
+        listener, hass, coordinator = self._make_listener()
+
+        listener._apply_security_state_from_event(
+            "space-1", {"raw_tag": "intrusion_alarm_confirmed"}
+        )
+
+        hass.loop.call_soon_threadsafe.assert_called_once_with(
+            coordinator.note_intrusion_alarm, "space-1"
+        )
 
     def test_missing_raw_tag_does_not_dispatch(self) -> None:
         listener, hass, _ = self._make_listener()


### PR DESCRIPTION
## What

The alarm panel now shows **`triggered`** during an intrusion alarm (#426). The security state Ajax serves has no alarm value — it models arming states only — so `triggered` is derived client-side, the way SIA panels synthesize it from the alarm event:

- An `intrusion_alarm` / `intrusion_alarm_confirmed` push marks the space in-alarm (`coordinator.alarmed_space_ids`, in-memory only).
- The space panel overlays `TRIGGERED` over any armed state.
- The overlay clears when the space is next seen **DISARMED**: instantly on a push disarm or an HA-initiated disarm, and on any poll/snapshot re-read as the backstop. A reload/restart never resurrects a stale alarm (nothing is persisted).

Diagnostics gain a per-space `intrusion_alarm_active` flag so a wrong-panel-state report is answerable from a dump.

## Scope notes

- `INTRUSION_ALARM_RAW_TAGS` is a named allowlist: whether `panic`/`fire`/`tamper` should also drive panel state is a deliberate follow-up decision, not a default.
- Space-level panel only in this pass; per-group panels are untouched (a group-mode alarm holds `triggered` until the space is disarmed).
- Depends on the intrusion push arriving (FCM configured) — exactly what #426's reporter is measuring; without FCM the panel behaves as before.

## Ajax API-call delta

Zero — consumes the push already flowing; no request added or changed.

## Tests

TDD: 13 new tests (coordinator overlay lifecycle, panel overlay/guard, push dispatch) watched failing before the implementation; `test_unmapped_tag_does_not_dispatch` re-pinned on a genuinely unmapped tag since `intrusion_alarm` now dispatches. Full suite 2274 pass, coverage 90.70%.

Refs #426