### PR TITLE
fix(coordinator): invert the MT wire-input contact mapping to match the capture

### DIFF
--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -62,10 +62,10 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
     # reading steam rather than smoke (e.g. shower/cooking false-positive).
     "steam": BinarySensorTypeInfo(BinarySensorDeviceClass.PROBLEM, "steam"),
     "wire_input_alert": BinarySensorTypeInfo(BinarySensorDeviceClass.SAFETY, "wire_input_alert"),
-    # #413: the MT wire input's contact state, mirroring the app's per-input
-    # Alerte/OK — the hub applies the input's NO/NC polarity itself, so
-    # "disrupted" always means the contact left its rest position (open),
-    # in both modes. OPENING, not SAFETY: the ask is a door/garage state
+    # #413: the MT wire input's contact state — open = the app's Alerte,
+    # closed = OK, at least for NC inputs (the timestamped capture; NO-mode
+    # semantics are still unsettled, see the coordinator applier's
+    # docstring). OPENING, not SAFETY: the ask is a door/garage state
     # usable independently of the alarm. Sourced from HTS `0x33`
     # (`coordinator._maybe_apply_hts_contact_state`); reads closed until the
     # first status row after a cold install (the persisted device cache

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -1985,14 +1985,19 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _maybe_apply_hts_contact_state(self, device_id_hex: str, kv: dict[int, bytes]) -> None:
         """Route HTS `0x33` onto `external_contact_open` for MT wire inputs (#413).
 
-        The hub reports the contact state with the input's configured NO/NC
-        polarity already applied (Taknok's four-state capture), so `01` —
-        CONTACT_DISRUPTED, the app's "Alerte" — maps straight to "open" with
-        no polarity handling here. `00` (what current firmware reports at
-        rest) and `02` (the enum's named CONTACT_NORMAL) map to "closed".
-        Anything else — `03` CONTACT_NOT_AVAILABLE, the `80` unknown sentinel,
-        a future value — says nothing about the contact's position and leaves
-        the stored state untouched.
+        Value mapping, from Taknok's timestamped NC-mode capture (2026-08-22):
+        circuit open — the app's "Alerte" — is `0x33=00`; circuit closed —
+        the app's "OK" — is `0x33=01`. The proto enum (CONTACT_DISRUPTED=1,
+        CONTACT_NORMAL=2) does NOT describe this byte — firmware sends a bool
+        whose values contradict the enum's names, and reading `01` as
+        "disrupted" is exactly the inversion both field reports saw on
+        1.17.1-beta.4/5 (a closed NC door showed "open"). Anything but
+        `00`/`01` — including the enum's `02`/`03`, whose names are no longer
+        evidence, and the `80` unknown sentinel — says nothing about the
+        contact's position and leaves the stored state untouched. Whether the
+        hub applies the input's NO/NC polarity to this byte before reporting
+        is still unsettled (the capture's NO-mode rows conflict with the
+        beta.5 field report); both readings agree on this value mapping.
 
         Family-gated hard to `wire_input_mt`: the same byte means
         `external_sensor_power_broken` on the MultiTransmitter itself and
@@ -2007,9 +2012,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if device is None or device.device_type != "wire_input_mt":
             return
         raw = kv.get(_HTS_CONTACT_STATE_KEY)
-        if raw == b"\x01":
+        if raw == b"\x00":
             contact_open = True
-        elif raw in (b"\x00", b"\x02"):
+        elif raw == b"\x01":
             contact_open = False
         else:
             return

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -3130,10 +3130,14 @@ class TestHtsCaseTamperRouting:
 class TestHtsContactState:
     """HTS `0x33` drives `external_contact_open` on MT wire inputs (#413).
 
-    Hardware-validated by Taknok's four-state capture (2026-08-22): the hub
-    applies the input's configured NO/NC polarity itself, so `01`
-    (CONTACT_DISRUPTED) always means "the contact left its rest position" —
-    the app's "Alerte" — in both modes, and `00`/`02` mean at rest ("OK").
+    The value mapping comes from Taknok's timestamped capture (2026-08-22),
+    NC mode: circuit open (app "Alerte") -> `0x33=00`, circuit closed (app
+    "OK") -> `0x33=01`. The first shipped build (1.17.1-beta.4) read those
+    two values the other way around — both field reports on the issue saw a
+    closed door as "open" in NC — so `00` is open and `01` is closed. The
+    proto enum (DISRUPTED=1/NORMAL=2) does NOT describe this byte: firmware
+    sends a bool that contradicts the enum's names, so `02` proves nothing
+    and is left untouched with the other unknowns.
     """
 
     def _make_device(
@@ -3153,27 +3157,26 @@ class TestHtsContactState:
             battery=None,
         )
 
-    def test_disrupted_reads_open(self) -> None:
+    def test_00_reads_open(self) -> None:
+        # Capture, NC mode, 13:58: circuit open, app shows Alerte -> 0x33=00.
         coordinator = _make_coordinator()
         coordinator.devices["082639CE"] = self._make_device()
         coordinator.async_set_updated_data = MagicMock()
 
-        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: b"\x01"})
+        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: b"\x00"})
 
         assert coordinator.devices["082639CE"].statuses["external_contact_open"] is True
         coordinator.async_set_updated_data.assert_called_once()
 
-    @pytest.mark.parametrize("raw", [b"\x00", b"\x02"])
-    def test_rest_state_reads_closed(self, raw: bytes) -> None:
-        # `00` is what current firmware reports at rest; `02` is the enum's
-        # named CONTACT_NORMAL — both mean the contact is in its rest position.
+    def test_01_reads_closed(self) -> None:
+        # Capture, NC mode, 13:59: circuit closed, app shows OK -> 0x33=01.
         coordinator = _make_coordinator()
         coordinator.devices["082639CE"] = self._make_device(
             statuses={"external_contact_open": True}
         )
         coordinator.async_set_updated_data = MagicMock()
 
-        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: raw})
+        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: b"\x01"})
 
         assert coordinator.devices["082639CE"].statuses["external_contact_open"] is False
 
@@ -3190,10 +3193,13 @@ class TestHtsContactState:
 
         assert "external_contact_open" not in coordinator.devices["082639CE"].statuses
 
-    @pytest.mark.parametrize("raw", [b"\x03", b"\x80"])
+    @pytest.mark.parametrize("raw", [b"\x02", b"\x03", b"\x80"])
     def test_not_available_and_unknown_sentinel_leave_state_untouched(self, raw: bytes) -> None:
-        # `03` = CONTACT_NOT_AVAILABLE; `80` is this protocol's unknown
-        # sentinel. Neither says anything about the contact's position.
+        # `80` is this protocol's unknown sentinel. `02`/`03` are the proto
+        # enum's CONTACT_NORMAL/CONTACT_NOT_AVAILABLE — but the enum's value
+        # 1 was empirically wrong for this byte, so an enum name is not
+        # evidence; no capture has shown either value, and neither says
+        # anything about the contact's position.
         coordinator = _make_coordinator()
         coordinator.devices["082639CE"] = self._make_device(
             statuses={"external_contact_open": True}
@@ -3214,7 +3220,7 @@ class TestHtsContactState:
         )
         coordinator.async_set_updated_data = MagicMock()
 
-        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: b"\x01"})
+        coordinator._on_hts_device_kv("0029B936", "082639CE", {0x33: b"\x00"})
 
         coordinator.async_set_updated_data.assert_not_called()
 


### PR DESCRIPTION
The contact sensor shipped in `1.17.1-beta.4` read HTS `0x33=01` as "disrupted → open", trusting the proto enum's names (`CONTACT_DISRUPTED=1`). The timestamped NC-mode capture on #413 says the opposite: circuit open (the app's *Alerte*) arrives as `00`, circuit closed (*OK*) as `01` — firmware sends a bool that contradicts the enum. Both field reports on the issue saw exactly that inversion: a closed NC door showed *open*.

**Change:** `00` → open, `01` → closed; every other value (`02`, `03`, the `80` sentinel) leaves the stored state untouched — the enum's names are no longer evidence after value 1 proved wrong. NO-mode semantics stay an open question (the capture's NO rows conflict with the beta.5 field report), but both candidate readings agree on this byte mapping, so the flip is right under either.

**API-call delta: zero** — same HTS stream, same keys, only the interpretation changes.

Tests rewritten to encode the capture timeline rather than the enum. Full suite green (2293 passed, mypy, vulture, ruff).