### PR TITLE
feat(binary_sensor): contact open/closed state for MT wire inputs

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -62,6 +62,18 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
     # reading steam rather than smoke (e.g. shower/cooking false-positive).
     "steam": BinarySensorTypeInfo(BinarySensorDeviceClass.PROBLEM, "steam"),
     "wire_input_alert": BinarySensorTypeInfo(BinarySensorDeviceClass.SAFETY, "wire_input_alert"),
+    # #413: the MT wire input's contact state, mirroring the app's per-input
+    # Alerte/OK — the hub applies the input's NO/NC polarity itself, so
+    # "disrupted" always means the contact left its rest position (open),
+    # in both modes. OPENING, not SAFETY: the ask is a door/garage state
+    # usable independently of the alarm. Sourced from HTS `0x33`
+    # (`coordinator._maybe_apply_hts_contact_state`); reads closed until the
+    # first status row after a cold install (the persisted device cache
+    # keeps it across restarts). An input with nothing wired reads
+    # permanently open (broken loop) — same as the app shows Alerte for it.
+    "external_contact_open": BinarySensorTypeInfo(
+        BinarySensorDeviceClass.OPENING, "external_contact_open"
+    ),
 }
 
 # Devices whose single "alert" entity should OR-reduce several hub status
@@ -310,7 +322,7 @@ _DEVICE_TYPE_SENSORS: dict[str, list[str]] = {
     "multi_transmitter": ["tamper"],
     "multi_transmitter_fibra": ["tamper"],
     "wire_input": ["tamper", "wire_input_alert"],
-    "wire_input_mt": ["tamper", "wire_input_alert"],
+    "wire_input_mt": ["tamper", "wire_input_alert", "external_contact_open"],
     "wire_input_rs": ["tamper", "wire_input_alert"],
     "life_quality": [],
     "life_quality_plus": [],

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -204,12 +204,34 @@ _HTS_TAMPER_ROUTED_DEVICE_TYPES: frozenset[str] = frozenset(
 #
 # `tamper` and the siren settings keep their own blocks below — they carry
 # provenance conditions this generic pass has no business reproducing.
+# HTS per-device key carrying a MultiTransmitter wire input's contact state
+# (#413): `WireInputMt.external_contact_state`. Hardware-validated by
+# Taknok's four-state capture (2026-08-22, NC and NO, bistable): the hub
+# applies the input's configured NO/NC polarity ITSELF before reporting, so
+# `01` (CONTACT_DISRUPTED — the app's "Alerte") always means "the contact
+# left its configured rest position" in both modes, and `00`/`02` mean at
+# rest ("OK"). It rides the STATUS_BODY the client already requests every
+# 60 s plus live STATUS_UPDATE deltas — consuming it adds no Ajax API
+# traffic. STRICTLY per-family: the same byte is
+# `external_sensor_power_broken` on the MultiTransmitter itself and other
+# things elsewhere (HTS sub-keys are legacy proto field numbers, per family).
+_HTS_CONTACT_STATE_KEY = 0x33
+
+# The statuses key the routed value lands on, read by the `opening`
+# binary sensor.
+_EXTERNAL_CONTACT_OPEN_KEY = "external_contact_open"
+
+#
+# `external_contact_open` (#413) is HTS-only: no gRPC surface carries it, so
+# a snapshot omitting it is NEVER a signal, and HTS itself updates or
+# withdraws it on its ≤60 s cadence.
 _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS: frozenset[str] = frozenset(
     {
         "humidity",
         "co2",
         "signal_strength",
         "temperature",
+        _EXTERNAL_CONTACT_OPEN_KEY,
     }
 )
 
@@ -1529,6 +1551,10 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # that can return early so every reporting family feeds the
         # deactivation carry-forward gate.
         self._maybe_track_hts_bypass_state(device_id_hex, device, kv)
+        # A MultiTransmitter wire input's contact state, 0x33 (#413) — runs
+        # after the writers above, so it re-reads the device in case one of
+        # them replaced it.
+        self._maybe_apply_hts_contact_state(device_id_hex, kv)
         # A modeled SpaceControl's settings row (#311) — read-only, logged
         # before anything that can return early: this hub class never reaches
         # the keyfob path, so this is the only place its row is ever visible.
@@ -1954,6 +1980,44 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             statuses = _without_hts_case_tamper(device.statuses)
 
         self.devices[device_id_hex] = dc_replace(device, statuses=statuses)
+        self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
+    def _maybe_apply_hts_contact_state(self, device_id_hex: str, kv: dict[int, bytes]) -> None:
+        """Route HTS `0x33` onto `external_contact_open` for MT wire inputs (#413).
+
+        The hub reports the contact state with the input's configured NO/NC
+        polarity already applied (Taknok's four-state capture), so `01` —
+        CONTACT_DISRUPTED, the app's "Alerte" — maps straight to "open" with
+        no polarity handling here. `00` (what current firmware reports at
+        rest) and `02` (the enum's named CONTACT_NORMAL) map to "closed".
+        Anything else — `03` CONTACT_NOT_AVAILABLE, the `80` unknown sentinel,
+        a future value — says nothing about the contact's position and leaves
+        the stored state untouched.
+
+        Family-gated hard to `wire_input_mt`: the same byte means
+        `external_sensor_power_broken` on the MultiTransmitter itself and
+        other things on other families (#406's lesson). Re-reads the device
+        from `self.devices` because an earlier applier in the kv chain may
+        have replaced the instance the caller holds. Runs on the event loop
+        (HTS listen task).
+        """
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+
+        device = self.devices.get(device_id_hex)
+        if device is None or device.device_type != "wire_input_mt":
+            return
+        raw = kv.get(_HTS_CONTACT_STATE_KEY)
+        if raw == b"\x01":
+            contact_open = True
+        elif raw in (b"\x00", b"\x02"):
+            contact_open = False
+        else:
+            return
+        if device.statuses.get(_EXTERNAL_CONTACT_OPEN_KEY) is contact_open:
+            return
+        self.devices[device_id_hex] = dc_replace(
+            device, statuses={**device.statuses, _EXTERNAL_CONTACT_OPEN_KEY: contact_open}
+        )
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
 
     def _withdraw_hts_case_tamper(self, device_id_hex: str, device: Device) -> None:

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -408,6 +408,9 @@
             },
             "mains_power": {
                 "name": "Mains power"
+            },
+            "external_contact_open": {
+                "name": "Contact"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Alimentació externa"
+            },
+            "external_contact_open": {
+                "name": "Contacte"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Napájení ze sítě"
+            },
+            "external_contact_open": {
+                "name": "Kontakt"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Netzstrom"
+            },
+            "external_contact_open": {
+                "name": "Kontakt"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -387,6 +387,9 @@
             },
             "mains_power": {
                 "name": "Mains power"
+            },
+            "external_contact_open": {
+                "name": "Contact"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -387,6 +387,9 @@
             },
             "mains_power": {
                 "name": "Alimentación externa"
+            },
+            "external_contact_open": {
+                "name": "Contacto"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Alimentation secteur"
+            },
+            "external_contact_open": {
+                "name": "Contact"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Alimentazione di rete"
+            },
+            "external_contact_open": {
+                "name": "Contatto"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Netstroom"
+            },
+            "external_contact_open": {
+                "name": "Contact"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Zasilanie sieciowe"
+            },
+            "external_contact_open": {
+                "name": "Styk"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Energia externa"
+            },
+            "external_contact_open": {
+                "name": "Contato"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Alimentação externa"
+            },
+            "external_contact_open": {
+                "name": "Contato"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Alimentare rețea"
+            },
+            "external_contact_open": {
+                "name": "Contact"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Şebeke gücü"
+            },
+            "external_contact_open": {
+                "name": "Kontak"
             }
         },
         "sensor": {

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -371,6 +371,9 @@
             },
             "mains_power": {
                 "name": "Зовнішнє живлення"
+            },
+            "external_contact_open": {
+                "name": "Контакт"
             }
         },
         "sensor": {

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -80,6 +80,24 @@ class TestBinarySensorTypes:
     def test_glass_break_sensor_type_exists(self) -> None:
         assert "glass_break" in BINARY_SENSOR_TYPES
 
+    def test_external_contact_open_type_is_an_opening_sensor(self) -> None:
+        # #413: mirrors the app's per-input Alerte/OK contact state — open =
+        # disrupted. OPENING, not SAFETY: the whole point is a door/garage
+        # state usable independently of the alarm.
+        from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+        assert "external_contact_open" in BINARY_SENSOR_TYPES
+        assert (
+            BINARY_SENSOR_TYPES["external_contact_open"].device_class
+            == BinarySensorDeviceClass.OPENING
+        )
+
+    def test_wire_input_mt_gets_the_contact_sensor(self) -> None:
+        # Only the capture-validated family (#413); plain wire_input and
+        # transmitter key the same concept on different sub-keys.
+        assert "external_contact_open" in _DEVICE_TYPE_SENSORS["wire_input_mt"]
+        assert "external_contact_open" not in _DEVICE_TYPE_SENSORS["wire_input"]
+
     def test_vibration_sensor_type_exists(self) -> None:
         assert "vibration" in BINARY_SENSOR_TYPES
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -3127,6 +3127,107 @@ class TestHtsCaseTamperRouting:
         assert coordinator.devices["003AE89B"].statuses["tamper"] is True
 
 
+class TestHtsContactState:
+    """HTS `0x33` drives `external_contact_open` on MT wire inputs (#413).
+
+    Hardware-validated by Taknok's four-state capture (2026-08-22): the hub
+    applies the input's configured NO/NC polarity itself, so `01`
+    (CONTACT_DISRUPTED) always means "the contact left its rest position" —
+    the app's "Alerte" — in both modes, and `00`/`02` mean at rest ("OK").
+    """
+
+    def _make_device(
+        self, device_type: str = "wire_input_mt", statuses: dict[str, object] | None = None
+    ) -> Device:
+        return Device(
+            id="082639CE",
+            hub_id="hub-1",
+            name="Wire input 8",
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses=statuses if statuses is not None else {},
+            battery=None,
+        )
+
+    def test_disrupted_reads_open(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.devices["082639CE"] = self._make_device()
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: b"\x01"})
+
+        assert coordinator.devices["082639CE"].statuses["external_contact_open"] is True
+        coordinator.async_set_updated_data.assert_called_once()
+
+    @pytest.mark.parametrize("raw", [b"\x00", b"\x02"])
+    def test_rest_state_reads_closed(self, raw: bytes) -> None:
+        # `00` is what current firmware reports at rest; `02` is the enum's
+        # named CONTACT_NORMAL — both mean the contact is in its rest position.
+        coordinator = _make_coordinator()
+        coordinator.devices["082639CE"] = self._make_device(
+            statuses={"external_contact_open": True}
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: raw})
+
+        assert coordinator.devices["082639CE"].statuses["external_contact_open"] is False
+
+    def test_other_families_are_not_routed(self) -> None:
+        # 0x33 is `external_sensor_power_broken` on the MultiTransmitter
+        # itself and other things elsewhere — the sub-key is a per-family
+        # legacy proto field number. Routing beyond the validated family
+        # would repeat #406.
+        coordinator = _make_coordinator()
+        coordinator.devices["082639CE"] = self._make_device(device_type="multi_transmitter")
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: b"\x01"})
+
+        assert "external_contact_open" not in coordinator.devices["082639CE"].statuses
+
+    @pytest.mark.parametrize("raw", [b"\x03", b"\x80"])
+    def test_not_available_and_unknown_sentinel_leave_state_untouched(self, raw: bytes) -> None:
+        # `03` = CONTACT_NOT_AVAILABLE; `80` is this protocol's unknown
+        # sentinel. Neither says anything about the contact's position.
+        coordinator = _make_coordinator()
+        coordinator.devices["082639CE"] = self._make_device(
+            statuses={"external_contact_open": True}
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: raw})
+
+        assert coordinator.devices["082639CE"].statuses["external_contact_open"] is True
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_unchanged_value_does_not_churn_entities(self) -> None:
+        # Every device row repeats on the 60 s status refresh; an unchanged
+        # value must not fire a state update.
+        coordinator = _make_coordinator()
+        coordinator.devices["082639CE"] = self._make_device(
+            statuses={"external_contact_open": True}
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: b"\x01"})
+
+        coordinator.async_set_updated_data.assert_not_called()
+
+    def test_contact_state_is_in_the_snapshot_carry(self) -> None:
+        """gRPC has NO source for this key — a snapshot omitting it is never
+        a signal, and only HTS itself (≤60 s cadence) updates or withdraws it."""
+        from custom_components.aegis_ajax.coordinator import (
+            _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS,
+        )
+
+        assert "external_contact_open" in _SNAPSHOT_CARRY_FORWARD_STATUS_KEYS
+
+
 class TestHtsCaseTamperFamilyGate:
     """Only families with a physical-tamper capture are routed (#406).
 


### PR DESCRIPTION
## What

Each MultiTransmitter wire input gets a second binary sensor (device_class `opening`) mirroring the Ajax app's per-input **Alerte/OK** contact state (#413). The existing `wire_input_alert` entity is untouched.

## Why this mapping is safe

Sourced from HTS `0x33` (`WireInputMt.external_contact_state`), hardware-validated by @Taknok's four-state capture (NC and NO × open and closed, bistable, screenshots per step): **the hub applies the input's configured NO/NC polarity itself**, so `01` (CONTACT_DISRUPTED, the app's Alerte) always means "the contact left its configured rest position" in both modes. The polarity inversion risk that blocked this issue doesn't exist client-side — there is nothing to invert.

- `01` → open · `00`/`02` → closed · `03`/`0x80`/anything else → state untouched.
- Family-gated hard to `wire_input_mt`: the same byte is `external_sensor_power_broken` on the MultiTransmitter itself and other things on other families (#406's lesson).
- The status key joins the snapshot carry-forward: no gRPC surface carries it, so a snapshot omitting it is never a signal — HTS updates or withdraws it on its ≤60 s cadence.

## Known edges (stated, not hidden)

- An input with nothing wired reads permanently open (broken loop) — same as the app shows Alerte for it.
- On a fresh install the sensor reads closed until the first status row (≤60 s); the persisted device cache keeps it across restarts.
- Plain `wire_input` / `transmitter` families key the same concept on different sub-keys — out of scope until captured.

## Ajax API-call delta

Zero — STATUS_BODY (60 s) and STATUS_UPDATE deltas already flow; in the capture, changes arrived in 15–70 s.

## Tests

TDD: 10 new tests (routing, polarity/rest values, family gate, unknown sentinel, churn guard, carry membership, descriptor + family list), 6 watched failing first, 4 guard-pins. Full suite 2291 pass, coverage 90.73%. Translations in strings.json + all 14 locales.

Refs #413