### PR TITLE
fix: verify session list completeness after termination

### DIFF
--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -720,7 +720,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             await hts_client.kill_client_sessions([session_id])
         except HtsTerminationOutcomeUnknownError:
-            if not await self._async_verify_termination_after_uncertain_outcome(session_id):
+            expected_active_session_ids = {
+                session.session_id for session in sessions if session.session_id is not None
+            } - {session_id}
+            if not await self._async_verify_termination_after_uncertain_outcome(
+                session_id, expected_active_session_ids
+            ):
                 raise HtsConnectionError(
                     "Ajax confirmed the session remains active after the termination request."
                 ) from None
@@ -747,7 +752,14 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             try:
                 terminated = await hts_client.kill_client_sessions(session_ids)
             except HtsTerminationOutcomeUnknownError as exc:
-                if not await self._async_verify_termination_after_uncertain_outcome(exc.session_id):
+                expected_active_session_ids = (
+                    {session.session_id for session in sessions if session.session_id is not None}
+                    - set(exc.succeeded_session_ids)
+                    - {exc.session_id}
+                )
+                if not await self._async_verify_termination_after_uncertain_outcome(
+                    exc.session_id, expected_active_session_ids
+                ):
                     raise HtsConnectionError(
                         f"Terminated {len(exc.succeeded_session_ids)} of "
                         f"{len(session_ids)} session(s); the uncertain session remains active."
@@ -757,7 +769,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return len(terminated)
         return 0
 
-    async def _async_verify_termination_after_uncertain_outcome(self, session_id: int) -> bool:
+    async def _async_verify_termination_after_uncertain_outcome(
+        self, session_id: int, expected_active_session_ids: set[int]
+    ) -> bool:
         """Confirm a sent termination after HTS recovers; never resend it."""
         await self._maybe_restart_hts()
         deadline = time.monotonic() + 30
@@ -776,7 +790,15 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         "Termination outcome is unknown because its read-only verification "
                         "returned no sessions; do not retry automatically."
                     )
-                return all(session.session_id != session_id for session in sessions)
+                verified_session_ids = {
+                    session.session_id for session in sessions if session.session_id is not None
+                }
+                if not expected_active_session_ids <= verified_session_ids:
+                    raise HtsConnectionError(
+                        "Termination outcome is unknown because its read-only verification "
+                        "omitted a previously active session; do not retry automatically."
+                    )
+                return session_id not in verified_session_ids
             await asyncio.sleep(0.1)
         raise HtsConnectionError(
             "Termination outcome is unknown because HTS did not reconnect for verification; "

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -793,10 +793,12 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 verified_session_ids = {
                     session.session_id for session in sessions if session.session_id is not None
                 }
-                if not expected_active_session_ids <= verified_session_ids:
+                missing_session_ids = expected_active_session_ids - verified_session_ids
+                if missing_session_ids:
                     raise HtsConnectionError(
                         "Termination outcome is unknown because its read-only verification "
-                        "omitted a previously active session; do not retry automatically."
+                        "omitted previously active session ID(s) "
+                        f"{sorted(missing_session_ids)}; do not retry automatically."
                     )
                 return session_id not in verified_session_ids
             await asyncio.sleep(0.1)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -320,7 +320,10 @@ class TestClientSessionServices:
         coordinator._hts_client.get_client_sessions = AsyncMock(return_value=[self._session(1)])
         coordinator._maybe_restart_hts = AsyncMock()
 
-        with pytest.raises(HtsConnectionError, match="omitted a previously active session"):
+        with pytest.raises(
+            HtsConnectionError,
+            match=r"omitted previously active session ID\(s\) \[3\]",
+        ):
             await coordinator._async_verify_termination_after_uncertain_outcome(2, {1, 3})
         coordinator._hts_client.get_client_sessions.assert_awaited_once()
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -184,7 +184,9 @@ class TestClientSessionServices:
 
         coordinator = object.__new__(AjaxCobrandedCoordinator)
         coordinator._hts_client = MagicMock(is_connected=True)
-        coordinator._hts_client.get_client_sessions = AsyncMock(return_value=[self._session(2)])
+        coordinator._hts_client.get_client_sessions = AsyncMock(
+            return_value=[self._session(1), self._session(2)]
+        )
         coordinator._hts_client.kill_client_sessions = AsyncMock(
             side_effect=HtsTerminationOutcomeUnknownError(2)
         )
@@ -193,7 +195,9 @@ class TestClientSessionServices:
         await coordinator.async_terminate_client_session(2)
 
         coordinator._hts_client.kill_client_sessions.assert_awaited_once_with([2])
-        coordinator._async_verify_termination_after_uncertain_outcome.assert_awaited_once_with(2)
+        coordinator._async_verify_termination_after_uncertain_outcome.assert_awaited_once_with(
+            2, {1}
+        )
 
     @pytest.mark.asyncio
     async def test_uncertain_bulk_termination_counts_verified_final_session(self) -> None:
@@ -212,7 +216,9 @@ class TestClientSessionServices:
 
         assert await coordinator.async_terminate_other_client_sessions() == 2
         coordinator._hts_client.kill_client_sessions.assert_awaited_once_with([2, 3])
-        coordinator._async_verify_termination_after_uncertain_outcome.assert_awaited_once_with(3)
+        coordinator._async_verify_termination_after_uncertain_outcome.assert_awaited_once_with(
+            3, {1}
+        )
 
     @pytest.mark.asyncio
     async def test_uncertain_termination_remaining_session_reports_confirmed_failure(self) -> None:
@@ -249,7 +255,7 @@ class TestClientSessionServices:
 
         coordinator._maybe_restart_hts = AsyncMock(side_effect=reconnect)
 
-        assert await coordinator._async_verify_termination_after_uncertain_outcome(2) is True
+        assert await coordinator._async_verify_termination_after_uncertain_outcome(2, {1}) is True
         coordinator._maybe_restart_hts.assert_awaited_once()
         coordinator._hts_client.get_client_sessions.assert_awaited_once()
 
@@ -266,7 +272,7 @@ class TestClientSessionServices:
         coordinator._maybe_restart_hts = AsyncMock()
 
         with pytest.raises(HtsConnectionError, match="outcome is unknown"):
-            await coordinator._async_verify_termination_after_uncertain_outcome(2)
+            await coordinator._async_verify_termination_after_uncertain_outcome(2, set())
         coordinator._hts_client.get_client_sessions.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -286,7 +292,7 @@ class TestClientSessionServices:
             ),
             pytest.raises(HtsConnectionError, match="did not reconnect"),
         ):
-            await coordinator._async_verify_termination_after_uncertain_outcome(2)
+            await coordinator._async_verify_termination_after_uncertain_outcome(2, set())
 
         coordinator._maybe_restart_hts.assert_awaited_once()
 
@@ -301,7 +307,21 @@ class TestClientSessionServices:
         coordinator._maybe_restart_hts = AsyncMock()
 
         with pytest.raises(HtsConnectionError, match="outcome is unknown"):
-            await coordinator._async_verify_termination_after_uncertain_outcome(2)
+            await coordinator._async_verify_termination_after_uncertain_outcome(2, set())
+        coordinator._hts_client.get_client_sessions.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_uncertain_outcome_truncated_verification_is_unknown(self) -> None:
+        from custom_components.aegis_ajax.api.hts.client import HtsConnectionError
+        from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+
+        coordinator = object.__new__(AjaxCobrandedCoordinator)
+        coordinator._hts_client = MagicMock(is_connected=True)
+        coordinator._hts_client.get_client_sessions = AsyncMock(return_value=[self._session(1)])
+        coordinator._maybe_restart_hts = AsyncMock()
+
+        with pytest.raises(HtsConnectionError, match="omitted a previously active session"):
+            await coordinator._async_verify_termination_after_uncertain_outcome(2, {1, 3})
         coordinator._hts_client.get_client_sessions.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- require the single post-recovery session list to corroborate all sessions known to remain active before declaring an uncertain termination successful
- treat an incomplete non-empty verification response as outcome unknown, without resending a destructive 