### PR TITLE
feat(binary_sensor): show whether a detector has a "Delay when leaving" configured (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Detectors show whether they have a "Delay when leaving" configured (#443).** A disabled-by-default diagnostic binary sensor on door, motion and combi detectors and MotionCams mirrors the per-detector exit-delay setting from the Ajax app. It came out of #443: the exit delay configured on a detector never shows up as the panel's `arming` state — that state is the app's own countdown, not the hub's — so until the countdown itself can be read, the one thing Home Assistant can show about the delay is that it exists. The flag already arrived with every device snapshot and was only missing an entity. No additional requests to Ajax.
+
 ## [1.18.0-beta.2] - 2026-09-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ An [example automations file](docs/automations.yaml) is also available with 24 a
 - **GSM type** — sensor showing connection type (2G/3G/4G)
 - **Hub network sensors** — Ethernet/Wi-Fi connectivity, Wi-Fi SSID/signal, Ethernet/Wi-Fi IP addressing, cellular signal/network, and mains power status
 - **Siren on panic button / Siren on tamper** — disabled-by-default diagnostic binary sensors mirroring the hub's siren behaviour settings (read-only; configured in the Ajax app, refreshed on integration reload)
+- **Delay when leaving** — disabled-by-default diagnostic binary sensor on door, motion and combi detectors and MotionCams, mirroring whether the detector has an exit delay configured in the Ajax app (read-only). Note that the hub-side exit delay itself does not surface as an `arming` panel state; see #443
 - **Lid opened** — tamper detection for the hub enclosure
 - **Battery** — hub battery level
 - **IMEI** — hub cellular modem identifier

--- a/custom_components/aegis_ajax/binary_sensor.py
+++ b/custom_components/aegis_ajax/binary_sensor.py
@@ -30,8 +30,10 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class BinarySensorTypeInfo:
-    device_class: BinarySensorDeviceClass
+    device_class: BinarySensorDeviceClass | None
     translation_key: str | None = None
+    entity_category: EntityCategory | None = None
+    enabled_default: bool = True
 
 
 BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
@@ -74,7 +76,39 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorTypeInfo] = {
     "external_contact_open": BinarySensorTypeInfo(
         BinarySensorDeviceClass.OPENING, "external_contact_open"
     ),
+    # #443: read-only mirror of the detector's "Delay when leaving" setting,
+    # which rides the light-device stream as a presence-only status. A
+    # configuration flag, not a state: no device class fits, diagnostic, and
+    # off by default like the hub siren settings (#438). The hub-side exit
+    # delay itself never surfaces as `arming` (the app's own timer does), so
+    # this is the one thing about the delay HA can currently show.
+    "delay_when_leaving": BinarySensorTypeInfo(
+        None,
+        "delay_when_leaving",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        enabled_default=False,
+    ),
 }
+
+# Device families whose Ajax model carries an arming part (arm/alarm delays):
+# door, motion and combi detectors plus the MotionCam line. Keypads, sirens,
+# fire detectors, wire inputs and hubs have no leaving delay to mirror.
+_ARMING_DELAY_FAMILY_PREFIXES: tuple[str, ...] = (
+    "door_protect",
+    "motion_protect",
+    "dual_curtain_outdoor",
+    "motion_cam",
+    "combi_protect",
+)
+
+
+def _sensor_keys_for(device_type: str) -> list[str]:
+    """Status keys that get a binary sensor for this device family."""
+    keys = list(_DEVICE_TYPE_SENSORS.get(device_type, ["tamper"]))
+    if device_type.startswith(_ARMING_DELAY_FAMILY_PREFIXES):
+        keys.append("delay_when_leaving")
+    return keys
+
 
 # Devices whose single "alert" entity should OR-reduce several hub status
 # oneofs into one state, because Ajax hub firmwares disagree on which oneof
@@ -372,7 +406,7 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[BinarySensorEntity] = []
     for device_id, device in coordinator.devices.items():
-        sensor_keys = _DEVICE_TYPE_SENSORS.get(device.device_type, ["tamper"])
+        sensor_keys = _sensor_keys_for(device.device_type)
         # #231 data probe: CO presence on the FireProtect 2 line is decided by
         # the object_type variant, but the cloud reports several units under
         # generic/non-sensor-encoded types (`fire_protect_two`, `_base`,
@@ -503,6 +537,9 @@ class AjaxBinarySensor(CoordinatorEntity[AjaxCobrandedCoordinator], BinarySensor
         self._attr_unique_id = f"aegis_ajax_{device_id}_{status_key}"
         self._attr_device_class = self._type_info.device_class
         self._attr_translation_key = self._type_info.translation_key
+        if self._type_info.entity_category is not None:
+            self._attr_entity_category = self._type_info.entity_category
+        self._attr_entity_registry_enabled_default = self._type_info.enabled_default
         device = coordinator.devices.get(device_id)
         if device:
             self._attr_device_info = build_device_info(

--- a/custom_components/aegis_ajax/icons.json
+++ b/custom_components/aegis_ajax/icons.json
@@ -27,7 +27,8 @@
             "connectivity": { "default": "mdi:wifi", "state": { "on": "mdi:wifi", "off": "mdi:wifi-off" } },
             "problem": { "default": "mdi:alert-circle-outline", "state": { "on": "mdi:alert-circle", "off": "mdi:check-circle-outline" } },
             "glass_break": { "default": "mdi:window-closed-variant", "state": { "on": "mdi:window-shutter-alert", "off": "mdi:window-closed-variant" } },
-            "vibration": { "default": "mdi:vibrate-off", "state": { "on": "mdi:vibrate", "off": "mdi:vibrate-off" } }
+            "vibration": { "default": "mdi:vibrate-off", "state": { "on": "mdi:vibrate", "off": "mdi:vibrate-off" } },
+            "delay_when_leaving": { "default": "mdi:timer-outline", "state": { "on": "mdi:timer-outline", "off": "mdi:timer-off-outline" } }
         },
         "sensor": {
             "signal_strength": { "default": "mdi:signal" },

--- a/custom_components/aegis_ajax/strings.json
+++ b/custom_components/aegis_ajax/strings.json
@@ -412,6 +412,9 @@
             "external_contact_open": {
                 "name": "Contact"
             },
+            "delay_when_leaving": {
+              "name": "Delay when leaving"
+            },
             "siren_on_panic_button": {
                 "name": "Siren on panic button"
             },

--- a/custom_components/aegis_ajax/translations/ca.json
+++ b/custom_components/aegis_ajax/translations/ca.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Contacte"
             },
+            "delay_when_leaving": {
+              "name": "Retard en sortir"
+            },
             "siren_on_panic_button": {
                 "name": "Sirena amb botó de pànic"
             },

--- a/custom_components/aegis_ajax/translations/cs.json
+++ b/custom_components/aegis_ajax/translations/cs.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Kontakt"
             },
+            "delay_when_leaving": {
+              "name": "Zpoždění při odchodu"
+            },
             "siren_on_panic_button": {
                 "name": "Siréna při tísňovém tlačítku"
             },

--- a/custom_components/aegis_ajax/translations/de.json
+++ b/custom_components/aegis_ajax/translations/de.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Kontakt"
             },
+            "delay_when_leaving": {
+              "name": "Verzögerung beim Verlassen"
+            },
             "siren_on_panic_button": {
                 "name": "Sirene bei Panikknopf"
             },

--- a/custom_components/aegis_ajax/translations/en.json
+++ b/custom_components/aegis_ajax/translations/en.json
@@ -391,6 +391,9 @@
             "external_contact_open": {
                 "name": "Contact"
             },
+            "delay_when_leaving": {
+              "name": "Delay when leaving"
+            },
             "siren_on_panic_button": {
                 "name": "Siren on panic button"
             },

--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -391,6 +391,9 @@
             "external_contact_open": {
                 "name": "Contacto"
             },
+            "delay_when_leaving": {
+              "name": "Retardo al salir"
+            },
             "siren_on_panic_button": {
                 "name": "Sirena ante botón de pánico"
             },

--- a/custom_components/aegis_ajax/translations/fr.json
+++ b/custom_components/aegis_ajax/translations/fr.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Contact"
             },
+            "delay_when_leaving": {
+              "name": "Délai de sortie"
+            },
             "siren_on_panic_button": {
                 "name": "Sirène sur bouton panique"
             },

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Contatto"
             },
+            "delay_when_leaving": {
+              "name": "Ritardo all'uscita"
+            },
             "siren_on_panic_button": {
                 "name": "Sirena su pulsante antipanico"
             },

--- a/custom_components/aegis_ajax/translations/nl.json
+++ b/custom_components/aegis_ajax/translations/nl.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Contact"
             },
+            "delay_when_leaving": {
+              "name": "Vertraging bij vertrek"
+            },
             "siren_on_panic_button": {
                 "name": "Sirene bij paniekknop"
             },

--- a/custom_components/aegis_ajax/translations/pl.json
+++ b/custom_components/aegis_ajax/translations/pl.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Styk"
             },
+            "delay_when_leaving": {
+              "name": "Opóźnienie przy wyjściu"
+            },
             "siren_on_panic_button": {
                 "name": "Syrena przy przycisku napadowym"
             },

--- a/custom_components/aegis_ajax/translations/pt-BR.json
+++ b/custom_components/aegis_ajax/translations/pt-BR.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Contato"
             },
+            "delay_when_leaving": {
+              "name": "Atraso ao sair"
+            },
             "siren_on_panic_button": {
                 "name": "Sirene com botão de pânico"
             },

--- a/custom_components/aegis_ajax/translations/pt.json
+++ b/custom_components/aegis_ajax/translations/pt.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Contato"
             },
+            "delay_when_leaving": {
+              "name": "Atraso ao sair"
+            },
             "siren_on_panic_button": {
                 "name": "Sirene com botão de pânico"
             },

--- a/custom_components/aegis_ajax/translations/ro.json
+++ b/custom_components/aegis_ajax/translations/ro.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Contact"
             },
+            "delay_when_leaving": {
+              "name": "Întârziere la plecare"
+            },
             "siren_on_panic_button": {
                 "name": "Sirenă la buton de panică"
             },

--- a/custom_components/aegis_ajax/translations/tr.json
+++ b/custom_components/aegis_ajax/translations/tr.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Kontak"
             },
+            "delay_when_leaving": {
+              "name": "Çıkışta gecikme"
+            },
             "siren_on_panic_button": {
                 "name": "Panik düğmesinde siren"
             },

--- a/custom_components/aegis_ajax/translations/uk.json
+++ b/custom_components/aegis_ajax/translations/uk.json
@@ -375,6 +375,9 @@
             "external_contact_open": {
                 "name": "Контакт"
             },
+            "delay_when_leaving": {
+              "name": "Затримка при виході"
+            },
             "siren_on_panic_button": {
                 "name": "Сирена при тривожній кнопці"
             },

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -93,6 +93,45 @@ class TestBinarySensorTypes:
             == BinarySensorDeviceClass.OPENING
         )
 
+    def test_delay_when_leaving_is_a_disabled_diagnostic_flag(self) -> None:
+        # #443: a read-only mirror of the detector's "Delay when leaving"
+        # setting. No device class fits a configuration flag; diagnostic and
+        # off by default like the hub siren settings (#438).
+        from homeassistant.const import EntityCategory
+
+        info = BINARY_SENSOR_TYPES["delay_when_leaving"]
+        assert info.device_class is None
+        assert info.translation_key == "delay_when_leaving"
+        assert info.entity_category == EntityCategory.DIAGNOSTIC
+        assert info.enabled_default is False
+
+    def test_delay_when_leaving_goes_to_arming_capable_families_only(self) -> None:
+        # Families whose device model carries an arming part (door/motion/
+        # combi detectors and MotionCams); keypads, sirens, fire detectors,
+        # wire inputs and hubs have no leaving delay to mirror.
+        from custom_components.aegis_ajax.binary_sensor import _sensor_keys_for
+
+        for dtype in (
+            "door_protect",
+            "door_protect_plus",
+            "motion_protect",
+            "motion_protect_curtain_outdoor_plus",
+            "dual_curtain_outdoor",
+            "motion_cam_phod",
+            "combi_protect",
+        ):
+            assert "delay_when_leaving" in _sensor_keys_for(dtype), dtype
+        for dtype in (
+            "keypad_combi",
+            "street_siren",
+            "fire_protect_two",
+            "wire_input_mt",
+            "hub_two_4g",
+            "glass_protect",
+            "unknown_family",
+        ):
+            assert "delay_when_leaving" not in _sensor_keys_for(dtype), dtype
+
     def test_wire_input_mt_gets_the_contact_sensor(self) -> None:
         # Only the capture-validated family (#413); plain wire_input and
         # transmitter key the same concept on different sub-keys.
@@ -225,6 +264,24 @@ class TestAjaxBinarySensor:
         coordinator.devices = {"dev-1": device}
         sensor = AjaxBinarySensor(coordinator=coordinator, device_id="dev-1", status_key="tamper")
         assert sensor.is_on is True
+
+    def test_delay_when_leaving_reflects_the_status_flag(self) -> None:
+        # #443 — presence-only status: the key exists when the setting is on
+        # and is absent otherwise (statuses are rebuilt from every snapshot).
+        from homeassistant.const import EntityCategory
+
+        coordinator = MagicMock()
+        coordinator.devices = {"dev-1": self._make_device({"delay_when_leaving": True})}
+        sensor = AjaxBinarySensor(
+            coordinator=coordinator, device_id="dev-1", status_key="delay_when_leaving"
+        )
+        assert sensor.is_on is True
+        assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+        assert sensor.entity_registry_enabled_default is False
+        assert sensor.device_class is None
+
+        coordinator.devices = {"dev-1": self._make_device({})}
+        assert sensor.is_on is False
 
     def test_non_hub_device_has_via_device_on_old_ha(self) -> None:
         device = self._make_device({})

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1252,6 +1252,21 @@ class TestStatusParser:
         result = DevicesApi._parse_statuses([status])
         assert result.get("leak_detected") is True
 
+    def test_delay_when_leaving_status(self) -> None:
+        # #443: the per-detector "Delay when leaving" setting rides the light
+        # stream as a presence-only status. Pinned because the new binary
+        # sensor reads exactly this key.
+        status = MagicMock()
+        status.WhichOneof.return_value = "delay_when_leaving"
+        result = DevicesApi._parse_statuses([status])
+        assert result.get("delay_when_leaving") is True
+
+    def test_delay_when_leaving_absent_leaves_no_key(self) -> None:
+        status = MagicMock()
+        status.WhichOneof.return_value = "door_opened"
+        result = DevicesApi._parse_statuses([status])
+        assert "delay_when_leaving" not in result
+
     def test_tamper_status(self) -> None:
         # NOTE: the current proto has NO plain `tamper` oneof case — this
         # exercises the defensive forward-compat branch only, which is why it


### PR DESCRIPTION
## Summary

Follow-up to #443 (correction posted there today). The per-detector **"Delay when leaving"** setting reaches the integration in every device snapshot as the light-stream status `delay_when_leaving`; the parser already mapped it into `device.statuses`, but nothing exposed it.

- New **disabled-by-default diagnostic binary sensor** "Delay when leaving" on the families whose Ajax device model carries an arming part: door, motion and combi detectors and the MotionCam line (`_ARMING_DELAY_FAMILY_PREFIXES`, applied by `_sensor_keys_for()`). Keypads, sirens, fire detectors, wire inputs and hubs have no leaving delay to mirror.
- `BinarySensorTypeInfo` gains per-type `entity_category` and `enabled_default` (a configuration flag has no fitting device class; `device_class` is now optional).
- 14 locales, icon, README bullet, CHANGELOG `[Unreleased]`.

Why only the flag and not the countdown: the hub-side exit delay never surfaces as the panel's `arming` state — that value is the app's own timer (`DISPLAYED_SPACE_SECURITY_STATE_AWAITING_APP_EXIT_TIMER`), confirmed on a hub with the delay configured on two detectors and zero `arming` samples in a week. Whether the richer `TransitionInProgress` structure is populated for a hub-side delay is still open and needs a capture; #443 stays open for that.

**Ajax API delta: zero** — the status already flows with every snapshot.

## Test plan

- [x] `make check` green: 2345 tests, 90.8 % coverage, ruff, mypy, vulture.
- [x] Tests first; two mutations (dropping the family gate, not applying `enabled_default`) each fail exactly one test.
- [x] Verified against real data: bvis-home's diagnostics show the status on exactly the two detectors that have the delay set in the app (one MotionCam PhOD, the DoorProtect Plus) and on none of the other eight devices.
- [ ] Beta on bvis-home: enable the entity on those two detectors → `on`; on a plain DoorProtect → `off`.
