### PR TITLE
refactor: move camera capabilities to device handlers

### DIFF
--- a/custom_components/aegis_ajax/button.py
+++ b/custom_components/aegis_ajax/button.py
@@ -10,9 +10,9 @@ from homeassistant.const import EntityCategory
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aegis_ajax.camera import PHOD_DEVICE_TYPES
 from custom_components.aegis_ajax.const import DOMAIN
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
@@ -35,7 +35,7 @@ async def async_setup_entry(
             device_type=device.device_type,
         )
         for device_id, device in coordinator.devices.items()
-        if device.device_type in PHOD_DEVICE_TYPES
+        if capabilities_for(device).is_phod
     ]
     # One refresh button per hub — bridges the gap between the 60s
     # periodic STATUS_BODY refresh and the user wanting a fresh reading

--- a/custom_components/aegis_ajax/camera.py
+++ b/custom_components/aegis_ajax/camera.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
@@ -20,18 +21,6 @@ if TYPE_CHECKING:
     from custom_components.aegis_ajax.api.models import Device
 
 _LOGGER = logging.getLogger(__name__)
-
-CAMERA_DEVICE_TYPES = {
-    "motion_cam",
-    "motion_cam_outdoor",
-    "motion_cam_fibra",
-    "motion_cam_phod",
-    "motion_cam_outdoor_phod",
-    "motion_cam_fibra_base",
-}
-
-# Only PhOD (Photo on Demand) models support on-demand photo capture
-PHOD_DEVICE_TYPES = {"motion_cam_phod", "motion_cam_outdoor_phod", "motion_cam_fibra_base"}
 
 
 async def async_setup_entry(
@@ -46,7 +35,7 @@ async def async_setup_entry(
             device_type=device.device_type,
         )
         for device_id, device in coordinator.devices.items()
-        if device.device_type in CAMERA_DEVICE_TYPES
+        if capabilities_for(device).is_camera
     ]
     async_add_entities(entities)
 

--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -15,6 +15,8 @@ class DeviceCapabilities:
 
     binary_sensor_keys: tuple[str, ...] = ()
     is_lock: bool = False
+    is_camera: bool = False
+    is_phod: bool = False
 
 
 class DeviceHandler(Protocol):
@@ -36,10 +38,15 @@ class StaticDeviceHandler:
         binary_sensor_keys: tuple[str, ...],
         *,
         is_lock: bool = False,
+        is_camera: bool = False,
+        is_phod: bool = False,
     ) -> None:
         self.device_types = frozenset(device_types)
         self._capabilities = DeviceCapabilities(
-            binary_sensor_keys=binary_sensor_keys, is_lock=is_lock
+            binary_sensor_keys=binary_sensor_keys,
+            is_lock=is_lock,
+            is_camera=is_camera,
+            is_phod=is_phod,
         )
 
     def capabilities(self, device: Device) -> DeviceCapabilities:
@@ -115,16 +122,21 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
     ),
     # MotionCam
     StaticDeviceHandler(
+        ("motion_cam", "motion_cam_outdoor", "motion_cam_fibra"),
+        ("motion_detected", "tamper", "delay_when_leaving"),
+        is_camera=True,
+    ),
+    StaticDeviceHandler(
+        ("motion_cam_phod", "motion_cam_outdoor_phod", "motion_cam_fibra_base"),
+        ("motion_detected", "tamper", "delay_when_leaving"),
+        is_camera=True,
+        is_phod=True,
+    ),
+    StaticDeviceHandler(
         (
-            "motion_cam",
-            "motion_cam_outdoor",
-            "motion_cam_fibra",
-            "motion_cam_fibra_base",
             "motion_cam_g3",
             "motion_cam_hd",
-            "motion_cam_phod",
             "motion_cam_phod_fibra",
-            "motion_cam_outdoor_phod",
             "motion_cam_outdoor_two_four_phod",
             "motion_cam_s_phod",
             "motion_cam_s_phod_am",

--- a/tests/unit/test_button.py
+++ b/tests/unit/test_button.py
@@ -154,6 +154,50 @@ class TestRefreshHubButtonSetup:
         assert not any(isinstance(e, AjaxRefreshHubButton) for e in added)
 
 
+class TestCapturePhotoButtonSetup:
+    @pytest.mark.asyncio
+    async def test_setup_adds_only_phod_capability(self) -> None:
+        from custom_components.aegis_ajax.button import async_setup_entry
+
+        coordinator = _make_coordinator()
+        coordinator.devices = {
+            "phod": Device(
+                id="phod",
+                hub_id="hub-1",
+                name="PhOD",
+                device_type="motion_cam_phod",
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            ),
+            "not-phod": Device(
+                id="not-phod",
+                hub_id="hub-1",
+                name="Camera",
+                device_type="motion_cam",
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            ),
+        }
+        coordinator.rooms = {}
+        coordinator.spaces = {}
+        entry = MagicMock(runtime_data=coordinator)
+        added: list[object] = []
+
+        await async_setup_entry(MagicMock(), entry, added.extend)
+
+        assert [entity.unique_id for entity in added] == ["aegis_ajax_phod_capture_photo"]
+
+
 class TestRefreshHubButtonPress:
     """Pressing the button dispatches through the coordinator guard."""
 

--- a/tests/unit/test_camera.py
+++ b/tests/unit/test_camera.py
@@ -26,45 +26,45 @@ def _stub_camera_module() -> None:
 
 _stub_camera_module()
 
-from custom_components.aegis_ajax.camera import (  # noqa: E402
-    CAMERA_DEVICE_TYPES,
-    PHOD_DEVICE_TYPES,
-    AjaxCamera,
-)
+from custom_components.aegis_ajax.api.models import Device  # noqa: E402
+from custom_components.aegis_ajax.camera import AjaxCamera  # noqa: E402
+from custom_components.aegis_ajax.const import DeviceState  # noqa: E402
 
 
-class TestCameraDeviceTypes:
-    def test_motion_cam_phod_is_camera(self) -> None:
-        assert "motion_cam_phod" in CAMERA_DEVICE_TYPES
+def _device(device_id: str, device_type: str) -> Device:
+    return Device(
+        id=device_id,
+        hub_id="hub-1",
+        name="Camera",
+        device_type=device_type,
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses={},
+        battery=None,
+    )
 
-    def test_motion_cam_is_camera(self) -> None:
-        assert "motion_cam" in CAMERA_DEVICE_TYPES
 
-    def test_motion_cam_outdoor_is_camera(self) -> None:
-        assert "motion_cam_outdoor" in CAMERA_DEVICE_TYPES
+class TestCameraSetup:
+    @pytest.mark.asyncio
+    async def test_setup_adds_only_camera_capability(self) -> None:
+        from custom_components.aegis_ajax.camera import async_setup_entry
 
-    def test_motion_cam_fibra_is_camera(self) -> None:
-        assert "motion_cam_fibra" in CAMERA_DEVICE_TYPES
+        coordinator = MagicMock()
+        coordinator.devices = {
+            "camera": _device("camera", "motion_cam"),
+            "not-camera": _device("not-camera", "motion_cam_g3"),
+        }
+        coordinator.rooms = {}
+        coordinator.hub_registry_id.return_value = None
+        entry = MagicMock(runtime_data=coordinator)
+        added: list[object] = []
 
+        await async_setup_entry(MagicMock(), entry, added.extend)
 
-class TestPhodDeviceTypes:
-    def test_motion_cam_phod_is_phod(self) -> None:
-        assert "motion_cam_phod" in PHOD_DEVICE_TYPES
-
-    def test_motion_cam_outdoor_phod_is_phod(self) -> None:
-        assert "motion_cam_outdoor_phod" in PHOD_DEVICE_TYPES
-
-    def test_motion_cam_fibra_base_is_phod(self) -> None:
-        assert "motion_cam_fibra_base" in PHOD_DEVICE_TYPES
-
-    def test_regular_motion_cam_is_not_phod(self) -> None:
-        assert "motion_cam" not in PHOD_DEVICE_TYPES
-
-    def test_motion_cam_outdoor_is_not_phod(self) -> None:
-        assert "motion_cam_outdoor" not in PHOD_DEVICE_TYPES
-
-    def test_phod_types_are_subset_of_camera_types(self) -> None:
-        assert PHOD_DEVICE_TYPES.issubset(CAMERA_DEVICE_TYPES)
+        assert [entity.unique_id for entity in added] == ["aegis_ajax_camera_camera"]
 
 
 class TestAjaxCamera:

--- a/tests/unit/test_device_handlers.py
+++ b/tests/unit/test_device_handlers.py
@@ -45,3 +45,35 @@ def test_lock_capability_is_registered(device_type: str) -> None:
 
 def test_non_lock_does_not_have_lock_capability() -> None:
     assert not device_handlers.capabilities_for(_device("door_protect")).is_lock
+
+
+@pytest.mark.parametrize(
+    "device_type",
+    [
+        "motion_cam",
+        "motion_cam_outdoor",
+        "motion_cam_fibra",
+        "motion_cam_phod",
+        "motion_cam_outdoor_phod",
+        "motion_cam_fibra_base",
+    ],
+)
+def test_camera_capability_is_registered(device_type: str) -> None:
+    assert device_handlers.capabilities_for(_device(device_type)).is_camera
+
+
+@pytest.mark.parametrize(
+    "device_type",
+    ["motion_cam_phod", "motion_cam_outdoor_phod", "motion_cam_fibra_base"],
+)
+def test_phod_capability_is_registered(device_type: str) -> None:
+    capabilities = device_handlers.capabilities_for(_device(device_type))
+    assert capabilities.is_camera
+    assert capabilities.is_phod
+
+
+@pytest.mark.parametrize(
+    "device_type", ["motion_cam", "motion_cam_outdoor", "motion_cam_fibra", "motion_cam_g3"]
+)
+def test_non_phod_motion_camera_has_no_phod_capability(device_type: str) -> None:
+    assert not device_handlers.capabilities_for(_device(device_type)).is_phod


### PR DESCRIPTION
## Summary
- add consumed is_camera and is_phod capabilities to the existing device-handler registry
- migrate the camera platform and photo-on-demand button platform from private type tables to those capabilities
- remove the utton.py import of camera-specific device types without changing the entity families either platform creates
- add handler and platform-dispatch coverage for camera and PhOD selection

Follows the PR-3 scope explicitly approved in #332. The existing committed binary-sensor characterization fixture remains unchanged and its test passes, preserving the mapping established in PR-1.

## Validation
- python -m pytest tests/unit/test_device_handlers.py tests/unit/test_camera.py tests/unit/test_button.py tests/unit/test_characterization_binary_sensor.py -q (186 passed)
- uff check and uff format --check on changed files
- full unit suite: 2,585 passed; 7 known Windows FCM logging failures unrelated to this change