### PR TITLE
feat(diagnostics): record whether an FCM registration has ever delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Diagnostics report whether push has ever delivered anything (#437).** The dump gains a `push` block: whether the client is connected and for how long, how many pushes have arrived since startup, when the last one landed, and — the field that matters — `ever_delivered`, whether this credential set has *ever* delivered a single push. That last one is persisted and keyed to a fingerprint of the four FCM values, so it survives restarts and resets by itself when the values change. The two existing counters are per-process, which is why an FCM registration that Ajax accepts and then never delivers to has been indistinguishable, after every restart, from a house that simply had no events: the client connects, stays connected, and receives nothing, with no error raised anywhere. Diagnosing that state in #359 took a month and 40 comments of logs; the first diagnostics download now answers it. Found through @aavdberg's captures, which is what made the shape of the hole visible. No additional requests to Ajax — it only counts what already flows.
+
 ## [1.17.1] - 2026-08-26
 
 Consolidates the `1.17.1-beta.1` → `beta.7` series, same bits as `beta.7`. Three of the six changes were confirmed directly on the reporters' own hardware: the recorder card by @pvangorp (7/7 channels), the dimmer by @mediaman66-dev, and the MultiTransmitter contact state by @Taknok's four-state capture — which also caught the first beta reading that state backwards, alongside @mfroger's report.

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -243,4 +244,38 @@ async def async_get_config_entry_diagnostics(
         },
         "stream_tasks": len(coordinator._stream_tasks),
         "notification_listener": coordinator.notification_listener is not None,
+        # Push delivery health (#437). A registration Ajax accepts and then
+        # never delivers to produces no error anywhere: the client connects,
+        # stays connected, and simply receives nothing. `ever_delivered` is the
+        # field that separates that from a quiet house, because it is persisted
+        # per credential set instead of resetting on every restart. The
+        # fingerprint identifies the credential set without carrying any of the
+        # four values, all of which are in `TO_REDACT` above.
+        "push": _push_diagnostics(coordinator.notification_listener),
+    }
+
+
+def _push_diagnostics(listener: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Summarise push delivery for the dump (#437).
+
+    Ages are relative because the underlying stamps are `time.monotonic()`,
+    which has no meaning as a wall clock. Relative is also the more useful
+    form here: "connected 4 h, never delivered" is the whole diagnosis.
+    """
+    if listener is None:
+        return {"configured": False}
+    started_at = listener._fcm_client_started_at
+    last_push_at = listener.last_push_at
+    now = time.monotonic()
+    return {
+        "configured": True,
+        "connected": listener.is_fcm_connected,
+        "client_connected_for_seconds": (
+            round(now - started_at) if started_at is not None else None
+        ),
+        "pushes_received_since_start": listener.pushes_received,
+        "last_push_seconds_ago": (round(now - last_push_at) if last_push_at is not None else None),
+        "ever_delivered": listener.ever_delivered,
+        "first_delivery_at": listener.first_delivery_at,
+        "creds_fingerprint": listener.creds_fingerprint,
     }

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
 
 from custom_components.aegis_ajax import notification_event_parser
 from custom_components.aegis_ajax.const import (
@@ -52,6 +53,7 @@ STORAGE_KEY = f"{DOMAIN}_fcm_credentials"
 # Google terminally rejected, so we don't re-hit the Firebase project on every
 # restart with a key we already know is wrong (#227).
 REJECTED_STORAGE_KEY = f"{DOMAIN}_fcm_rejected"
+DELIVERY_STORAGE_KEY = f"{DOMAIN}_fcm_delivery"
 STORAGE_VERSION = 1
 
 # Ajax dispatches two FCM messages per security transition (one user-facing
@@ -197,6 +199,25 @@ class AjaxNotificationListener:
         # doesn't double-count.
         self._pushes_received: int = 0
         self._last_push_at: float | None = None
+        # #437: the two counters above are per-process, so after every restart
+        # a registration that Ajax accepts and never delivers to is
+        # indistinguishable from one that simply hasn't seen an event yet.
+        # That is the mechanical reason #359 could stay in total silence for a
+        # month without producing any observable signal. This record survives
+        # restarts, and it is keyed to the credential fingerprint so that
+        # re-entering the four values resets the evidence by construction.
+        self._delivery_store: Store[dict[str, Any]] = Store(
+            hass, STORAGE_VERSION, DELIVERY_STORAGE_KEY
+        )
+        self._creds_fingerprint: str = _fcm_creds_hash(
+            fcm_project_id=fcm_project_id,
+            fcm_app_id=fcm_app_id,
+            fcm_api_key=fcm_api_key,
+            fcm_sender_id=fcm_sender_id,
+        )[:16]
+        self._ever_delivered: bool = False
+        self._first_delivery_at: str | None = None
+        self._delivery_record_unsaved: bool = False
 
     @property
     def pushes_received(self) -> int:
@@ -207,6 +228,26 @@ class AjaxNotificationListener:
     def last_push_at(self) -> float | None:
         """`time.monotonic()` of the most recent non-deduped push, or None."""
         return self._last_push_at
+
+    @property
+    def creds_fingerprint(self) -> str:
+        """Short digest of the four FCM values — never the values themselves.
+
+        Truncated to 16 chars deliberately: it only ever has to answer "are
+        these the same credentials the stored record was written for", and a
+        fingerprint that short is not a re-derivable digest of the secret.
+        """
+        return self._creds_fingerprint
+
+    @property
+    def ever_delivered(self) -> bool:
+        """True if this credential set has ever delivered a push (#437)."""
+        return self._ever_delivered
+
+    @property
+    def first_delivery_at(self) -> str | None:
+        """ISO timestamp of the first push this credential set ever delivered."""
+        return self._first_delivery_at
 
     @property
     def is_fcm_connected(self) -> bool:
@@ -296,6 +337,7 @@ class AjaxNotificationListener:
         # Load or create FCM credentials
         stored = await self._store.async_load()
         self._credentials = dict(stored) if stored else None
+        await self._async_load_delivery_record()
 
         fcm_config = FcmRegisterConfig(
             project_id=self._fcm_project_id,
@@ -672,6 +714,10 @@ class AjaxNotificationListener:
         """
         if now is None:
             now = time.monotonic()
+        # Flush a first-delivery mark made on the worker thread (#437). Before
+        # the liveness branches below, all of which can return early.
+        if self._delivery_record_unsaved:
+            await self._async_persist_delivery_record()
         client = self._push_client
         if client is not None:
             tasks = getattr(client, "tasks", None) or []
@@ -855,6 +901,7 @@ class AjaxNotificationListener:
         # System Health card so users can confirm push delivery is alive.
         self._pushes_received += 1
         self._last_push_at = time.monotonic()
+        self._note_push_delivered()
 
         # Parse event from ENCODED_DATA using compiled protos
         if encoded_data:
@@ -866,6 +913,67 @@ class AjaxNotificationListener:
                 self._hass.async_create_task,
                 self._coordinator.async_request_refresh(),
             )
+
+    async def _async_load_delivery_record(self) -> None:
+        """Restore the delivery record for the CURRENT credential set (#437).
+
+        A record written for other credentials is ignored rather than
+        migrated: after someone re-enters the four values, "delivery already
+        worked once" is no longer a claim about the registration in force, and
+        keeping it would permanently silence the detector this record feeds.
+
+        Never raises. The record is diagnostic, so a storage problem must not
+        be able to stop push from starting.
+        """
+        try:
+            stored = await self._delivery_store.async_load()
+        except Exception:
+            _LOGGER.debug("Could not load the FCM delivery record", exc_info=True)
+            return
+        if not stored or stored.get("hash") != self._creds_fingerprint:
+            return
+        self._ever_delivered = True
+        self._first_delivery_at = stored.get("first_delivery_at")
+
+    def _note_push_delivered(self) -> None:
+        """Mark that this credential set has now delivered at least one push.
+
+        Runs on the `firebase_messaging` worker thread, so it touches plain
+        attributes only and does not schedule anything: the supervisor tick,
+        which is already on the event loop, picks the write up within a minute.
+        Deliberately NOT marshalled from here — `_on_notification` marshals
+        exactly one call to the loop (the refresh) and adding a second hop per
+        push buys nothing for a record that is written once per credential set.
+
+        Idempotent: the first delivery is the one worth dating, and a later
+        push must not move the timestamp.
+
+        Worst case, a restart inside that minute loses the record and the next
+        delivered push re-marks it. Acceptable — the record's job is to make a
+        registration that NEVER delivers visible, and that case has no push to
+        race with.
+        """
+        if self._ever_delivered:
+            return
+        self._ever_delivered = True
+        self._first_delivery_at = dt_util.utcnow().isoformat()
+        self._delivery_record_unsaved = True
+
+    async def _async_persist_delivery_record(self) -> None:
+        """Write the delivery record. Only ever called on a first delivery,
+        so this touches `.storage` once per credential set rather than once
+        per push."""
+        try:
+            await self._delivery_store.async_save(
+                {
+                    "hash": self._creds_fingerprint,
+                    "first_delivery_at": self._first_delivery_at,
+                }
+            )
+        except Exception:
+            _LOGGER.debug("Could not persist the FCM delivery record", exc_info=True)
+            return
+        self._delivery_record_unsaved = False
 
     def _is_stale_push(self, encoded_data: str) -> bool:
         """Return True when an FCM push carries a `Notification.server_timestamp`

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -87,6 +87,60 @@ class TestAsyncGetConfigEntryDiagnostics:
         return e
 
     @pytest.mark.asyncio
+    async def test_push_delivery_is_reported(
+        self, coordinator: MagicMock, entry: MagicMock
+    ) -> None:
+        """#437: the dump has to answer "has push ever delivered here".
+
+        A registration Ajax accepts and never delivers to raises no error
+        anywhere — the client connects, stays connected and receives nothing —
+        so `ever_delivered` is the field that separates that from a house that
+        simply had no events.
+        """
+        listener = coordinator.notification_listener
+        listener.is_fcm_connected = True
+        listener.pushes_received = 0
+        listener.last_push_at = None
+        listener.ever_delivered = False
+        listener.first_delivery_at = None
+        listener.creds_fingerprint = "abc123def456"
+        listener._fcm_client_started_at = None
+
+        push = (await async_get_config_entry_diagnostics(MagicMock(), entry))["push"]
+
+        assert push["configured"] is True
+        assert push["connected"] is True
+        assert push["ever_delivered"] is False
+        assert push["pushes_received_since_start"] == 0
+        assert push["last_push_seconds_ago"] is None
+        assert push["creds_fingerprint"] == "abc123def456"
+
+    @pytest.mark.asyncio
+    async def test_push_reports_not_configured_without_a_listener(
+        self, coordinator: MagicMock, entry: MagicMock
+    ) -> None:
+        coordinator.notification_listener = None
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        assert result["push"] == {"configured": False}
+
+    @pytest.mark.asyncio
+    async def test_push_block_carries_no_fcm_credentials(
+        self, coordinator: MagicMock, entry: MagicMock
+    ) -> None:
+        """The fingerprint identifies the credential set; the four values
+        themselves are redacted everywhere else in the dump and must not
+        reappear here."""
+        secret = "AIza" + "x" * 35
+        entry.data = {**entry.data, "fcm_api_key": secret}
+        coordinator.notification_listener.creds_fingerprint = "fingerprintonly"
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        assert secret not in str(result["push"])
+
+    @pytest.mark.asyncio
     async def test_returns_dict(self, entry: MagicMock) -> None:
         result = await async_get_config_entry_diagnostics(MagicMock(), entry)
         assert isinstance(result, dict)

--- a/tests/unit/test_notification_delivery_record.py
+++ b/tests/unit/test_notification_delivery_record.py
@@ -1,0 +1,239 @@
+"""Persisted "has this credential set ever delivered a push" record (#437).
+
+`_pushes_received` and `_last_push_at` are per-process, so a registration that
+Ajax accepts and then never delivers to looks identical, after every restart, to
+one that simply hasn't seen an event yet. That is mechanically why #359 spent a
+month in total silence without producing a single observable signal. This record
+survives restarts and is keyed to the credential fingerprint, so re-entering the
+four values resets the evidence by construction.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.aegis_ajax.notification import AjaxNotificationListener
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+_FCM_KWARGS = {
+    "fcm_project_id": "mws-mobile-client---2",
+    "fcm_app_id": "1:991608156148:android:" + "a" * 40,
+    "fcm_api_key": "AIza" + "x" * 35,
+    "fcm_sender_id": "991608156148",
+}
+
+# Same shapes, different project — a distinct fingerprint.
+_OTHER_FCM_KWARGS = {
+    **_FCM_KWARGS,
+    "fcm_app_id": "1:60875194502:android:" + "b" * 40,
+    "fcm_sender_id": "60875194502",
+}
+
+
+def _make_listener(**overrides: str) -> AjaxNotificationListener:
+    hass = MagicMock()
+    # A real loop marshals the store write; these tests drive the record
+    # directly, so keep the threadsafe hop out of the way.
+    hass.loop = None
+    return AjaxNotificationListener(
+        hass=hass,
+        coordinator=MagicMock(),
+        **{**_FCM_KWARGS, **overrides},
+    )
+
+
+class TestDeliveryRecord:
+    """The in-memory half of the record."""
+
+    def test_starts_undelivered(self) -> None:
+        listener = _make_listener()
+        assert listener.ever_delivered is False
+        assert listener.first_delivery_at is None
+
+    def test_first_delivery_is_recorded_once(self) -> None:
+        listener = _make_listener()
+
+        listener._note_push_delivered()
+        first = listener.first_delivery_at
+        assert listener.ever_delivered is True
+        assert first is not None
+
+        # A later push must not move the timestamp: "when did this credential
+        # set first prove itself" is the question, and it has one answer.
+        listener._note_push_delivered()
+        assert listener.first_delivery_at == first
+
+    def test_fingerprint_is_not_the_credentials(self) -> None:
+        listener = _make_listener()
+        fingerprint = listener.creds_fingerprint
+
+        assert fingerprint
+        for value in _FCM_KWARGS.values():
+            assert value not in fingerprint
+        # Short enough to be a fingerprint rather than a re-derivable digest.
+        assert len(fingerprint) <= 16
+
+    def test_fingerprint_changes_with_the_credentials(self) -> None:
+        assert _make_listener().creds_fingerprint != (
+            _make_listener(**_OTHER_FCM_KWARGS).creds_fingerprint
+        )
+
+
+class TestDeliveryRecordPersistence:
+    """The stored half: it must survive a restart, and reset on new values."""
+
+    @pytest.mark.asyncio
+    async def test_loads_a_matching_record(self) -> None:
+        listener = _make_listener()
+        stored = {
+            "hash": listener.creds_fingerprint,
+            "first_delivery_at": "2026-08-01T10:00:00+00:00",
+        }
+        listener._delivery_store.async_load = _async_return(stored)
+
+        await listener._async_load_delivery_record()
+
+        assert listener.ever_delivered is True
+        assert listener.first_delivery_at == "2026-08-01T10:00:00+00:00"
+
+    @pytest.mark.asyncio
+    async def test_ignores_a_record_from_other_credentials(self) -> None:
+        """Re-entering the four values must reset the evidence.
+
+        Otherwise a user who fixes broken credentials keeps a record saying
+        delivery already worked, and the detector this record exists to feed
+        would never fire again.
+        """
+        listener = _make_listener()
+        listener._delivery_store.async_load = _async_return(
+            {"hash": "not-this-credential-set", "first_delivery_at": "2026-08-01T10:00:00+00:00"}
+        )
+
+        await listener._async_load_delivery_record()
+
+        assert listener.ever_delivered is False
+        assert listener.first_delivery_at is None
+
+    @pytest.mark.asyncio
+    async def test_no_record_at_all(self) -> None:
+        listener = _make_listener()
+        listener._delivery_store.async_load = _async_return(None)
+
+        await listener._async_load_delivery_record()
+
+        assert listener.ever_delivered is False
+
+    @pytest.mark.asyncio
+    async def test_a_load_failure_does_not_break_startup(self) -> None:
+        """The record is diagnostic; it must never be able to stop push."""
+        listener = _make_listener()
+
+        async def _boom() -> dict[str, Any]:
+            raise OSError("storage unavailable")
+
+        listener._delivery_store.async_load = _boom
+
+        await listener._async_load_delivery_record()
+
+        assert listener.ever_delivered is False
+
+    @pytest.mark.asyncio
+    async def test_saves_the_fingerprint_and_timestamp(self) -> None:
+        listener = _make_listener()
+        saved: list[dict[str, Any]] = []
+
+        async def _save(data: dict[str, Any]) -> None:
+            saved.append(data)
+
+        listener._delivery_store.async_save = _save
+        listener._note_push_delivered()
+
+        await listener._async_persist_delivery_record()
+
+        assert len(saved) == 1
+        assert saved[0]["hash"] == listener.creds_fingerprint
+        assert saved[0]["first_delivery_at"] == listener.first_delivery_at
+        # The four values must never reach disk here — the credentials store
+        # is a different key and this one is only ever a fingerprint.
+        for value in _FCM_KWARGS.values():
+            assert value not in str(saved[0])
+
+
+class TestDeliveryRecordDoesNotDisturbThePushPath:
+    """The mark must not add a thread hop, and must still reach disk."""
+
+    def test_marking_schedules_nothing(self) -> None:
+        """`_on_notification` marshals exactly one call to the loop (the
+        refresh). A record written once per credential set does not justify a
+        second hop on every push, and adding one silently broke ten existing
+        push tests when this was first written that way."""
+        listener = _make_listener()
+        listener._hass = MagicMock()
+
+        listener._note_push_delivered()
+
+        listener._hass.loop.call_soon_threadsafe.assert_not_called()
+        assert listener._delivery_record_unsaved is True
+
+    @pytest.mark.asyncio
+    async def test_supervisor_flushes_the_mark(self) -> None:
+        listener = _make_listener()
+        saved: list[dict[str, Any]] = []
+
+        async def _save(data: dict[str, Any]) -> None:
+            saved.append(data)
+
+        listener._delivery_store.async_save = _save
+        listener._note_push_delivered()
+
+        await listener._async_supervise_push_client(now=1000.0)
+
+        assert len(saved) == 1
+        assert listener._delivery_record_unsaved is False
+
+    @pytest.mark.asyncio
+    async def test_supervisor_does_not_rewrite_a_saved_record(self) -> None:
+        """Otherwise every supervisor tick writes to `.storage` forever."""
+        listener = _make_listener()
+        saved: list[dict[str, Any]] = []
+
+        async def _save(data: dict[str, Any]) -> None:
+            saved.append(data)
+
+        listener._delivery_store.async_save = _save
+        listener._note_push_delivered()
+
+        await listener._async_supervise_push_client(now=1000.0)
+        await listener._async_supervise_push_client(now=1060.0)
+
+        assert len(saved) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_save_failure_is_retried_next_tick(self) -> None:
+        listener = _make_listener()
+        attempts: list[int] = []
+
+        async def _boom(_data: dict[str, Any]) -> None:
+            attempts.append(1)
+            raise OSError("storage unavailable")
+
+        listener._delivery_store.async_save = _boom
+        listener._note_push_delivered()
+
+        await listener._async_supervise_push_client(now=1000.0)
+        assert listener._delivery_record_unsaved is True
+        await listener._async_supervise_push_client(now=1060.0)
+
+        assert len(attempts) == 2
+
+
+def _async_return(value: object) -> Callable[[], Awaitable[object]]:
+    async def _inner() -> object:
+        return value
+
+    return _inner


### PR DESCRIPTION
Phase (a) of #437. Bookkeeping and diagnostics only — the Repair that consumes this record is phase (b) and is not here.

## The problem

An FCM registration that Ajax accepts and then never delivers to raises no error anywhere. The client connects, logs in, heartbeats indefinitely, and simply receives nothing. Nothing warns, nothing degrades, and arm/disarm keeps working because state never depends on push — so the only symptom is the absence of real-time events, which a user has no baseline for.

`_pushes_received` and `_last_push_at` are per-process. So after every restart, "accepted and never delivering" looks exactly like "a house that hasn't had an event yet". That is the mechanical reason #359 could sit in total silence for a month without producing one observable signal, while every log its reporter produced came back clean.

## What this adds

A **persisted** record of whether the current credential set has ever delivered a push, and a `push` block in the diagnostics dump:

```
"push": {
  "configured": true,
  "connected": true,
  "client_connected_for_seconds": 14402,
  "pushes_received_since_start": 0,
  "last_push_seconds_ago": null,
  "ever_delivered": false,
  "first_delivery_at": null,
  "creds_fingerprint": "9f2a1c4e7b0d3856"
}
```

`connected: true` for four hours with `ever_delivered: false` is the whole diagnosis, in one look. It took a month and forty comments to establish that much on #359.

The record is keyed to a 16-character fingerprint of the four FCM values, so re-entering them resets the evidence by construction — otherwise a user who fixes broken credentials would keep a record claiming delivery already worked, and the phase (b) detector would never fire again. The fingerprint never carries the values themselves; all four remain in `TO_REDACT`.

Ages are relative because the underlying stamps are `time.monotonic()` and have no meaning as a wall clock.

## The threading decision

`_note_push_delivered()` runs on the `firebase_messaging` worker thread and deliberately schedules nothing. It sets plain attributes plus an unsaved flag; `_async_supervise_push_client`, already on the event loop, flushes the write within a minute. A save failure leaves the flag set so the next tick retries.

The first attempt did marshal the write with `call_soon_threadsafe` from the push path, and that broke ten existing tests which assert exactly one threadsafe call per push. They were right to: a record written once per credential set does not justify a second hop on every push. `test_marking_schedules_nothing` pins that.

Worst case, a restart inside that minute loses the record and the next delivered push re-marks it. Acceptable — the state this exists to expose is the one with no push to race with.

## Verification

- 2311 unit tests pass, coverage 91% (gate is 80%)
- `ruff check`, `ruff format --check`, `mypy` (50 files, clean), `vulture` — all clean
- Mutation-checked: removing the fingerprint guard, disabling the supervisor flush, and hardcoding `ever_delivered` each fail the intended test and only that test

## API-call delta

**Zero.** Everything here counts data already flowing.

Refs #437, #359
