### PR TITLE
Fix uncertain Ajax session termination outcomes

### DIFF
--- a/custom_components/aegis_ajax/api/hts/client.py
+++ b/custom_components/aegis_ajax/api/hts/client.py
@@ -246,6 +246,17 @@ class HtsConnectionError(Exception):
     """Raised when the TCP/TLS connection fails."""
 
 
+class HtsTerminationOutcomeUnknownError(HtsConnectionError):
+    """A sent session-termination request lost its confirmation."""
+
+    def __init__(self, session_id: int, succeeded_session_ids: list[int] | None = None) -> None:
+        super().__init__(
+            f"Termination request for session {session_id} was sent, but its result is unknown"
+        )
+        self.session_id = session_id
+        self.succeeded_session_ids = succeeded_session_ids or []
+
+
 class HtsAuthError(Exception):
     """Raised when the authentication handshake fails."""
 
@@ -699,7 +710,10 @@ class HtsClient:
                     request_key=_USER_REGISTRATION_KEY_KILL_SESSIONS,
                     response_key=_USER_REGISTRATION_KEY_CLIENT_SESSIONS,
                     params=[session_id.to_bytes(8, "big", signed=True)],
+                    termination_session_id=session_id,
                 )
+            except HtsTerminationOutcomeUnknownError as exc:
+                raise HtsTerminationOutcomeUnknownError(session_id, succeeded) from exc
             except Exception as exc:
                 if succeeded:
                     _LOGGER.info(
@@ -788,6 +802,7 @@ class HtsClient:
         request_key: int,
         response_key: int,
         params: list[bytes] | None = None,
+        termination_session_id: int | None = None,
     ) -> list[bytes]:
         """Send a USER_REGISTRATION request and await its listener-delivered reply."""
         if not self._connected:
@@ -795,19 +810,27 @@ class HtsClient:
         async with self._user_registration_request_lock:
             future: asyncio.Future[list[bytes]] = asyncio.get_running_loop().create_future()
             self._pending_user_registration_response = (response_key, future)
+            request_sent = False
             try:
                 await self._send_message(
                     MsgType.USER_REGISTRATION,
                     tlv_encode([bytes([request_key]), *(params or [])]),
                 )
+                request_sent = True
                 return await asyncio.wait_for(
                     asyncio.shield(future), timeout=SESSION_REQUEST_TIMEOUT
                 )
             except TimeoutError as exc:
+                if request_sent and termination_session_id is not None:
+                    raise HtsTerminationOutcomeUnknownError(termination_session_id) from exc
                 raise HtsConnectionError(
                     f"Timed out waiting for USER_REGISTRATION key 0x{response_key:02X} "
                     "(the Ajax server may be rate limiting requests)"
                 ) from exc
+            except HtsConnectionError as exc:
+                if request_sent and termination_session_id is not None:
+                    raise HtsTerminationOutcomeUnknownError(termination_session_id) from exc
+                raise
             finally:
                 if self._pending_user_registration_response == (response_key, future):
                     self._pending_user_registration_response = None

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -20,7 +20,11 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.aegis_ajax.api import devices_parser
 from custom_components.aegis_ajax.api.devices import DevicesApi
-from custom_components.aegis_ajax.api.hts.client import HtsClient
+from custom_components.aegis_ajax.api.hts.client import (
+    HtsClient,
+    HtsConnectionError,
+    HtsTerminationOutcomeUnknownError,
+)
 from custom_components.aegis_ajax.api.hts.hub_events import (
     HUB_EVENT_ENTRY_DELAY_STARTED,
     HUB_EVENT_EXIT_DELAY_COMPLETE,
@@ -717,7 +721,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise ValueError("The selected Ajax session is no longer active.")
         if target.is_current or target.is_self_identity:
             raise ValueError("Refusing to terminate Aegis integration sessions.")
-        await hts_client.kill_client_sessions([session_id])
+        try:
+            await hts_client.kill_client_sessions([session_id])
+        except HtsTerminationOutcomeUnknownError:
+            if not await self._async_verify_termination_after_uncertain_outcome(session_id):
+                raise HtsConnectionError(
+                    "Ajax confirmed the session remains active after the termination request."
+                ) from None
         _LOGGER.info("Terminated one other Ajax account session")
 
     async def async_terminate_other_client_sessions(self) -> int:
@@ -738,10 +748,39 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             and session.session_id is not None
         ]
         if session_ids:
-            terminated = await hts_client.kill_client_sessions(session_ids)
+            try:
+                terminated = await hts_client.kill_client_sessions(session_ids)
+            except HtsTerminationOutcomeUnknownError as exc:
+                if not await self._async_verify_termination_after_uncertain_outcome(exc.session_id):
+                    raise HtsConnectionError(
+                        f"Terminated {len(exc.succeeded_session_ids)} of "
+                        f"{len(session_ids)} session(s); the uncertain session remains active."
+                    ) from None
+                terminated = [*exc.succeeded_session_ids, exc.session_id]
             _LOGGER.info("Terminated %d other Ajax account session(s)", len(terminated))
             return len(terminated)
         return 0
+
+    async def _async_verify_termination_after_uncertain_outcome(self, session_id: int) -> bool:
+        """Confirm a sent termination after HTS recovers; never resend it."""
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            await self._maybe_restart_hts()
+            hts_client = self._hts_client
+            if hts_client is not None and hts_client.is_connected:
+                try:
+                    sessions = await hts_client.get_client_sessions()
+                except HtsConnectionError as exc:
+                    raise HtsConnectionError(
+                        "Termination outcome is unknown because its read-only verification failed; "
+                        "do not retry automatically."
+                    ) from exc
+                return all(session.session_id != session_id for session in sessions)
+            await asyncio.sleep(0.1)
+        raise HtsConnectionError(
+            "Termination outcome is unknown because HTS did not reconnect for verification; "
+            "do not retry automatically."
+        )
 
     def _require_hts_client(self) -> HtsClient:
         """Return the active HTS client or explain why session management cannot run."""

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -763,9 +763,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_verify_termination_after_uncertain_outcome(self, session_id: int) -> bool:
         """Confirm a sent termination after HTS recovers; never resend it."""
+        await self._maybe_restart_hts()
         deadline = time.monotonic() + 30
         while time.monotonic() < deadline:
-            await self._maybe_restart_hts()
             hts_client = self._hts_client
             if hts_client is not None and hts_client.is_connected:
                 try:
@@ -775,6 +775,11 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         "Termination outcome is unknown because its read-only verification failed; "
                         "do not retry automatically."
                     ) from exc
+                if not sessions:
+                    raise HtsConnectionError(
+                        "Termination outcome is unknown because its read-only verification "
+                        "returned no sessions; do not retry automatically."
+                    )
                 return all(session.session_id != session_id for session in sessions)
             await asyncio.sleep(0.1)
         raise HtsConnectionError(

--- a/tests/unit/hts/test_client.py
+++ b/tests/unit/hts/test_client.py
@@ -17,6 +17,7 @@ from custom_components.aegis_ajax.api.hts.client import (
     HtsAuthError,
     HtsClient,
     HtsConnectionError,
+    HtsTerminationOutcomeUnknownError,
 )
 from custom_components.aegis_ajax.api.hts.hub_state import HubNetworkState
 from custom_components.aegis_ajax.api.hts.messages import (
@@ -134,7 +135,10 @@ class TestClientSessions:
         targets = [1_000, 2_000]
 
         async def mock_request_user_registration(
-            request_key: int, response_key: int, params: list[bytes] | None = None
+            request_key: int,
+            response_key: int,
+            params: list[bytes] | None = None,
+            termination_session_id: int | None = None,
         ) -> list[bytes]:
             assert params is not None
             req_id = int.from_bytes(params[0], "big", signed=True)
@@ -149,6 +153,51 @@ class TestClientSessions:
 
         assert "Terminated 1 of 2 session(s)" in str(exc_info.value)
         assert client._request_user_registration.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_kill_client_sessions_timeout_after_send_is_uncertain(self) -> None:
+        client = _make_client()
+        client._connected = True
+        client._send_message = AsyncMock()  # type: ignore[method-assign]
+
+        with (
+            patch("custom_components.aegis_ajax.api.hts.client.SESSION_REQUEST_TIMEOUT", 0),
+            pytest.raises(HtsTerminationOutcomeUnknownError) as exc_info,
+        ):
+            await client.kill_client_sessions([1_000])
+
+        assert exc_info.value.session_id == 1_000
+        assert exc_info.value.succeeded_session_ids == []
+        client._send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_kill_client_sessions_connection_close_after_send_is_uncertain(self) -> None:
+        client = _make_client()
+        client._connected = True
+        client._send_message = AsyncMock()  # type: ignore[method-assign]
+
+        task = asyncio.create_task(client.kill_client_sessions([1_000]))
+        await asyncio.sleep(0)
+        assert client._pending_user_registration_response is not None
+        client._pending_user_registration_response[1].set_exception(
+            HtsConnectionError("HTS connection closed")
+        )
+
+        with pytest.raises(HtsTerminationOutcomeUnknownError) as exc_info:
+            await task
+
+        assert exc_info.value.session_id == 1_000
+
+    @pytest.mark.asyncio
+    async def test_kill_client_sessions_send_failure_is_not_uncertain(self) -> None:
+        client = _make_client()
+        client._connected = True
+        client._send_message = AsyncMock(side_effect=HtsConnectionError("write failed"))  # type: ignore[method-assign]
+
+        with pytest.raises(HtsConnectionError) as exc_info:
+            await client.kill_client_sessions([1_000])
+
+        assert not isinstance(exc_info.value, HtsTerminationOutcomeUnknownError)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -178,6 +178,94 @@ class TestClientSessionServices:
         coordinator._hts_client.kill_client_sessions.assert_awaited_once_with([2, 3])
 
     @pytest.mark.asyncio
+    async def test_uncertain_single_termination_succeeds_when_verified_absent(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import HtsTerminationOutcomeUnknownError
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = object.__new__(AjaxCobrandedCoordinator)
+        coordinator._hts_client = MagicMock(is_connected=True)
+        coordinator._hts_client.get_client_sessions = AsyncMock(return_value=[self._session(2)])
+        coordinator._hts_client.kill_client_sessions = AsyncMock(
+            side_effect=HtsTerminationOutcomeUnknownError(2)
+        )
+        coordinator._async_verify_termination_after_uncertain_outcome = AsyncMock(return_value=True)
+
+        await coordinator.async_terminate_client_session(2)
+
+        coordinator._hts_client.kill_client_sessions.assert_awaited_once_with([2])
+        coordinator._async_verify_termination_after_uncertain_outcome.assert_awaited_once_with(2)
+
+    @pytest.mark.asyncio
+    async def test_uncertain_bulk_termination_counts_verified_final_session(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import HtsTerminationOutcomeUnknownError
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = object.__new__(AjaxCobrandedCoordinator)
+        coordinator._hts_client = MagicMock(is_connected=True)
+        coordinator._hts_client.get_client_sessions = AsyncMock(
+            return_value=[self._session(1, is_current=True), self._session(2), self._session(3)]
+        )
+        coordinator._hts_client.kill_client_sessions = AsyncMock(
+            side_effect=HtsTerminationOutcomeUnknownError(3, [2])
+        )
+        coordinator._async_verify_termination_after_uncertain_outcome = AsyncMock(return_value=True)
+
+        assert await coordinator.async_terminate_other_client_sessions() == 2
+        coordinator._hts_client.kill_client_sessions.assert_awaited_once_with([2, 3])
+        coordinator._async_verify_termination_after_uncertain_outcome.assert_awaited_once_with(3)
+
+    @pytest.mark.asyncio
+    async def test_uncertain_termination_remaining_session_reports_confirmed_failure(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import (
+            HtsConnectionError,
+            HtsTerminationOutcomeUnknownError,
+        )
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = object.__new__(AjaxCobrandedCoordinator)
+        coordinator._hts_client = MagicMock(is_connected=True)
+        coordinator._hts_client.get_client_sessions = AsyncMock(return_value=[self._session(2)])
+        coordinator._hts_client.kill_client_sessions = AsyncMock(
+            side_effect=HtsTerminationOutcomeUnknownError(2)
+        )
+        coordinator._async_verify_termination_after_uncertain_outcome = AsyncMock(
+            return_value=False
+        )
+
+        with pytest.raises(HtsConnectionError, match="remains active"):
+            await coordinator.async_terminate_client_session(2)
+        coordinator._hts_client.kill_client_sessions.assert_awaited_once_with([2])
+
+    @pytest.mark.asyncio
+    async def test_uncertain_outcome_verification_lists_once_after_reconnect(self) -> None:
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = object.__new__(AjaxCobrandedCoordinator)
+        coordinator._hts_client = MagicMock(is_connected=True)
+        coordinator._hts_client.get_client_sessions = AsyncMock(return_value=[self._session(1)])
+        coordinator._maybe_restart_hts = AsyncMock()
+
+        assert await coordinator._async_verify_termination_after_uncertain_outcome(2) is True
+        coordinator._maybe_restart_hts.assert_awaited_once()
+        coordinator._hts_client.get_client_sessions.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_uncertain_outcome_verification_failure_is_explicit(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import HtsConnectionError
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = object.__new__(AjaxCobrandedCoordinator)
+        coordinator._hts_client = MagicMock(is_connected=True)
+        coordinator._hts_client.get_client_sessions = AsyncMock(
+            side_effect=HtsConnectionError("verification closed")
+        )
+        coordinator._maybe_restart_hts = AsyncMock()
+
+        with pytest.raises(HtsConnectionError, match="outcome is unknown"):
+            await coordinator._async_verify_termination_after_uncertain_outcome(2)
+        coordinator._hts_client.get_client_sessions.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_termination_requires_confirmation(self) -> None:
         from homeassistant.exceptions import ServiceValidationError
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -241,9 +241,13 @@ class TestClientSessionServices:
         from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
 
         coordinator = object.__new__(AjaxCobrandedCoordinator)
-        coordinator._hts_client = MagicMock(is_connected=True)
+        coordinator._hts_client = MagicMock(is_connected=False)
         coordinator._hts_client.get_client_sessions = AsyncMock(return_value=[self._session(1)])
-        coordinator._maybe_restart_hts = AsyncMock()
+
+        async def reconnect() -> None:
+            coordinator._hts_client.is_connected = True
+
+        coordinator._maybe_restart_hts = AsyncMock(side_effect=reconnect)
 
         assert await coordinator._async_verify_termination_after_uncertain_outcome(2) is True
         coordinator._maybe_restart_hts.assert_awaited_once()

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -270,6 +270,41 @@ class TestClientSessionServices:
         coordinator._hts_client.get_client_sessions.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_uncertain_outcome_verification_attempts_one_reconnect(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import HtsConnectionError
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = object.__new__(AjaxCobrandedCoordinator)
+        coordinator._hts_client = None
+        coordinator._maybe_restart_hts = AsyncMock()
+
+        monotonic = iter([0.0, 30.0])
+        with (
+            patch(
+                "custom_components.aegis_ajax.coordinator.time.monotonic",
+                side_effect=monotonic,
+            ),
+            pytest.raises(HtsConnectionError, match="did not reconnect"),
+        ):
+            await coordinator._async_verify_termination_after_uncertain_outcome(2)
+
+        coordinator._maybe_restart_hts.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_uncertain_outcome_empty_verification_is_unknown(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import HtsConnectionError
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = object.__new__(AjaxCobrandedCoordinator)
+        coordinator._hts_client = MagicMock(is_connected=True)
+        coordinator._hts_client.get_client_sessions = AsyncMock(return_value=[])
+        coordinator._maybe_restart_hts = AsyncMock()
+
+        with pytest.raises(HtsConnectionError, match="outcome is unknown"):
+            await coordinator._async_verify_termination_after_uncertain_outcome(2)
+        coordinator._hts_client.get_client_sessions.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_termination_requires_confirmation(self) -> None:
         from homeassistant.exceptions import ServiceValidationError
 


### PR DESCRIPTION
## Summary

Models a `KILL_SESSIONS` (`0x42`) request whose write completed but whose `0x41` confirmation was lost as an uncertain outcome, rather than a confirmed failure. The coordinator waits for its managed HTS connection to recover, performs exactly one read-only `0x40` session-list verification, and reports success only when the target is absent. A target still present is reported as a confirmed non-termination; unavailable verification reports an explicit outcome-unknown error and tells the user not to retry automatically.

Bulk termination preserves already confirmed IDs and counts an in-flight target only when that one verification proves it disappeared. It never retransmits `0x42`.

Relates to #330.

## Test plan

- [ ] `make check` passes locally on a freshly built Docker image
- [x] New behaviour covered by unit tests in `tests/unit/`
- [x] Coverage stays at or above the 80% threshold
- [ ] User-facing strings updated in `strings.json` and the 14 translation files
- [ ] `README.md` / `CHANGELOG.md` updated when the change is user-visible

Focused tests cover a pre-send failure, post-send timeout, post-send connection close, confirmed absence/presence, verification failure, and the bulk partial-count path.

## Notes for the reviewer

The focused suite passes (128 tests), along with Ruff lint and format checks for the changed files. The full unit run completed 2,430 tests but has seven pre-existing failures in `tests/unit/test_notification.py` FCM-log assertions, unrelated to this branch. The active Home Assistant test container was updated and restarted, but no live destructive action was run because the prior disposable Desktop session had already been removed and confirmation was unavailable to choose from the remaining sessions.