### PR TITLE
fix(registry): use the config-entry-scoped device registry API (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Home Assistant 2026.9 no longer warns about deprecated device-registry calls (#444).** HA 2026.9 flags two calls the integration made for every entity — the `via_device` link that attaches each detector to its hub, and the device lookup used when a device is removed on the panel side or the hub's firmware version is written to its device page — and HA 2027.8 removes them, at which point the integration would stop loading. Both now use the replacements. The via link is not a plain rename: the new form wants the hub's registry entry rather than its identifier, so every hub is registered before any platform adds entities, and a child whose hub has no entry yet is created without the link rather than rejected. Older cores (the integration still supports 2024.1) keep the previous behaviour, chosen at runtime from what the running core understands. Reported by @AnthonyOD with the exact file and line references. No additional requests to Ajax: this touches only Home Assistant's own registry.
+
 ## [1.18.0-beta.1] - 2026-09-01
 
 Both changes are diagnostic-only and add zero Ajax API calls. The push delivery record ships with two installs already waiting to use it (#359); the siren settings were probed and validated on real hardware before implementation, with the caveat that a hub with sirens still owes the first `true` reading.

--- a/custom_components/aegis_ajax/__init__.py
+++ b/custom_components/aegis_ajax/__init__.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,6 +79,7 @@ from custom_components.aegis_ajax.const import (  # noqa: E402
     LABELS,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator  # noqa: E402
+from custom_components.aegis_ajax.entity import build_device_info, is_hub_device  # noqa: E402
 from custom_components.aegis_ajax.repairs import async_check_grpcio_version  # noqa: E402
 
 if TYPE_CHECKING:
@@ -485,6 +488,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AjaxCobrandedConfigEntry
     hass.async_create_task(_photo_cleanup())
     entry.async_on_unload(unsub_cleanup)
 
+    _async_register_hub_devices(hass, entry, coordinator)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Auto-label entities for easy grouping in automations.
@@ -571,6 +575,27 @@ _ENTITY_ID_LABELS: dict[str, str] = {
     "_cra": "aegis_hub",
     "_conexion_cra": "aegis_hub",
 }
+
+
+@callback
+def _async_register_hub_devices(
+    hass: HomeAssistant, entry: ConfigEntry, coordinator: AjaxCobrandedCoordinator
+) -> None:
+    """Register every hub in the device registry before any platform runs (#444).
+
+    Children link to their hub with `via_device_id`, the hub's registry entry
+    id, and HA rejects a `DeviceInfo` whose via device is not registered yet.
+    Platforms add entities in no guaranteed order, so the hubs go in first;
+    the same identifiers make the hub entities' own `DeviceInfo` an update of
+    this entry, not a duplicate. Non-hub devices are created by their entities
+    as before.
+    """
+    registry = dr.async_get(hass)
+    for device in coordinator.devices.values():
+        if is_hub_device(device):
+            registry.async_get_or_create(
+                config_entry_id=entry.entry_id, **build_device_info(device, coordinator.rooms)
+            )
 
 
 async def _async_apply_labels(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.const import EntityCategory
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.const import DOMAIN, MANUFACTURER, SIGNAL_NEW_DEVICE
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
-from custom_components.aegis_ajax.entity import build_device_info
+from custom_components.aegis_ajax.entity import build_device_info, via_device_fields
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -505,7 +505,9 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensor
         self._attr_translation_key = self._type_info.translation_key
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:
@@ -565,7 +567,9 @@ class AjaxConnectivitySensor(CoordinatorEntity[AjaxCobrandedCoordinator], Binary
         self._attr_unique_id = f"aegis_ajax_{device_id}_connectivity"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def is_on(self) -> bool:
@@ -588,7 +592,9 @@ class AjaxProblemSensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySenso
         self._attr_unique_id = f"aegis_ajax_{device_id}_problem"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def available(self) -> bool:
@@ -633,13 +639,19 @@ class AjaxKeyfobActiveSensor(CoordinatorEntity[AjaxCobrandedCoordinator], Binary
             # The entity's own name is the keyfob name; with has_entity_name the
             # device page lists it (e.g. "Front fob") under the "Keyfobs" device.
             self._attr_name = keyfob.name
-            self._attr_device_info = DeviceInfo(
+            info = DeviceInfo(
                 identifiers={(DOMAIN, f"{keyfob.hub_id}_keyfobs")},
                 name="Keyfobs",
                 manufacturer=MANUFACTURER,
                 model="SpaceControl keyfobs (experimental)",
-                via_device=(DOMAIN, keyfob.hub_id),
             )
+            info.update(
+                cast(
+                    "DeviceInfo",
+                    via_device_fields(keyfob.hub_id, coordinator.hub_registry_id(keyfob.hub_id)),
+                )
+            )
+            self._attr_device_info = info
 
     @property
     def available(self) -> bool:

--- a/custom_components/aegis_ajax/button.py
+++ b/custom_components/aegis_ajax/button.py
@@ -106,7 +106,9 @@ class AjaxCapturePhotoButton(CoordinatorEntity[AjaxCobrandedCoordinator], Button
         self._attr_unique_id = f"aegis_ajax_{device_id}_capture_photo"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     async def async_press(self) -> None:
         """Trigger photo capture, retrieve the URL, download and save it.

--- a/custom_components/aegis_ajax/camera.py
+++ b/custom_components/aegis_ajax/camera.py
@@ -72,7 +72,9 @@ class AjaxCamera(CoordinatorEntity[AjaxCobrandedCoordinator], Camera):
         self._last_image: bytes | None = None
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -63,6 +63,7 @@ from custom_components.aegis_ajax.const import (
     ConnectionStatus,
 )
 from custom_components.aegis_ajax.device_cache import DevicesCache
+from custom_components.aegis_ajax.entity import async_get_registered_device
 from custom_components.aegis_ajax.repairs import (
     async_clear_hts_chronic_failure,
     async_clear_hub_offline,
@@ -433,6 +434,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=poll_interval)
         )
         self._poll_interval = poll_interval
+        self.entry_id = entry_id
         self._client = client
         self._on_session_persist = on_session_persist
         self._space_ids = space_ids
@@ -2744,7 +2746,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.devices = {d.id: d for d in deduped}
         device_reg = dr.async_get(self.hass)
         for ghost in dropped:
-            reg_device = device_reg.async_get_device(identifiers={(DOMAIN, ghost.id)})
+            reg_device = async_get_registered_device(device_reg, (DOMAIN, ghost.id), self.entry_id)
             if reg_device is not None:
                 _LOGGER.info(
                     "Removing duplicate video-doorbell ghost %s (%s) from the "
@@ -2753,6 +2755,18 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     ghost.device_type,
                 )
                 device_reg.async_remove_device(reg_device.id)
+
+    def hub_registry_id(self, hub_id: str) -> str | None:
+        """The hub's device-registry entry id, for children's `via_device_id` (#444).
+
+        None when the hub has no registry entry yet (a hub that appeared after
+        setup); the child is then created without the link rather than
+        rejected, and gets it on the next reload.
+        """
+        entry = async_get_registered_device(
+            dr.async_get(self.hass), (DOMAIN, hub_id), self.entry_id
+        )
+        return entry.id if entry is not None else None
 
     def _handle_device_removed(self, device_id: str) -> None:
         """Handle the stream's explicit device REMOVE (#422).
@@ -2768,7 +2782,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device = self.devices.pop(device_id, None)
         self._hts_carried_deactivation_ids.discard(device_id)
         device_reg = dr.async_get(self.hass)
-        reg_device = device_reg.async_get_device(identifiers={(DOMAIN, device_id)})
+        reg_device = async_get_registered_device(device_reg, (DOMAIN, device_id), self.entry_id)
         if reg_device is not None:
             device_reg.async_remove_device(reg_device.id)
         if device is None and reg_device is None:

--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntry, DeviceInfo, DeviceRegistry
 
 from custom_components.aegis_ajax.const import (
     COMMAND_ERROR_TRANSLATION_KEYS,
@@ -20,6 +20,51 @@ if TYPE_CHECKING:
     from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 
 
+# HA 2026.8 added `via_device_id` to `DeviceInfo` and, in the same release,
+# `DeviceRegistry.async_get_device_by_identifier`; 2026.9 deprecates the
+# identifier-tuple `via_device` and the cross-entry `async_get_device`, and
+# 2027.8 removes both (#444). Older cores reject the new key with a TypeError
+# deep inside `async_get_or_create`, so the key the running core understands is
+# detected once here and every via link goes through `via_device_fields`.
+_VIA_DEVICE_ID_SUPPORTED = "via_device_id" in (
+    DeviceInfo.__required_keys__ | DeviceInfo.__optional_keys__
+)
+
+
+def is_hub_device(device: Device) -> bool:
+    """Whether an Ajax device row is a hub (the root of its device tree)."""
+    return device.device_type.startswith("hub")
+
+
+def via_device_fields(hub_id: str, hub_registry_id: str | None) -> dict[str, Any]:
+    """The `DeviceInfo` fields linking a child device to its hub.
+
+    On HA 2026.8+ the link is the hub's device-registry entry id; when the hub
+    is not registered yet there is nothing valid to pass — HA rejects an
+    unknown `via_device_id` together with the entity — so the link is simply
+    omitted. Older cores get the identifier tuple they understand.
+    """
+    if not _VIA_DEVICE_ID_SUPPORTED:
+        return {"via_device": (DOMAIN, hub_id)}
+    if hub_registry_id is None:
+        return {}
+    return {"via_device_id": hub_registry_id}
+
+
+def async_get_registered_device(
+    registry: DeviceRegistry, identifier: tuple[str, str], config_entry_id: str
+) -> DeviceEntry | None:
+    """Look a device up by identifier, scoped to our config entry (#444).
+
+    Falls back to the pre-2026.8 cross-entry lookup where the scoped one does
+    not exist yet.
+    """
+    lookup = getattr(registry, "async_get_device_by_identifier", None)
+    if lookup is not None:
+        return lookup(identifier, config_entry_id)  # type: ignore[no-any-return]
+    return registry.async_get_device(identifiers={identifier})
+
+
 # device_type → model display overrides for names `.title()` mangles
 # (acronyms). Everything else keeps the generic title-cased fallback.
 _MODEL_OVERRIDES: dict[str, str] = {
@@ -32,6 +77,7 @@ def build_device_info(
     rooms: Mapping[str, Room] | None = None,
     *,
     firmware_version: str | None = None,
+    via_device_id: str | None = None,
 ) -> DeviceInfo:
     """Build a HA DeviceInfo for an Ajax device.
 
@@ -39,9 +85,11 @@ def build_device_info(
     shown in the Ajax app) and `suggested_area` from the device's Ajax room
     when available, so HA can auto-assign devices to matching areas.
     `firmware_version` is keyword-only so call sites stay explicit about
-    populating `sw_version` (#388).
+    populating `sw_version` (#388). `via_device_id` is the hub's registry
+    entry id (`coordinator.hub_registry_id`), used for the child→hub link on
+    HA 2026.8+ and ignored for hubs themselves (#444).
     """
-    is_hub = device.device_type.startswith("hub")
+    is_hub = is_hub_device(device)
     info = DeviceInfo(
         identifiers={(DOMAIN, device.id)},
         name=device.name,
@@ -52,7 +100,7 @@ def build_device_info(
         serial_number=device.id,
     )
     if not is_hub:
-        info["via_device"] = (DOMAIN, device.hub_id)
+        info.update(cast("DeviceInfo", via_device_fields(device.hub_id, via_device_id)))
     if rooms and device.room_id:
         room = rooms.get(device.room_id) if isinstance(rooms, dict) else None
         if room is not None:

--- a/custom_components/aegis_ajax/event.py
+++ b/custom_components/aegis_ajax/event.py
@@ -134,7 +134,9 @@ class AjaxDoorbellEvent(CoordinatorEntity[AjaxCobrandedCoordinator], EventEntity
         self._attr_unique_id = f"aegis_ajax_{device_id}_doorbell_event"
         device = coordinator.devices.get(device_id)
         if device is not None:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
         else:
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, device_id)},
@@ -191,7 +193,9 @@ class AjaxButtonPressEvent(CoordinatorEntity[AjaxCobrandedCoordinator], EventEnt
         self._attr_unique_id = f"aegis_ajax_{device_id}_button_press_event"
         device = coordinator.devices.get(device_id)
         if device is not None:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
         else:
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, device_id)},

--- a/custom_components/aegis_ajax/light.py
+++ b/custom_components/aegis_ajax/light.py
@@ -69,7 +69,9 @@ class AjaxLight(CoordinatorEntity[AjaxCobrandedCoordinator], LightEntity):
         self._attr_unique_id = f"aegis_ajax_{device_id}_light_{channel}"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:

--- a/custom_components/aegis_ajax/lock.py
+++ b/custom_components/aegis_ajax/lock.py
@@ -74,7 +74,9 @@ class AjaxLock(CoordinatorEntity[AjaxCobrandedCoordinator], LockEntity):
         self._attr_unique_id = f"aegis_ajax_{device_id}_lock"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:

--- a/custom_components/aegis_ajax/number.py
+++ b/custom_components/aegis_ajax/number.py
@@ -71,7 +71,9 @@ class AjaxSirenAlarmDurationNumber(CoordinatorEntity[AjaxCobrandedCoordinator], 
         self._attr_unique_id = f"aegis_ajax_{device_id}_siren_alarm_duration"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:

--- a/custom_components/aegis_ajax/select.py
+++ b/custom_components/aegis_ajax/select.py
@@ -66,7 +66,9 @@ class AjaxSirenVolumeSelect(CoordinatorEntity[AjaxCobrandedCoordinator], SelectE
         self._attr_unique_id = f"aegis_ajax_{device_id}_siren_volume_level"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -270,7 +270,9 @@ class AjaxSensor(CoordinatorEntity[AjaxCobrandedCoordinator], SensorEntity):
         self._attr_entity_registry_enabled_default = self._type_info.entity_registry_enabled_default
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:
@@ -560,7 +562,9 @@ class _AjaxDeviceReadingsBase(CoordinatorEntity[AjaxCobrandedCoordinator], Resto
         self._restored_native_value: float | None = None
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()

--- a/custom_components/aegis_ajax/switch.py
+++ b/custom_components/aegis_ajax/switch.py
@@ -239,7 +239,9 @@ class AjaxSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity):
             self._attr_name = None
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:
@@ -311,7 +313,9 @@ class AjaxBypassSwitch(CoordinatorEntity[AjaxCobrandedCoordinator], SwitchEntity
         self._attr_unique_id = f"aegis_ajax_{device_id}_bypass"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:

--- a/custom_components/aegis_ajax/update.py
+++ b/custom_components/aegis_ajax/update.py
@@ -41,7 +41,10 @@ from custom_components.aegis_ajax.api.hub_object import (
 )
 from custom_components.aegis_ajax.const import DOMAIN
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
-from custom_components.aegis_ajax.entity import build_device_info
+from custom_components.aegis_ajax.entity import (
+    async_get_registered_device,
+    build_device_info,
+)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -146,7 +149,9 @@ class AjaxHubFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], UpdateE
         if not version:
             return
         registry = dr.async_get(self.hass)
-        entry = registry.async_get_device(identifiers={(DOMAIN, self._hub_id)})
+        entry = async_get_registered_device(
+            registry, (DOMAIN, self._hub_id), self.coordinator.entry_id
+        )
         # Guard on equality so a steady stream of HTS updates doesn't write
         # to (and re-save) the registry on every coordinator tick.
         if entry is None or entry.sw_version == version:
@@ -257,7 +262,9 @@ class AjaxDeviceFirmwareUpdate(CoordinatorEntity[AjaxCobrandedCoordinator], Upda
         self._attr_unique_id = f"aegis_ajax_{device_id}_firmware"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def available(self) -> bool:

--- a/custom_components/aegis_ajax/valve.py
+++ b/custom_components/aegis_ajax/valve.py
@@ -70,7 +70,9 @@ class AjaxValve(CoordinatorEntity[AjaxCobrandedCoordinator], ValveEntity):
         self._attr_unique_id = f"aegis_ajax_{device_id}_valve"
         device = coordinator.devices.get(device_id)
         if device:
-            self._attr_device_info = build_device_info(device, coordinator.rooms)
+            self._attr_device_info = build_device_info(
+                device, coordinator.rooms, via_device_id=coordinator.hub_registry_id(device.hub_id)
+            )
 
     @property
     def _device(self) -> Device | None:

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -226,15 +226,32 @@ class TestAjaxBinarySensor:
         sensor = AjaxBinarySensor(coordinator=coordinator, device_id="dev-1", status_key="tamper")
         assert sensor.is_on is True
 
-    def test_non_hub_device_has_via_device(self) -> None:
+    def test_non_hub_device_has_via_device_on_old_ha(self) -> None:
         device = self._make_device({})
         coordinator = MagicMock()
         coordinator.devices = {"dev-1": device}
-        sensor = AjaxBinarySensor(
-            coordinator=coordinator, device_id="dev-1", status_key="door_opened"
-        )
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", False):
+            sensor = AjaxBinarySensor(
+                coordinator=coordinator, device_id="dev-1", status_key="door_opened"
+            )
         assert sensor._attr_device_info is not None
         assert sensor._attr_device_info.get("via_device") == ("aegis_ajax", "hub-1")
+
+    def test_non_hub_device_links_by_registry_id_on_new_ha(self) -> None:
+        # #444: on HA 2026.8+ the link is the hub's registry entry id, which
+        # the entity asks the coordinator for at construction time.
+        device = self._make_device({})
+        coordinator = MagicMock()
+        coordinator.devices = {"dev-1": device}
+        coordinator.hub_registry_id.return_value = "reg-hub-1"
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", True):
+            sensor = AjaxBinarySensor(
+                coordinator=coordinator, device_id="dev-1", status_key="door_opened"
+            )
+        assert sensor._attr_device_info is not None
+        assert sensor._attr_device_info.get("via_device_id") == "reg-hub-1"
+        assert "via_device" not in sensor._attr_device_info
+        coordinator.hub_registry_id.assert_called_once_with("hub-1")
 
     def test_motion_sensor_extra_attributes_with_timestamp(self) -> None:
         device = self._make_device({"motion_detected": True, "motion_detected_at": 1700000000})
@@ -1366,8 +1383,31 @@ class TestKeyfobActiveSensor:
         # itself is named after the keyfob.
         assert sensor.name == "ALICE"
         assert sensor.device_info["identifiers"] == {("aegis_ajax", "002B1A51_keyfobs")}
-        assert sensor.device_info["via_device"] == ("aegis_ajax", "002B1A51")
         assert sensor.device_info["name"] == "Keyfobs"
+
+    def test_keyfob_device_links_to_hub_by_registry_id_on_new_ha(self) -> None:
+        # #444: the virtual Keyfobs device builds its own DeviceInfo and must
+        # follow the same via_device → via_device_id migration as the rest.
+        from custom_components.aegis_ajax.binary_sensor import AjaxKeyfobActiveSensor
+
+        coordinator = MagicMock()
+        coordinator.keyfobs = {"2ACCB91C": self._keyfob()}
+        coordinator.hub_registry_id.return_value = "reg-hub"
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", True):
+            sensor = AjaxKeyfobActiveSensor(coordinator, "2ACCB91C")
+        assert sensor.device_info["via_device_id"] == "reg-hub"
+        assert "via_device" not in sensor.device_info
+        coordinator.hub_registry_id.assert_called_once_with("002B1A51")
+
+    def test_keyfob_device_keeps_identifier_link_on_old_ha(self) -> None:
+        from custom_components.aegis_ajax.binary_sensor import AjaxKeyfobActiveSensor
+
+        coordinator = MagicMock()
+        coordinator.keyfobs = {"2ACCB91C": self._keyfob()}
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", False):
+            sensor = AjaxKeyfobActiveSensor(coordinator, "2ACCB91C")
+        assert sensor.device_info["via_device"] == ("aegis_ajax", "002B1A51")
+        assert "via_device_id" not in sensor.device_info
 
     def test_unavailable_when_keyfob_gone(self) -> None:
         from custom_components.aegis_ajax.binary_sensor import AjaxKeyfobActiveSensor

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -957,8 +957,35 @@ class TestStreamHandlers:
                 hass=hass, client=client, space_ids=["s1"], poll_interval=300
             )
         coordinator.hass = hass
+        coordinator.entry_id = "entry-1"
         coordinator.async_set_updated_data = MagicMock()
         return coordinator
+
+    def test_hub_registry_id_resolves_through_the_scoped_lookup(self) -> None:
+        # #444: children link to the hub by registry id (`via_device_id`), so
+        # entities need the hub's registry entry id at construction time.
+        coordinator = self._make_coordinator_with_stream()
+        device_reg = MagicMock()
+        device_reg.async_get_device_by_identifier.return_value = MagicMock(id="reg-hub")
+
+        with patch(
+            "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg
+        ):
+            assert coordinator.hub_registry_id("HUB7") == "reg-hub"
+
+        device_reg.async_get_device_by_identifier.assert_called_once_with(
+            ("aegis_ajax", "HUB7"), "entry-1"
+        )
+
+    def test_hub_registry_id_is_none_when_hub_not_registered(self) -> None:
+        coordinator = self._make_coordinator_with_stream()
+        device_reg = MagicMock()
+        device_reg.async_get_device_by_identifier.return_value = None
+
+        with patch(
+            "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg
+        ):
+            assert coordinator.hub_registry_id("HUB7") is None
 
     def test_handle_devices_snapshot_populates_devices(self) -> None:
         coordinator = self._make_coordinator_with_stream()
@@ -1254,7 +1281,7 @@ class TestStreamHandlers:
         reg_device = MagicMock()
         reg_device.id = "reg-ghost"
         device_reg = MagicMock()
-        device_reg.async_get_device.return_value = reg_device
+        device_reg.async_get_device_by_identifier.return_value = reg_device
 
         sibling = self._make_doorbell("9c756e2bca39-0", "video_edge_doorbell")
         with patch(
@@ -1265,6 +1292,12 @@ class TestStreamHandlers:
         assert "310A8DF4" not in coordinator.devices
         assert "9c756e2bca39-0" in coordinator.devices
         device_reg.async_remove_device.assert_called_once_with("reg-ghost")
+        # #444: the lookup is scoped to our config entry, never the deprecated
+        # cross-entry `async_get_device(identifiers=...)`.
+        device_reg.async_get_device_by_identifier.assert_called_once_with(
+            ("aegis_ajax", "310A8DF4"), "entry-1"
+        )
+        device_reg.async_get_device.assert_not_called()
 
     def test_snapshot_keeps_ghost_when_no_sibling(self) -> None:
         """Unbalanced #119 case: only the hub_device twin exists — keep it."""
@@ -1283,7 +1316,7 @@ class TestStreamHandlers:
             "310A8DF4", "motion_cam_video_doorbell"
         )
         device_reg = MagicMock()
-        device_reg.async_get_device.return_value = None
+        device_reg.async_get_device_by_identifier.return_value = None
 
         sibling = self._make_doorbell("9c756e2bca39-0", "video_edge_doorbell")
         with patch(
@@ -1306,7 +1339,7 @@ class TestStreamHandlers:
         reg_device = MagicMock()
         reg_device.id = "reg-d1"
         device_reg = MagicMock()
-        device_reg.async_get_device.return_value = reg_device
+        device_reg.async_get_device_by_identifier.return_value = reg_device
 
         with patch(
             "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg
@@ -1325,7 +1358,7 @@ class TestStreamHandlers:
         coordinator = self._make_coordinator_with_stream()
         coordinator._devices_cache = MagicMock()
         device_reg = MagicMock()
-        device_reg.async_get_device.return_value = None
+        device_reg.async_get_device_by_identifier.return_value = None
 
         with patch(
             "custom_components.aegis_ajax.coordinator.dr.async_get", return_value=device_reg

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 from custom_components.aegis_ajax.api.models import Device, Room
 from custom_components.aegis_ajax.const import DOMAIN, DeviceState
-from custom_components.aegis_ajax.entity import build_device_info
+from custom_components.aegis_ajax.entity import (
+    async_get_registered_device,
+    build_device_info,
+    via_device_fields,
+)
 
 
 def _make_device(
@@ -38,13 +44,45 @@ class TestBuildDeviceInfo:
         info = build_device_info(_make_device(device_id="DEV42"))
         assert (DOMAIN, "DEV42") in info["identifiers"]
 
-    def test_non_hub_device_has_via_device(self) -> None:
-        info = build_device_info(_make_device(device_type="door_protect", hub_id="HUB7"))
-        assert info["via_device"] == (DOMAIN, "HUB7")
-
-    def test_hub_device_has_no_via_device(self) -> None:
-        info = build_device_info(_make_device(device_type="hub_two_4g", device_id="HUB7"))
+    def test_non_hub_device_links_to_hub_by_registry_id_on_new_ha(self) -> None:
+        # HA 2026.8+ (#444): `via_device` is deprecated and removed in 2027.8;
+        # the replacement `via_device_id` takes the hub's registry entry id.
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", True):
+            info = build_device_info(
+                _make_device(device_type="door_protect", hub_id="HUB7"), via_device_id="reg-hub7"
+            )
+        assert info["via_device_id"] == "reg-hub7"
         assert "via_device" not in info
+
+    def test_link_is_omitted_when_hub_not_yet_registered_on_new_ha(self) -> None:
+        # A `via_device_id` that is not a registered device id makes HA reject
+        # the whole DeviceInfo (and the entity with it), so no id → no link.
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", True):
+            info = build_device_info(
+                _make_device(device_type="door_protect", hub_id="HUB7"), via_device_id=None
+            )
+        assert "via_device_id" not in info
+        assert "via_device" not in info
+
+    def test_non_hub_device_keeps_identifier_link_on_old_ha(self) -> None:
+        # Before 2026.8 `DeviceInfo` has no `via_device_id` key and passing one
+        # is a TypeError inside HA, so the identifier tuple stays in use there.
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", False):
+            info = build_device_info(
+                _make_device(device_type="door_protect", hub_id="HUB7"), via_device_id="reg-hub7"
+            )
+        assert info["via_device"] == (DOMAIN, "HUB7")
+        assert "via_device_id" not in info
+
+    def test_hub_device_has_no_via_link(self) -> None:
+        for supported in (True, False):
+            with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", supported):
+                info = build_device_info(
+                    _make_device(device_type="hub_two_4g", device_id="HUB7"),
+                    via_device_id="reg-hub7",
+                )
+            assert "via_device" not in info
+            assert "via_device_id" not in info
 
     def test_suggested_area_set_from_room(self) -> None:
         rooms = {"r1": Room(id="r1", name="Kitchen", space_id="s1")}
@@ -151,3 +189,41 @@ class TestAsyncSendDeviceCommand:
 
         assert exc.value.translation_key == "command_failed"
         assert exc.value.translation_placeholders == {"reason": "weird_new_code"}
+
+
+class TestViaDeviceFields:
+    """The keyfob device builds its own DeviceInfo; it shares the via logic."""
+
+    def test_new_ha_uses_registry_id(self) -> None:
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", True):
+            assert via_device_fields("HUB7", "reg-hub7") == {"via_device_id": "reg-hub7"}
+            assert via_device_fields("HUB7", None) == {}
+
+    def test_old_ha_uses_identifier_tuple(self) -> None:
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", False):
+            assert via_device_fields("HUB7", "reg-hub7") == {"via_device": (DOMAIN, "HUB7")}
+            assert via_device_fields("HUB7", None) == {"via_device": (DOMAIN, "HUB7")}
+
+
+class TestAsyncGetRegisteredDevice:
+    """`async_get_device(identifiers=...)` is deprecated in 2026.9 and removed
+    in 2027.8 (#444); the replacement is scoped to the config entry."""
+
+    def test_prefers_the_config_entry_scoped_lookup(self) -> None:
+        registry = MagicMock()
+        registry.async_get_device_by_identifier.return_value = "entry"
+
+        found = async_get_registered_device(registry, (DOMAIN, "HUB7"), "cfg-1")
+
+        assert found == "entry"
+        registry.async_get_device_by_identifier.assert_called_once_with((DOMAIN, "HUB7"), "cfg-1")
+        registry.async_get_device.assert_not_called()
+
+    def test_falls_back_to_the_legacy_lookup_on_old_ha(self) -> None:
+        registry = MagicMock(spec=["async_get_device"])
+        registry.async_get_device.return_value = "entry"
+
+        found = async_get_registered_device(registry, (DOMAIN, "HUB7"), "cfg-1")
+
+        assert found == "entry"
+        registry.async_get_device.assert_called_once_with(identifiers={(DOMAIN, "HUB7")})

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -137,6 +137,78 @@ class TestAsyncSetupEntry:
         assert "password" not in call_kwargs or call_kwargs.get("password") is None
 
     @pytest.mark.asyncio
+    async def test_setup_registers_hub_devices_before_forwarding_platforms(self) -> None:
+        # #444: children link to their hub with `via_device_id`, which HA
+        # rejects unless the hub is already a registered device. Platforms
+        # add entities in no particular order, so the hub is registered here,
+        # before any platform runs. Only hubs are pre-registered; every other
+        # device is created by its own entities as before.
+        from custom_components.aegis_ajax import async_setup_entry
+        from custom_components.aegis_ajax.api.models import Device
+        from custom_components.aegis_ajax.const import DeviceState
+
+        def _device(device_id: str, device_type: str) -> Device:
+            return Device(
+                id=device_id,
+                hub_id="HUB7",
+                name=device_id,
+                device_type=device_type,
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            )
+
+        order: list[str] = []
+        hass = MagicMock()
+        hass.data = {}
+
+        async def _forward(*_args: object, **_kwargs: object) -> bool:
+            order.append("forward")
+            return True
+
+        hass.config_entries.async_forward_entry_setups = _forward
+        entry = MagicMock()
+        entry.entry_id = "entry-hub"
+        entry.data = {"email": "x@y", "password_hash": "h", "spaces": ["s1"]}
+        entry.options = {}
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.session = MagicMock()
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_start_push_notifications = MagicMock()
+        mock_coordinator.devices = {
+            "HUB7": _device("HUB7", "hub_two_4g"),
+            "DOOR1": _device("DOOR1", "door_protect"),
+        }
+        mock_coordinator.rooms = {}
+        registry = MagicMock()
+        registry.async_get_or_create.side_effect = lambda **_kw: order.append("register")
+
+        with (
+            patch("custom_components.aegis_ajax.AjaxGrpcClient", return_value=mock_client),
+            patch(
+                "custom_components.aegis_ajax.AjaxCobrandedCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch("custom_components.aegis_ajax.dr.async_get", return_value=registry),
+        ):
+            await async_setup_entry(hass, entry)
+
+        assert order == ["register", "forward"]
+        registry.async_get_or_create.assert_called_once()
+        kwargs = registry.async_get_or_create.call_args.kwargs
+        assert kwargs["config_entry_id"] == "entry-hub"
+        assert kwargs["identifiers"] == {("aegis_ajax", "HUB7")}
+        assert kwargs["name"] == "HUB7"
+        assert "via_device" not in kwargs and "via_device_id" not in kwargs
+
+    @pytest.mark.asyncio
     async def test_setup_entry_closes_client_when_first_refresh_fails(self) -> None:
         """A failed first refresh must close the gRPC channel before propagating.
 

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -333,7 +333,10 @@ class TestAjaxSensor:
         device = self._make_device({"temperature": 22.5})
         coordinator = MagicMock()
         coordinator.devices = {"dev-1": device}
-        sensor = AjaxSensor(coordinator=coordinator, device_id="dev-1", sensor_key="temperature")
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", False):
+            sensor = AjaxSensor(
+                coordinator=coordinator, device_id="dev-1", sensor_key="temperature"
+            )
         assert sensor._attr_device_info is not None
         assert sensor._attr_device_info.get("via_device") == ("aegis_ajax", "hub-1")
 

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -148,7 +148,9 @@ class TestAjaxHubFirmwareUpdate:
         HA instance.
         """
         registry = MagicMock()
-        registry.async_get_device.return_value = MagicMock(id="reg-1", sw_version=sw_version)
+        registry.async_get_device_by_identifier.return_value = MagicMock(
+            id="reg-1", sw_version=sw_version
+        )
         entity.hass = MagicMock()
         return registry
 
@@ -171,6 +173,11 @@ class TestAjaxHubFirmwareUpdate:
             entity._async_write_sw_version()
 
         registry.async_update_device.assert_called_once_with("reg-1", sw_version="2.41.116")
+        # #444: config-entry-scoped lookup, not the deprecated cross-entry one.
+        registry.async_get_device_by_identifier.assert_called_once_with(
+            ("aegis_ajax", "002B1A51"), coordinator.entry_id
+        )
+        registry.async_get_device.assert_not_called()
 
     def test_registry_is_not_written_when_version_is_unchanged(self) -> None:
         # HTS pushes hub status rows continuously; rewriting an identical
@@ -204,7 +211,7 @@ class TestAjaxHubFirmwareUpdate:
         coordinator = self._make_coordinator(None, firmware_version="2.41.116")
         entity = AjaxHubFirmwareUpdate(coordinator, "002B1A51")
         registry = MagicMock()
-        registry.async_get_device.return_value = None
+        registry.async_get_device_by_identifier.return_value = None
         entity.hass = MagicMock()
 
         with patch("custom_components.aegis_ajax.update.dr.async_get", return_value=registry):


### PR DESCRIPTION
## Summary

Fixes #444. HA 2026.9 deprecates two device-registry calls the integration made for every entity, and HA 2027.8 removes them — at which point the integration would stop loading.

- **`via_device` → `via_device_id`.** Not a rename: the new key takes the hub's registry *entry id*, and HA rejects a `DeviceInfo` whose via device is not registered yet (the entity is dropped with it). Hubs are therefore registered in `async_setup_entry` before any platform runs (`_async_register_hub_devices`), and a child whose hub has no entry yet is created without the link instead of being rejected. The link is built in one place, `entity.via_device_fields`, used by the shared `build_device_info` and by the virtual Keyfobs device.
- **`async_get_device(identifiers=…)` → `async_get_device_by_identifier(identifier, config_entry_id)`** at the three lookup sites: ghost doorbell eviction, the stream's device REMOVE (#422), and the hub firmware `sw_version` write (#388). The coordinator now keeps its `entry_id` for that. `entity.async_get_registered_device` wraps it with a fallback for older cores.
- **Runtime detection.** Both replacements arrived in HA **2026.8** and the integration still declares 2024.1 as its floor, where passing `via_device_id` is a `TypeError` inside HA. Which key is used is decided once, from the running core's `DeviceInfo` (`entity._VIA_DEVICE_ID_SUPPORTED`); older cores keep the exact previous behaviour.

**Ajax API delta: zero** — this touches Home Assistant's own registry only.

## Test plan

- [x] `make check` green in the dev image: 2340 tests, 90.8 % coverage, ruff, mypy, vulture.
- [x] Tests written first and each new behaviour mutation-checked (forcing the legacy tuple, disabling the scoped lookup, skipping hub pre-registration each fail only their tests).
- [x] Tests patch `_VIA_DEVICE_ID_SUPPORTED` explicitly, so they are independent of the HA version installed — relevant because the newest HA installable on Python 3.12/3.13 is 2026.2, so neither CI nor the dev image exercises the 2026.8+ path natively.
- [ ] Real install on HA 2026.8.3 (bvis-home): same 11 devices / 10 via-links / 1 root after restart, no aegis errors, entity health unchanged.
- [ ] Reporter confirms the warnings are gone on HA 2026.9 (`1.18.0-beta.2`).
- [x] `CHANGELOG.md` entry under `[Unreleased]`.
