### PR TITLE
docs(dashboard): add the exit/entry delay card to the example dashboard (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+- **The example dashboard shows the exit / entry delays (#454).** A card under the alarm panel with the hub's own state, the space's exit delay and a live countdown to the end of a running delay, built from the attributes the `delay_panel_states` option adds. Standard cards only.
+
 ## [1.18.0-beta.5] - 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ data:
 
 An example Lovelace dashboard is included in [`docs/dashboard.yaml`](docs/dashboard.yaml) with sections for:
 
-- Alarm control panel + system status
+- Alarm control panel + system status, with the exit / entry delay card (hub state, exit delay, countdown to the end of a running delay — needs the option described in [Exit and entry delays](#exit-and-entry-delays))
 - Hub network (Ethernet, Wi-Fi, cellular, power)
 - Door & window sensors with batteries
 - Cameras & motion detectors with photo capture buttons

--- a/docs/dashboard.yaml
+++ b/docs/dashboard.yaml
@@ -31,6 +31,35 @@ sections:
           - arm_night
           - arm_home
 
+      # ─── Exit / entry delays (#454) ───
+      # Needs the "Show exit / entry delays as panel states" option
+      # (Configure). The alarm panel above then reads `arming` / `pending`
+      # by itself; this card adds what the state alone can't show: the hub's
+      # own state under the overlay, the space's exit delay, and a live
+      # countdown to the end of the running delay (empty when none runs).
+      - type: entities
+        title: Exit / entry delays
+        icon: mdi:timer-sand
+        show_header_toggle: false
+        entities:
+          - type: attribute
+            entity: alarm_control_panel.my_hub
+            attribute: hub_state
+            name: Hub state
+            icon: mdi:shield-home-outline
+          - type: attribute
+            entity: alarm_control_panel.my_hub
+            attribute: exit_delay_seconds
+            name: Exit delay
+            suffix: s
+            icon: mdi:exit-run
+          - type: attribute
+            entity: alarm_control_panel.my_hub
+            attribute: delay_ends_at
+            name: Running delay ends
+            format: relative
+            icon: mdi:timer-outline
+
       # ─── System Health at a Glance ───
       - type: entities
         title: System Status


### PR DESCRIPTION
## Summary

Relates to #454. The example dashboard gets a standard `entities` card under the alarm panel showing the attributes the `delay_panel_states` option adds: the hub's own state beneath the overlay, the space's exit delay, and a live countdown (`format: relative`) to the end of a running delay. README bullet and CHANGELOG `### Documentation` entry. Docs only, no runtime change.

## Test plan

- [x] `docs/dashboard.yaml` parses (yaml.safe_load) and the new card sits right after the alarm panel
- [x] Same card added to my live dashboard over WebSocket, saved and re-read fine
- [x] No code touched; CI is the pre-push hook + the usual workflows

## Notes for the reviewer

Live rendering of the `relative` row on a `null` attribute shows an empty value until a delay runs; that is intended.