### PR TITLE
test(init): give setup tests a device registry under HA 2026.8+ semantics (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A valid 2FA code is no longer rejected during re-authentication (#448).** When the Ajax session Home Assistant uses is revoked externally, the integration opens the re-authentication flow — but the old coordinator kept making its own login attempts in the background, and each one made Ajax issue a fresh two-factor challenge, invalidating the code the user was typing until Home Assistant was restarted. The coordinator now latches into the re-authentication state at the first challenge and makes no further login requests until the flow completes and reloads it. Found, diagnosed and fixed by @aavdberg. No additional requests to Ajax: it removes requests.
+- **A push registration saved without a token is repaired instead of reused (#450).** An interrupted Firebase registration could be persisted with no token; on every later start the integration treated that cache as valid, connected the push client and heartbeated happily while it had nothing to register with Ajax — the exact "connected but never delivers" shape #437 describes, from a different cause. Such a cache is now treated as absent and the registration is run again. The four push credential fields also have surrounding whitespace stripped when pasted into the options form. Found, diagnosed and fixed by @aavdberg. No additional requests to Ajax.
+
+### Changed
+- **Setup tests no longer depend on a lazily created device registry.** Home Assistant 2026.8 stopped creating the device registry on first access, so the hub pre-registration added for #444 made every setup test that drives the integration with a bare mock fail on a current core. Test scaffolding only; no runtime change.
+
 ## [1.18.0-beta.3] - 2026-09-04
 
 ### Added

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2,9 +2,28 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _device_registry_for_bare_hass() -> Iterator[None]:
+    """Give `async_setup_entry` a device registry to pre-register hubs into (#444).
+
+    These tests drive setup with a bare `MagicMock` hass whose `data` is an
+    empty dict. Since HA 2026.8 `device_registry.async_get` raises
+    `RuntimeError("Device registry not set up")` in that situation instead of
+    lazily creating one, so without this every setup test breaks on a current
+    core (aavdberg saw 12 failures on #447/#449). A test that needs a specific
+    registry patches `dr.async_get` itself; the inner patch wins.
+    """
+    with patch("custom_components.aegis_ajax.dr.async_get", return_value=MagicMock()):
+        yield
 
 
 class TestAsyncSetupEntry:

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -128,6 +128,7 @@ class TestServiceRegistration:
         mock_coordinator.async_start_push_notifications = AsyncMock()
 
         with (
+            patch("custom_components.aegis_ajax.dr.async_get", return_value=MagicMock()),
             patch(
                 "custom_components.aegis_ajax.AjaxGrpcClient",
                 return_value=mock_client,


### PR DESCRIPTION
## Summary

Follow-up to #444/#445, surfaced by @aavdberg's runs on a current core (12 `test_init.py` failures on #447 and #449).

`device_registry.async_get` used to create the registry lazily; since HA 2026.8 it raises `RuntimeError("Device registry not set up")` when a bare mock hass has none. The hub pre-registration added for #444 calls it from `async_setup_entry`, so 13 setup tests (12 in `test_init.py`, 1 in `test_services.py`) fail on a current core while staying green on the HA our images and CI can install (2025.1 / 2026.2).

- Autouse fixture in `test_init.py` and one explicit patch in `test_services.py` provide a registry; tests that need a specific one still patch it themselves (inner patch wins).
- CHANGELOG entries for the two fixes merged today from @aavdberg (#449 → #448, #451 → #450), written here per the usual policy.

Test scaffolding only; no runtime change. **Ajax API delta: zero.**

## Test plan

- [x] Reproduced first: a wrapper that monkeypatches `dr.async_get` to the 2026.9 strict semantics → **13 failed** on `main`.
- [x] Same wrapper on this branch → **2345 passed**; normal run → 2345 passed; ruff clean.
- [x] `make check` runs in the pre-push hook.