### PR TITLE
Refactor SmartLock capability dispatch

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -75,6 +75,7 @@ from custom_components.aegis_ajax.delay_states import (
     parse_arm_delays,
 )
 from custom_components.aegis_ajax.device_cache import DevicesCache
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_get_registered_device
 from custom_components.aegis_ajax.repairs import (
     async_clear_hts_chronic_failure,
@@ -392,11 +393,6 @@ def _without_hts_case_tamper(statuses: dict[str, Any]) -> dict[str, Any]:
         remaining.pop("tamper", None)
     return remaining
 
-
-# Mirror of `lock.LOCK_DEVICE_TYPES` (kept local to avoid a circular import
-# with the lock platform, which imports the coordinator). Used only by the
-# one-shot #206 Bug-B SmartLock id probe.
-_LOCK_DEVICE_TYPES: frozenset[str] = frozenset({"smart_lock", "smart_lock_yale"})
 
 # HTS `type=0x08` Chime-event state byte → ChimeStatus (#239). The hub stamps
 # the new chime state into params[3] of the event frame the instant the chime
@@ -1462,7 +1458,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._smart_lock_probe_done = True
         lock_ids_by_space: dict[str, list[str]] = {}
         for device in self.devices.values():
-            if device.device_type not in _LOCK_DEVICE_TYPES:
+            if not capabilities_for(device).is_lock:
                 continue
             space_id = next((s.id for s in self.spaces.values() if s.hub_id == device.hub_id), None)
             if space_id:

--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -14,6 +14,7 @@ class DeviceCapabilities:
     """Capabilities provided by a device family."""
 
     binary_sensor_keys: tuple[str, ...] = ()
+    is_lock: bool = False
 
 
 class DeviceHandler(Protocol):
@@ -29,9 +30,17 @@ class DeviceHandler(Protocol):
 class StaticDeviceHandler:
     """Handler returning static capabilities for a set of device types."""
 
-    def __init__(self, device_types: tuple[str, ...], binary_sensor_keys: tuple[str, ...]) -> None:
+    def __init__(
+        self,
+        device_types: tuple[str, ...],
+        binary_sensor_keys: tuple[str, ...],
+        *,
+        is_lock: bool = False,
+    ) -> None:
         self.device_types = frozenset(device_types)
-        self._capabilities = DeviceCapabilities(binary_sensor_keys=binary_sensor_keys)
+        self._capabilities = DeviceCapabilities(
+            binary_sensor_keys=binary_sensor_keys, is_lock=is_lock
+        )
 
     def capabilities(self, device: Device) -> DeviceCapabilities:
         """Return static capabilities for this device family."""
@@ -247,6 +256,12 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
     StaticDeviceHandler(
         ("range_extender_2_fire",),
         ("smoke_detected", "high_temperature", "tamper"),
+    ),
+    # SmartLock / LockBridge
+    StaticDeviceHandler(
+        ("smart_lock", "smart_lock_yale"),
+        ("tamper",),
+        is_lock=True,
     ),
     # Wired inputs
     StaticDeviceHandler(

--- a/custom_components/aegis_ajax/lock.py
+++ b/custom_components/aegis_ajax/lock.py
@@ -15,6 +15,7 @@ from custom_components.aegis_ajax.api.devices import (
 )
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
@@ -26,13 +27,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Ajax catalog ships two SmartLock device-type buckets — `smart_lock` for
-# generic LockBridge integrations and `smart_lock_yale` for Yale-branded
-# locks. Both expose the same status oneof, so they share a single entity
-# class. Lock/unlock is driven through the generic device on/off command
-# (see `_async_switch`), unlatch through SwitchSmartLockService.
-LOCK_DEVICE_TYPES: frozenset[str] = frozenset({"smart_lock", "smart_lock_yale"})
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -40,7 +34,7 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[AjaxLock] = []
     for device_id, device in coordinator.devices.items():
-        if device.device_type in LOCK_DEVICE_TYPES:
+        if capabilities_for(device).is_lock:
             entities.append(AjaxLock(coordinator=coordinator, device_id=device_id))
     async_add_entities(entities)
 

--- a/tests/fixtures/binary_sensor_characterization.json
+++ b/tests/fixtures/binary_sensor_characterization.json
@@ -4009,6 +4009,46 @@
       "enabled_by_default": false
     }
   ],
+  "smart_lock": [
+    {
+      "unique_id": "aegis_ajax_test_device_tamper",
+      "device_class": "tamper",
+      "entity_category": null,
+      "enabled_by_default": true
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_connectivity",
+      "device_class": "connectivity",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_problem",
+      "device_class": "problem",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    }
+  ],
+  "smart_lock_yale": [
+    {
+      "unique_id": "aegis_ajax_test_device_tamper",
+      "device_class": "tamper",
+      "entity_category": null,
+      "enabled_by_default": true
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_connectivity",
+      "device_class": "connectivity",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_problem",
+      "device_class": "problem",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    }
+  ],
   "unmapped_unknown_device": [
     {
       "unique_id": "aegis_ajax_test_device_tamper",

--- a/tests/unit/test_device_handlers.py
+++ b/tests/unit/test_device_handlers.py
@@ -5,6 +5,24 @@ from __future__ import annotations
 import pytest
 
 from custom_components.aegis_ajax import device_handlers
+from custom_components.aegis_ajax.api.models import Device
+from custom_components.aegis_ajax.const import DeviceState
+
+
+def _device(device_type: str) -> Device:
+    return Device(
+        id="device-1",
+        hub_id="hub-1",
+        name="Test device",
+        device_type=device_type,
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses={},
+        battery=None,
+    )
 
 
 def test_build_handler_map_rejects_duplicate_device_type(
@@ -18,3 +36,12 @@ def test_build_handler_map_rejects_duplicate_device_type(
         ValueError, match="Duplicate device handler registration for 'duplicate_type'"
     ):
         device_handlers._build_handler_map()
+
+
+@pytest.mark.parametrize("device_type", ["smart_lock", "smart_lock_yale"])
+def test_lock_capability_is_registered(device_type: str) -> None:
+    assert device_handlers.capabilities_for(_device(device_type)).is_lock
+
+
+def test_non_lock_does_not_have_lock_capability() -> None:
+    assert not device_handlers.capabilities_for(_device("door_protect")).is_lock

--- a/tests/unit/test_lock.py
+++ b/tests/unit/test_lock.py
@@ -16,7 +16,7 @@ from custom_components.aegis_ajax.const import (
     DeviceState,
     SecurityState,
 )
-from custom_components.aegis_ajax.lock import LOCK_DEVICE_TYPES, AjaxLock
+from custom_components.aegis_ajax.lock import AjaxLock, async_setup_entry
 
 
 def _make_device(device_type: str, smart_lock_state: str | None = None) -> Device:
@@ -61,14 +61,6 @@ def _make_coordinator(device: Device) -> MagicMock:
     coordinator.devices_api.send_command = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
     return coordinator
-
-
-class TestLockDeviceTypes:
-    def test_smart_lock_in_lock_types(self) -> None:
-        assert "smart_lock" in LOCK_DEVICE_TYPES
-
-    def test_smart_lock_yale_in_lock_types(self) -> None:
-        assert "smart_lock_yale" in LOCK_DEVICE_TYPES
 
 
 class TestAjaxLockState:
@@ -121,6 +113,21 @@ class TestAjaxLockState:
         coordinator = _make_coordinator(device)
         lock = AjaxLock(coordinator=coordinator, device_id=device.id)
         assert lock.available is False
+
+
+class TestLockSetup:
+    @pytest.mark.asyncio
+    async def test_setup_adds_only_registered_lock_capabilities(self) -> None:
+        lock_device = _make_device("smart_lock")
+        coordinator = _make_coordinator(lock_device)
+        coordinator.devices["door-1"] = _make_device("door_protect")
+        async_add_entities = MagicMock()
+        entry = MagicMock(runtime_data=coordinator)
+
+        await async_setup_entry(MagicMock(), entry, async_add_entities)
+
+        entities = async_add_entities.call_args.args[0]
+        assert [entity._device_id for entity in entities] == [lock_device.id]
 
 
 class TestAjaxLockCommands:

--- a/tests/unit/test_lock.py
+++ b/tests/unit/test_lock.py
@@ -19,12 +19,14 @@ from custom_components.aegis_ajax.const import (
 from custom_components.aegis_ajax.lock import AjaxLock, async_setup_entry
 
 
-def _make_device(device_type: str, smart_lock_state: str | None = None) -> Device:
+def _make_device(
+    device_type: str, smart_lock_state: str | None = None, *, device_id: str = "lock-1"
+) -> Device:
     statuses: dict = {}
     if smart_lock_state is not None:
         statuses["smart_lock_state"] = smart_lock_state
     return Device(
-        id="lock-1",
+        id=device_id,
         hub_id="hub-1",
         name="Front Door Lock",
         device_type=device_type,
@@ -120,7 +122,8 @@ class TestLockSetup:
     async def test_setup_adds_only_registered_lock_capabilities(self) -> None:
         lock_device = _make_device("smart_lock")
         coordinator = _make_coordinator(lock_device)
-        coordinator.devices["door-1"] = _make_device("door_protect")
+        door_device = _make_device("door_protect", device_id="door-1")
+        coordinator.devices[door_device.id] = door_device
         async_add_entities = MagicMock()
         entry = MagicMock(runtime_data=coordinator)
 


### PR DESCRIPTION
## Summary

PR-2 of the device-handler refactor: makes the handler registry the single source of truth for SmartLock family detection. `smart_lock` and `smart_lock_yale` now carry the consumed `is_lock` capability, replacing the duplicate type sets previously maintained by the lock platform and coordinator's one-shot SmartLock probe.

The existing tamper binary-sensor behavior for both families is explicitly retained in the handler, and their committed characterization snapshots prove the entity shape remains unchanged. No lock command or status behavior changed.

Relates to #332.

## Test plan

- [ ] `make check` passes locally on a freshly built Docker image
- [x] New behaviour covered by unit tests in `tests/unit/`
- [x] Coverage stays at or above the 80% threshold
- [ ] User-facing strings updated in `strings.json` and the 14 translation files
- [ ] `README.md` / `CHANGELOG.md` updated when the change is user-visible

Focused platform, coordinator, capability, and binary-sensor characterization tests: 469 passed. Ruff lint and formatting pass for all changed files. The local full run had 2,570 passing tests; its seven failures are the pre-existing Windows FCM logging tests, outside this change.

## Notes for the reviewer

This is intentionally limited to the `_LOCK_DEVICE_TYPES` deduplication called out in the merged #461 review. The capability is introduced only because this PR consumes it in both the lock platform and coordinator probe; no switch, camera, or other future fields are included.