### PR TITLE
fix: prevent reauth MFA challenge races

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -436,6 +436,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._poll_interval = poll_interval
         self.entry_id = entry_id
         self._client = client
+        self._reauth_required = False
         self._on_session_persist = on_session_persist
         self._space_ids = space_ids
         self._spaces_api = SpacesApi(client)
@@ -783,11 +784,14 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         and raise `ConfigEntryAuthFailed` (surfaces the HA "Reconfigure"
         banner) when credentials are no longer accepted.
         """
+        if self._reauth_required:
+            raise ConfigEntryAuthFailed("Two-factor authentication required")
         if self._client.session.is_authenticated:
             return
         try:
             await self._login_and_persist()
         except TwoFactorRequiredError as err:
+            self._reauth_required = True
             self.update_interval = timedelta(minutes=30)
             _LOGGER.error(
                 "Ajax requires a 2FA code to log in again — triggering reauth so the "
@@ -841,6 +845,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # typing into the reconfigure form. `ConfigEntryAuthFailed`
                 # stops the polling and opens the reauth flow, which does
                 # know how to ask for the code.
+                self._reauth_required = True
                 raise ConfigEntryAuthFailed("Two-factor authentication required") from tfa_err
             except AuthenticationError as auth_err:
                 raise ConfigEntryAuthFailed(str(auth_err)) from auth_err

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -785,6 +785,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         banner) when credentials are no longer accepted.
         """
         if self._reauth_required:
+            self.update_interval = timedelta(minutes=30)
             raise ConfigEntryAuthFailed("Two-factor authentication required")
         if self._client.session.is_authenticated:
             return

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -754,6 +754,7 @@ class TestAsyncUpdateData:
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator._async_update_data()
         coordinator._client.login.assert_awaited_once()
+        assert coordinator.update_interval == timedelta(minutes=30)
 
     @pytest.mark.asyncio
     async def test_update_data_raises_auth_failed_when_token_rejected_and_relogin_needs_2fa(
@@ -788,6 +789,7 @@ class TestAsyncUpdateData:
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator._async_update_data()
         coordinator._client.login.assert_awaited_once()
+        assert coordinator.update_interval == timedelta(minutes=30)
 
     @pytest.mark.asyncio
     async def test_login_persists_session_via_callback(self) -> None:

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -751,6 +751,10 @@ class TestAsyncUpdateData:
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator._async_update_data()
 
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+        coordinator._client.login.assert_awaited_once()
+
     @pytest.mark.asyncio
     async def test_update_data_raises_auth_failed_when_token_rejected_and_relogin_needs_2fa(
         self,
@@ -780,6 +784,10 @@ class TestAsyncUpdateData:
 
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator._async_update_data()
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+        coordinator._client.login.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_login_persists_session_via_callback(self) -> None:


### PR DESCRIPTION
Fixes #448.

## Problem

After the active Home Assistant Ajax session is revoked externally, reauthentication can request MFA successfully but reject a valid TOTP until Home Assistant is restarted.

## Root cause and fix

The previous coordinator can make another automatic login attempt after triggering reauth. Ajax issues a new MFA challenge for that attempt, invalidating the config flow's request ID. The coordinator now latches into a reauth-required state as soon as automatic login needs MFA. Later updates immediately raise `ConfigEntryAuthFailed` and cannot request another challenge. The successful reauth reload creates a fresh coordinator, so normal operation resumes.

## Tests

Regression coverage exercises both the missing-session and externally rejected-token paths, verifies a second update still raises the reauth signal, and asserts it never performs a second login request.

Focused lint, format, and 416 coordinator/HTS/service tests pass. The broader invocation retains one unrelated baseline failure in `TestServiceRegistration.test_services_registered_on_setup`, whose bare `MagicMock` Home Assistant instance does not initialise the currently required device registry.