### PR TITLE
fix: invalidate cached FCM registration on credential changes

### DIFF
--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -312,4 +312,5 @@ def _push_diagnostics(listener: Any) -> dict[str, Any]:  # noqa: ANN401
         "ever_delivered": listener.ever_delivered,
         "first_delivery_at": listener.first_delivery_at,
         "creds_fingerprint": listener.creds_fingerprint,
+        "cache_creds_fingerprint": listener.cache_creds_fingerprint,
     }

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -240,6 +240,15 @@ class AjaxNotificationListener:
         return self._creds_fingerprint
 
     @property
+    def cache_creds_fingerprint(self) -> str | None:
+        """Short digest of the cached credential set, or None if not cached."""
+        if isinstance(self._credentials, dict) and isinstance(
+            self._credentials.get("creds_hash"), str
+        ):
+            return self._credentials["creds_hash"][:16]
+        return None
+
+    @property
     def ever_delivered(self) -> bool:
         """True if this credential set has ever delivered a push (#437)."""
         return self._ever_delivered
@@ -346,6 +355,13 @@ class AjaxNotificationListener:
             messaging_sender_id=self._fcm_sender_id,
         )
 
+        creds_hash = _fcm_creds_hash(
+            fcm_project_id=self._fcm_project_id,
+            fcm_app_id=self._fcm_app_id,
+            fcm_api_key=self._fcm_api_key,
+            fcm_sender_id=self._fcm_sender_id,
+        )
+
         stored_registration = (
             self._credentials.get("fcm", {}).get("registration")
             if isinstance(self._credentials, dict)
@@ -355,9 +371,25 @@ class AjaxNotificationListener:
         stored_token = (
             stored_registration.get("token") if isinstance(stored_registration, dict) else None
         )
-        if not stored_token:
+        stored_creds_hash = (
+            self._credentials.get("creds_hash") if isinstance(self._credentials, dict) else None
+        )
+
+        valid_cache = (
+            bool(stored_token)
+            and isinstance(stored_creds_hash, str)
+            and stored_creds_hash == creds_hash
+        )
+
+        if not valid_cache:
             if self._credentials:
-                _LOGGER.info("Stored FCM registration has no token; registering again")
+                if not stored_token:
+                    _LOGGER.info("Stored FCM registration has no token; registering again")
+                else:
+                    _LOGGER.info(
+                        "cached push registration belongs to a different credential set; "
+                        "registering again"
+                    )
                 self._credentials = None
             # Short-circuit if this exact credential set was already rejected
             # by Google (#227). Without working credentials, `async_start` runs
@@ -366,12 +398,6 @@ class AjaxNotificationListener:
             # failed requests against the Firebase project. We remember the
             # rejected set by hash (never the secret) and skip the network
             # attempt until the user changes the values.
-            creds_hash = _fcm_creds_hash(
-                fcm_project_id=self._fcm_project_id,
-                fcm_app_id=self._fcm_app_id,
-                fcm_api_key=self._fcm_api_key,
-                fcm_sender_id=self._fcm_sender_id,
-            )
             rejected = await self._rejected_store.async_load()
             if rejected and rejected.get("hash") == creds_hash:
                 _LOGGER.warning(
@@ -421,6 +447,7 @@ class AjaxNotificationListener:
                 else:
                     raw_result = await self._hass.async_add_executor_job(registerer.register)
                 self._credentials = dict(raw_result)
+                self._credentials["creds_hash"] = creds_hash
                 await self._store.async_save(self._credentials)
                 if rejected:
                     # These values worked — drop any stale rejection marker.

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -242,10 +242,10 @@ class AjaxNotificationListener:
     @property
     def cache_creds_fingerprint(self) -> str | None:
         """Short digest of the cached credential set, or None if not cached."""
-        if isinstance(self._credentials, dict) and isinstance(
-            self._credentials.get("creds_hash"), str
-        ):
-            return self._credentials["creds_hash"][:16]
+        if isinstance(self._credentials, dict):
+            creds_hash = self._credentials.get("creds_hash")
+            if isinstance(creds_hash, str):
+                return creds_hash[:16]
         return None
 
     @property

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -104,6 +104,7 @@ class TestAsyncGetConfigEntryDiagnostics:
         listener.ever_delivered = False
         listener.first_delivery_at = None
         listener.creds_fingerprint = "abc123def456"
+        listener.cache_creds_fingerprint = "abc123def456"
         listener._fcm_client_started_at = None
 
         push = (await async_get_config_entry_diagnostics(MagicMock(), entry))["push"]
@@ -114,6 +115,7 @@ class TestAsyncGetConfigEntryDiagnostics:
         assert push["pushes_received_since_start"] == 0
         assert push["last_push_seconds_ago"] is None
         assert push["creds_fingerprint"] == "abc123def456"
+        assert push["cache_creds_fingerprint"] == "abc123def456"
 
     @pytest.mark.asyncio
     async def test_push_reports_not_configured_without_a_listener(

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -13,6 +13,7 @@ import pytest
 from custom_components.aegis_ajax.notification import (
     AjaxNotificationListener,
     _classify_fcm_failure,
+    _fcm_creds_hash,
     _validate_fcm_shape,
     async_probe_fcm_refusal_reason,
 )
@@ -575,8 +576,17 @@ class TestFcmPushClientSupervision:
         """
         hass = MagicMock()
         listener = AjaxNotificationListener(hass=hass, coordinator=MagicMock(), **_FCM_KWARGS)
+        expected_hash = _fcm_creds_hash(
+            fcm_project_id=_FCM_KWARGS["fcm_project_id"],
+            fcm_app_id=_FCM_KWARGS["fcm_app_id"],
+            fcm_api_key=_FCM_KWARGS["fcm_api_key"],
+            fcm_sender_id=_FCM_KWARGS["fcm_sender_id"],
+        )
         listener._store.async_load = AsyncMock(
-            return_value={"fcm": {"registration": {"token": "tok"}}}
+            return_value={
+                "fcm": {"registration": {"token": "tok"}},
+                "creds_hash": expected_hash,
+            }
         )
         listener._register_push_token = AsyncMock()
         listener._async_start_push_client = AsyncMock(return_value=False)

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1000,6 +1000,166 @@ class TestFcmRejectedCredsShortCircuit:
         listener._register_push_token.assert_awaited_once_with("replacement-token")
 
 
+class TestFcmCacheFingerprinting:
+    """Issue #452 — invalidate cached FCM registration on credential changes."""
+
+    @staticmethod
+    def _listener(hass: MagicMock) -> AjaxNotificationListener:
+        listener = AjaxNotificationListener(
+            hass=hass, coordinator=MagicMock(), **_FCM_KWARGS, entry_id="entry-x"
+        )
+        listener._rejected_store.async_load = AsyncMock(return_value=None)
+        listener._rejected_store.async_save = AsyncMock()
+        listener._rejected_store.async_remove = AsyncMock()
+        return listener
+
+    @staticmethod
+    def _expected_hash() -> str:
+        from custom_components.aegis_ajax.notification import _fcm_creds_hash
+
+        return _fcm_creds_hash(
+            fcm_project_id=_FCM_KWARGS["fcm_project_id"],
+            fcm_app_id=_FCM_KWARGS["fcm_app_id"],
+            fcm_api_key=_FCM_KWARGS["fcm_api_key"],
+            fcm_sender_id=_FCM_KWARGS["fcm_sender_id"],
+        )
+
+    @staticmethod
+    def _repair_patches() -> tuple:
+        return (
+            patch(
+                "custom_components.aegis_ajax.notification.async_register_fcm_credentials_invalid"
+            ),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_credentials_invalid"),
+            patch("custom_components.aegis_ajax.notification.async_register_fcm_not_configured"),
+            patch("custom_components.aegis_ajax.notification.async_clear_fcm_not_configured"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_valid_cache_with_matching_creds_hash_skips_reregistration(self) -> None:
+        hass = MagicMock()
+        listener = self._listener(hass)
+        expected_hash = self._expected_hash()
+        listener._store.async_load = AsyncMock(
+            return_value={
+                "fcm": {"registration": {"token": "cached-token"}},
+                "creds_hash": expected_hash,
+            }
+        )
+        listener._store.async_save = AsyncMock()
+        listener._register_push_token = AsyncMock()
+        register_cls = MagicMock()
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+            patch("firebase_messaging.FcmPushClient", MagicMock()),
+        ):
+            await listener.async_start()
+
+        register_cls.assert_not_called()
+        listener._register_push_token.assert_awaited_once_with("cached-token")
+        assert listener.cache_creds_fingerprint == expected_hash[:16]
+
+    @pytest.mark.asyncio
+    async def test_reregisters_when_stored_creds_hash_is_missing(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            return_value={"fcm": {"registration": {"token": "new-token"}}}
+        )
+        listener = self._listener(hass)
+        expected_hash = self._expected_hash()
+        listener._store.async_load = AsyncMock(
+            return_value={"fcm": {"registration": {"token": "old-token"}}}
+        )
+        listener._store.async_save = AsyncMock()
+        listener._register_push_token = AsyncMock()
+        register_cls = MagicMock(return_value=MagicMock(register=MagicMock()))
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+            patch("firebase_messaging.FcmPushClient", MagicMock()),
+        ):
+            await listener.async_start()
+
+        register_cls.assert_called_once()
+        listener._store.async_save.assert_awaited_once_with(
+            {"fcm": {"registration": {"token": "new-token"}}, "creds_hash": expected_hash}
+        )
+        listener._register_push_token.assert_awaited_once_with("new-token")
+
+    @pytest.mark.asyncio
+    async def test_reregisters_when_stored_creds_hash_mismatches(self) -> None:
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            return_value={"fcm": {"registration": {"token": "new-token"}}}
+        )
+        listener = self._listener(hass)
+        expected_hash = self._expected_hash()
+        listener._store.async_load = AsyncMock(
+            return_value={
+                "fcm": {"registration": {"token": "old-token"}},
+                "creds_hash": "different-hash-from-previous-creds",
+            }
+        )
+        listener._store.async_save = AsyncMock()
+        listener._register_push_token = AsyncMock()
+        register_cls = MagicMock(return_value=MagicMock(register=MagicMock()))
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+            patch("firebase_messaging.FcmPushClient", MagicMock()),
+        ):
+            await listener.async_start()
+
+        register_cls.assert_called_once()
+        listener._store.async_save.assert_awaited_once_with(
+            {"fcm": {"registration": {"token": "new-token"}}, "creds_hash": expected_hash}
+        )
+        listener._register_push_token.assert_awaited_once_with("new-token")
+
+    @pytest.mark.asyncio
+    async def test_rejected_store_check_runs_before_cache_reregistration(self) -> None:
+        hass = MagicMock()
+        listener = self._listener(hass)
+        expected_hash = self._expected_hash()
+        listener._store.async_load = AsyncMock(
+            return_value={
+                "fcm": {"registration": {"token": "stale-token"}},
+                "creds_hash": "old-hash",
+            }
+        )
+        listener._rejected_store.async_load = AsyncMock(return_value={"hash": expected_hash})
+        register_cls = MagicMock()
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv as reg,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+        ):
+            await listener.async_start()
+
+        register_cls.assert_not_called()
+        reg.assert_called_once_with(hass, entry_id="entry-x")
+
+
 class TestIsTerminalFcmFailure:
     def test_credential_rejection_strings_are_terminal(self) -> None:
         from custom_components.aegis_ajax.notification import _is_terminal_fcm_failure


### PR DESCRIPTION
## Summary

Invalidates cached Firebase registration credentials when the user changes any of the four FCM configuration options (`fcm_project_id`, `fcm_app_id`, `fcm_api_key`, `fcm_sender_id`).

Relates to #452

- Stores the SHA-256 fingerprint (`creds_hash`) of the four FCM configuration values alongside the Firebase registration in `.storage/aegis_ajax_fcm_credentials`.
- Validates that a cached registration has a token, a stored `creds_hash`, and that `creds_hash` matches the current FCM options. If missing or mismatched, logs `"cached push registration belongs to a different credential set; registering again"` and re-executes registration.
- Preserves the Google rejection check (#227) before attempting re-registration so previously rejected credentials stay throttled.
- Adds `cache_creds_fingerprint` (16-char digest) to `_push_diagnostics` for diagnostics dumps.

## Test plan

- [x] New behaviour covered by unit tests in `tests/unit/test_notification.py` and `tests/unit/test_diagnostics.py`
- [x] Ruff linting and formatting pass cleanly (`ruff check .` and `ruff format .`)
- [x] Tested valid cache reuse, missing token recovery, missing creds_hash recovery, mismatched creds_hash recovery, and rejection short-circuit order.
