### PR TITLE
fix: retry incomplete FCM registrations

### DIFF
--- a/custom_components/aegis_ajax/config_flow.py
+++ b/custom_components/aegis_ajax/config_flow.py
@@ -594,6 +594,7 @@ class AjaxCobrandedOptionsFlow(OptionsFlow):
                     new_data.pop(k, None)
             else:
                 for k, v in fcm_input.items():
+                    v = v.strip()
                     if v:
                         new_data[k] = v
                     elif k == "fcm_api_key":

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -442,6 +442,7 @@ class AjaxNotificationListener:
                     await fcm_session.close()
 
         # Extract FCM token and register with Ajax servers
+        assert self._credentials is not None
         fcm_data = self._credentials.get("fcm", {})
         registration = fcm_data.get("registration", {}) if isinstance(fcm_data, dict) else {}
         fcm_token = registration.get("token") if isinstance(registration, dict) else None

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -346,7 +346,19 @@ class AjaxNotificationListener:
             messaging_sender_id=self._fcm_sender_id,
         )
 
-        if not self._credentials:
+        stored_registration = (
+            self._credentials.get("fcm", {}).get("registration")
+            if isinstance(self._credentials, dict)
+            and isinstance(self._credentials.get("fcm"), dict)
+            else None
+        )
+        stored_token = (
+            stored_registration.get("token") if isinstance(stored_registration, dict) else None
+        )
+        if not stored_token:
+            if self._credentials:
+                _LOGGER.info("Stored FCM registration has no token; registering again")
+                self._credentials = None
             # Short-circuit if this exact credential set was already rejected
             # by Google (#227). Without working credentials, `async_start` runs
             # the registration again on every restart / reload; for a

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -914,6 +914,35 @@ class TestOptionsFlow:
             assert k not in stored_options
 
     @pytest.mark.asyncio
+    async def test_options_flow_trims_fcm_values(self) -> None:
+        """Whitespace pasted with FCM credentials must not change their identity."""
+        flow, _ = self._make_flow(data={"email": "x@y"})
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+
+        await flow.async_step_init(
+            {
+                "poll_interval": 60,
+                "use_pin_code": False,
+                "fcm_project_id": " project ",
+                "fcm_app_id": " app ",
+                "fcm_api_key": " key ",
+                "fcm_sender_id": " sender ",
+            }
+        )
+
+        new_data = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert {
+            key: new_data[key]
+            for key in ("fcm_project_id", "fcm_app_id", "fcm_api_key", "fcm_sender_id")
+        } == {
+            "fcm_project_id": "project",
+            "fcm_app_id": "app",
+            "fcm_api_key": "key",
+            "fcm_sender_id": "sender",
+        }
+
+    @pytest.mark.asyncio
     async def test_options_flow_clearing_three_text_fcm_fields_removes_them(self) -> None:
         """Empty strings for the three text FCM fields remove them (#138).
 

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -969,6 +969,36 @@ class TestFcmRejectedCredsShortCircuit:
 
         listener._rejected_store.async_remove.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_reregisters_when_stored_credentials_lack_token(self) -> None:
+        """An incomplete stored registration cannot receive Ajax pushes."""
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            return_value={"fcm": {"registration": {"token": "replacement-token"}}}
+        )
+        listener = self._listener(hass)
+        listener._store.async_load = AsyncMock(
+            return_value={"fcm": {"registration": None, "installation": {"fid": "old"}}}
+        )
+        listener._store.async_save = AsyncMock()
+        listener._register_push_token = AsyncMock()
+        register_cls = MagicMock(return_value=MagicMock(register=MagicMock()))
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+            patch("firebase_messaging.FcmPushClient", MagicMock()),
+        ):
+            await listener.async_start()
+
+        register_cls.assert_called_once()
+        listener._store.async_save.assert_awaited_once()
+        listener._register_push_token.assert_awaited_once_with("replacement-token")
+
 
 class TestIsTerminalFcmFailure:
     def test_credential_rejection_strings_are_terminal(self) -> None:


### PR DESCRIPTION
Fixes #450.

## Problem

A persisted Firebase registration without `fcm.registration.token` was reused after every reload. Aegis could establish an MCS connection and receive heartbeat acknowledgements, but could not register a push token with Ajax and therefore could never receive Ajax notifications.

## Fix

- Treat cached Firebase credentials without a registration token as incomplete and invoke `FcmRegister.register()` again.
- Strip leading and trailing whitespace from all FCM fields submitted through the options flow.

## Tests

- Covers recovery from a cached tokenless registration, including cache replacement and Ajax token registration.
- Covers trimming all four FCM form values.
- Targeted lint, formatting, notification, and config-flow tests pass (224 tests).