### PR TITLE
fix(devices): surface the NVR/video-edge box as a device

### DIFF
--- a/custom_components/aegis_ajax/api/devices_parser.py
+++ b/custom_components/aegis_ajax/api/devices_parser.py
@@ -620,12 +620,77 @@ def _parse_spread_properties(hub_dev: Any) -> dict[str, Any]:  # noqa: ANN401
     return result
 
 
+def _parse_video_edge(edge: Any) -> Device | None:  # noqa: ANN401
+    """Parse a `LightVideoEdge` — the video recorder/bridge box itself (#425).
+
+    With a Hub + NVR, the cameras arrive as `video_edge_channel` rows and the
+    recorder arrives as its own `video_edge` LightDevice oneof case, which was
+    skipped as "unsupported" — so the NVR never appeared as a device. The row
+    carries the standard `LightDeviceProfile` (id, name, online state) plus
+    the recorder's channel counts in `spread_properties`; the health metrics
+    the Ajax app shows for an NVR (disk, CPU, RAM, temperature) do NOT ride
+    this row — they live behind a separate per-device endpoint the
+    integration deliberately doesn't call.
+
+    `video_edge_box` marks the provenance: this is the box, not an
+    NVR-republished channel, so `_dedupe_nvr_republished_channels` (#290)
+    must never drop it however its id happens to be keyed.
+    """
+    if not edge.HasField("profile"):
+        _LOGGER.debug("video_edge without profile, skipping")
+        return None
+
+    profile = edge.profile
+    device_type = "video_edge_unknown"
+    type_value = 0
+    if edge.HasField("video_edge_properties"):
+        type_value = int(edge.video_edge_properties.video_edge_type)
+        mapped = _VIDEO_EDGE_TYPE_MAP.get(type_value)
+        if mapped is None:
+            _LOGGER.warning(
+                "Unmapped video_edge_type %s on video edge %s — surfacing as "
+                "video_edge_unknown; please report the value on "
+                "https://github.com/bvis/aegis-hass/issues/425",
+                type_value,
+                profile.id,
+            )
+        else:
+            device_type = mapped
+
+    statuses = _parse_statuses(profile.statuses)
+    statuses["video_edge_type"] = type_value
+    statuses["video_edge_box"] = True
+    for spread in edge.spread_properties:
+        if spread.WhichOneof("properties") == "channels":
+            statuses["channels_total"] = spread.channels.total_count
+            statuses["channels_online"] = spread.channels.online_count
+            break
+
+    # Same hub_id convention as the channels: Ajax models the video edge as a
+    # sibling of the hub, not a child, so the box is its own registry root.
+    return Device(
+        id=profile.id,
+        hub_id=profile.id,
+        name=profile.name,
+        device_type=device_type,
+        room_id=profile.room_id if profile.room_id else None,
+        group_id=profile.group_id if profile.group_id else None,
+        state=_parse_device_state(profile.states),
+        malfunctions=profile.malfunctions,
+        bypassed=profile.bypassed,
+        statuses=statuses,
+        battery=_parse_battery(profile.statuses),
+    )
+
+
 def parse_device(proto_light_device: Any) -> Device | None:  # noqa: ANN401
     device_kind = proto_light_device.WhichOneof("device")
     if device_kind == "hub_device":
         return _parse_hub_device(proto_light_device.hub_device)
     if device_kind == "video_edge_channel":
         return _parse_video_edge_channel(proto_light_device.video_edge_channel)
+    if device_kind == "video_edge":
+        return _parse_video_edge(proto_light_device.video_edge)
     # `device_kind is None` means the LightDevice proto's `device`
     # oneof didn't match any case we know (`hub_device`,
     # `video_edge`, `video_edge_channel`, `smart_lock`), and the bytes
@@ -882,7 +947,14 @@ def _dedupe_nvr_republished_channels(
     aliases: dict[str, str] = {}
     for d in devices:
         primary_id = nvr_channel_to_primary.get(d.id)
-        if d.device_type == _VIDEO_EDGE_NVR and primary_id is not None:
+        # The recorder's own row (#425, `video_edge_box`) is never a
+        # republished channel — dropping it on an id coincidence would
+        # silently delete the device this pass exists to keep honest.
+        if (
+            d.device_type == _VIDEO_EDGE_NVR
+            and primary_id is not None
+            and not d.statuses.get("video_edge_box")
+        ):
             aliases[d.id] = primary_id
             _LOGGER.debug(
                 "Dropping NVR-republished video channel %s (%s) — re-publishes "

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -117,6 +117,25 @@ SENSOR_TYPES: dict[str, SensorTypeInfo] = {
         translation_key="wifi_signal_level",
         entity_registry_enabled_default=False,
     ),
+    # NVR/video-edge box channel counters (#425) — the only per-row
+    # measurements the recorder's light row carries. Creation is gated on
+    # the keys being present, so only the box grows these.
+    "channels_online": SensorTypeInfo(
+        None,
+        SensorStateClass.MEASUREMENT,
+        None,
+        "status",
+        None,
+        translation_key="channels_online",
+    ),
+    "channels_total": SensorTypeInfo(
+        None,
+        None,
+        None,
+        "status",
+        EntityCategory.DIAGNOSTIC,
+        translation_key="channels_total",
+    ),
 }
 
 
@@ -143,6 +162,8 @@ async def async_setup_entry(
             "signal_strength",
             "mobile_network_type",
             "wifi_signal_level",
+            "channels_online",
+            "channels_total",
         )
         for key in _status_sensor_keys:
             if _should_create_status_sensor(device, key):

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -461,6 +461,12 @@
             },
             "power_derived": {
                 "name": "Power"
+            },
+            "channels_online": {
+                "name": "Channels online"
+            },
+            "channels_total": {
+                "name": "Channels total"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Potència"
+            },
+            "channels_online": {
+                "name": "Canals en línia"
+            },
+            "channels_total": {
+                "name": "Canals totals"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Výkon"
+            },
+            "channels_online": {
+                "name": "Kanály online"
+            },
+            "channels_total": {
+                "name": "Celkem kanálů"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Leistung"
+            },
+            "channels_online": {
+                "name": "Kanäle online"
+            },
+            "channels_total": {
+                "name": "Kanäle gesamt"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -446,6 +446,12 @@
             },
             "power": {
                 "name": "Power"
+            },
+            "channels_online": {
+                "name": "Channels online"
+            },
+            "channels_total": {
+                "name": "Channels total"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -446,6 +446,12 @@
             },
             "power": {
                 "name": "Potencia"
+            },
+            "channels_online": {
+                "name": "Canales en línea"
+            },
+            "channels_total": {
+                "name": "Canales totales"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Puissance"
+            },
+            "channels_online": {
+                "name": "Canaux en ligne"
+            },
+            "channels_total": {
+                "name": "Canaux au total"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Potenza"
+            },
+            "channels_online": {
+                "name": "Canali online"
+            },
+            "channels_total": {
+                "name": "Canali totali"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Vermogen"
+            },
+            "channels_online": {
+                "name": "Kanalen online"
+            },
+            "channels_total": {
+                "name": "Totaal kanalen"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Moc"
+            },
+            "channels_online": {
+                "name": "Kanały online"
+            },
+            "channels_total": {
+                "name": "Łączna liczba kanałów"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Potência"
+            },
+            "channels_online": {
+                "name": "Canais online"
+            },
+            "channels_total": {
+                "name": "Total de canais"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Potência"
+            },
+            "channels_online": {
+                "name": "Canais online"
+            },
+            "channels_total": {
+                "name": "Total de canais"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Putere"
+            },
+            "channels_online": {
+                "name": "Canale online"
+            },
+            "channels_total": {
+                "name": "Total canale"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Güç"
+            },
+            "channels_online": {
+                "name": "Çevrimiçi kanallar"
+            },
+            "channels_total": {
+                "name": "Toplam kanal"
             }
         },
         "switch": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -430,6 +430,12 @@
             },
             "power": {
                 "name": "Потужність"
+            },
+            "channels_online": {
+                "name": "Канали онлайн"
+            },
+            "channels_total": {
+                "name": "Всього каналів"
             }
         },
         "switch": {

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -85,11 +85,11 @@ class TestParseDevice:
         assert device.state == DeviceState.OFFLINE
 
     def test_parse_unsupported_oneof_returns_none(self) -> None:
-        # `video_edge` (the recorder), `smart_lock` (the auxiliary
-        # smart-lock variant) and an unset oneof all fall through to
-        # None — only `hub_device` and `video_edge_channel` are mapped.
+        # `smart_lock` (the auxiliary smart-lock variant) and an unset
+        # oneof fall through to None — `hub_device`, `video_edge_channel`
+        # and (since #425) `video_edge` are the mapped cases.
         proto_device = MagicMock()
-        proto_device.WhichOneof.return_value = "video_edge"
+        proto_device.WhichOneof.return_value = "smart_lock"
         assert DevicesApi.parse_device(proto_device) is None
 
     def test_parse_unsupported_oneof_tiny_proto_logs_raw_hex(
@@ -596,6 +596,87 @@ class TestRedactProtoBytesToHex:
         device = DevicesApi.parse_device(light_device)
         assert device is not None
         assert device.device_type == "video_edge_indoor"
+
+    # --- #425: the recorder/bridge box itself rides the `video_edge` oneof ---
+
+    def test_parse_video_edge_box_nvr(self) -> None:
+        """@pvangorp in #425: with a Hub + NVR the recorder's own row arrives
+        as the `video_edge` LightDevice oneof case — distinct from the
+        `video_edge_channel` rows of its cameras — and was skipped as
+        'unsupported', so the NVR never appeared as a device."""
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        about_type_nvr_h_ac = 7  # About.Type.NVR_H_AC (#290's recorder)
+        light_device = light_device_pb2.LightDevice(
+            video_edge=light_video_edge_pb2.LightVideoEdge(
+                profile=light_device_profile_pb2.LightDeviceProfile(
+                    id="310B121D",
+                    name="NVR",
+                ),
+                video_edge_properties=light_video_edge_pb2.LightVideoEdge.VideoEdgeProperties(
+                    video_edge_type=about_type_nvr_h_ac,
+                ),
+                spread_properties=[
+                    light_video_edge_pb2.LightVideoEdge.SpreadProperties(
+                        channels=light_video_edge_pb2.LightVideoEdge.SpreadProperties.Channels(
+                            total_count=8,
+                            online_count=6,
+                        ),
+                    )
+                ],
+            )
+        )
+
+        device = DevicesApi.parse_device(light_device)
+        assert device is not None
+        assert device.id == "310B121D"
+        assert device.name == "NVR"
+        assert device.device_type == "video_edge_nvr"
+        assert device.state == DeviceState.ONLINE
+        assert device.statuses["channels_total"] == 8
+        assert device.statuses["channels_online"] == 6
+        # Provenance marker: this is the box, not an NVR-republished channel,
+        # so the #290 dedupe must never eat it.
+        assert device.statuses["video_edge_box"] is True
+
+    def test_parse_video_edge_box_without_properties_is_unknown(self) -> None:
+        """A box row without `video_edge_properties` still surfaces — the
+        oneof case itself is the identity; only the sub-type is unknown."""
+        from v3.mobilegwsvc.commonmodels.space.device.light import (
+            light_device_pb2,
+            light_device_profile_pb2,
+        )
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        light_device = light_device_pb2.LightDevice(
+            video_edge=light_video_edge_pb2.LightVideoEdge(
+                profile=light_device_profile_pb2.LightDeviceProfile(id="ve-1", name="Bridge"),
+            )
+        )
+
+        device = DevicesApi.parse_device(light_device)
+        assert device is not None
+        assert device.device_type == "video_edge_unknown"
+
+    def test_parse_video_edge_box_without_profile_is_skipped(self) -> None:
+        from v3.mobilegwsvc.commonmodels.space.device.light import light_device_pb2
+        from v3.mobilegwsvc.commonmodels.video.videoedge.light import (
+            light_video_edge_pb2,
+        )
+
+        light_device = light_device_pb2.LightDevice(
+            video_edge=light_video_edge_pb2.LightVideoEdge()
+        )
+
+        assert DevicesApi.parse_device(light_device) is None
 
     def test_parse_video_edge_channel_unknown_type(self, caplog: pytest.LogCaptureFixture) -> None:
         # `About.Type` is open-ended; new firmwares can introduce
@@ -1747,6 +1828,22 @@ class TestDeduplicateNvrRepublishedChannels:
         native = self._make("nvr-cam-7", "Garage Cam", "video_edge_nvr")
         deduped = DevicesApi._dedupe_video_doorbells([native])
         assert [d.id for d in deduped] == ["nvr-cam-7"]
+
+    def test_keeps_the_nvr_box_even_on_id_collision(self) -> None:
+        """The recorder's own device row (#425) is `video_edge_nvr`-typed but
+        is not a republished channel — even if a firmware ever keyed it by an
+        id some primary references as its `nvr` source, dropping the box
+        would silently delete the device this issue is about surfacing.
+        `video_edge_box` is the provenance that exempts it."""
+        primary = self._make(
+            "9c756e2bca39-0", "Deurbel", "video_edge_doorbell", video_sources=self._SOURCES
+        )
+        box = self._make("gRdWkZna2l-9c756e2bca39-0", "NVR", "video_edge_nvr")
+        box.statuses["video_edge_box"] = True
+
+        deduped = DevicesApi._dedupe_video_doorbells([primary, box])
+
+        assert {d.id for d in deduped} == {"9c756e2bca39-0", "gRdWkZna2l-9c756e2bca39-0"}
 
     def test_bullet_and_doorbell_both_deduped(self) -> None:
         """One NVR republishes several channels; each republish is matched to

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -53,6 +53,12 @@ class TestSensorTypes:
     def test_signal_strength_type_exists(self) -> None:
         assert "signal_strength" in SENSOR_TYPES
 
+    def test_nvr_channel_count_types_exist(self) -> None:
+        # #425: the NVR box's only per-row measurements are its channel
+        # counts; without descriptors the parsed device renders a bare card.
+        assert "channels_online" in SENSOR_TYPES
+        assert "channels_total" in SENSOR_TYPES
+
     def test_mobile_network_type_exists(self) -> None:
         assert "mobile_network_type" in SENSOR_TYPES
 
@@ -112,6 +118,53 @@ class TestAjaxSensor:
             coordinator=coordinator, device_id="dev-1", sensor_key="signal_strength"
         )
         assert sensor.native_value == "Normal"
+
+    def test_nvr_channel_counts(self) -> None:
+        # #425: the NVR box's channel counters ride `statuses` like any
+        # other status-sourced reading.
+        device = self._make_device({"channels_online": 6, "channels_total": 8})
+        coordinator = MagicMock()
+        coordinator.devices = {"dev-1": device}
+        online = AjaxSensor(
+            coordinator=coordinator, device_id="dev-1", sensor_key="channels_online"
+        )
+        total = AjaxSensor(coordinator=coordinator, device_id="dev-1", sensor_key="channels_total")
+        assert online.native_value == 6
+        assert total.native_value == 8
+
+    @pytest.mark.asyncio
+    async def test_nvr_channel_count_sensors_created_at_setup(self) -> None:
+        """Creation is gated on the keys being present, so only devices that
+        actually report channel counts (the NVR box, #425) grow the sensors."""
+        from custom_components.aegis_ajax.sensor import async_setup_entry
+
+        nvr = Device(
+            id="310B121D",
+            hub_id="310B121D",
+            name="NVR",
+            device_type="video_edge_nvr",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={"channels_online": 6, "channels_total": 8, "video_edge_box": True},
+            battery=None,
+        )
+        coordinator = MagicMock()
+        coordinator.devices = {"310B121D": nvr}
+        coordinator.rooms = {}
+        coordinator.spaces = {}
+        coordinator.sim_info = {}
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+        with patch("custom_components.aegis_ajax.sensor._remove_orphan_outlet_power_derived"):
+            await async_setup_entry(MagicMock(), entry, added.extend)
+
+        keys = {getattr(e, "_sensor_key", None) for e in added}
+        assert "channels_online" in keys
+        assert "channels_total" in keys
 
     def test_native_value_returns_none_when_no_device(self) -> None:
         coordinator = MagicMock()


### PR DESCRIPTION
## What

Parses the `video_edge` LightDevice oneof case — the video recorder/bridge box itself (#425). With a Hub + NVR, the cameras arrive as `video_edge_channel` rows and the recorder as its own `video_edge` row, which was skipped as unsupported (the reporter's `Skipping unsupported device type: video_edge` lines). The NVR now surfaces as a device with:

- name + online/offline state (standard `LightDeviceProfile`),
- its type via the existing `About.Type` map (NVR variants → `video_edge_nvr`),
- **channels online / channels total** sensors from `spread_properties` (creation gated on the keys being present, so only devices reporting them grow the sensors; translated in all 14 locales).

`video_edge_box` marks provenance so the #290 republished-channel dedupe can never drop the box on an id coincidence.

## Deliberately not included

Disk/CPU/RAM/temperature — the health metrics the app shows for an NVR do **not** ride this row; the app reads them from a separate per-device endpoint the integration doesn't call. Adding that would be a non-zero API-call delta and is a separate decision.

## Ajax API-call delta

Zero — parses rows the stream already delivers.

## Caveat

Modeled from the compiled protos (real generated classes in tests); which fields the reporter's NVR actually populates is confirmed only for the row's existence. The channel-count sensors appear only if his rows carry them — either way the device card appears.

## Tests

TDD: 6 new tests watched failing first (parser ×3, dedupe exemption, sensor types + creation); `test_parse_unsupported_oneof_returns_none` re-pinned on `smart_lock` since `video_edge` is now mapped. Full suite 2281 pass, coverage 90.71%.

Refs #425