### PR TITLE
refactor: move remaining platform capabilities to device handlers

### DIFF
--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -17,6 +17,11 @@ class DeviceCapabilities:
     is_lock: bool = False
     is_camera: bool = False
     is_phod: bool = False
+    is_light: bool = False
+    is_valve: bool = False
+    has_siren_settings: bool = False
+    has_doorbell_event: bool = False
+    has_button_press_event: bool = False
 
 
 class DeviceHandler(Protocol):
@@ -40,6 +45,11 @@ class StaticDeviceHandler:
         is_lock: bool = False,
         is_camera: bool = False,
         is_phod: bool = False,
+        is_light: bool = False,
+        is_valve: bool = False,
+        has_siren_settings: bool = False,
+        has_doorbell_event: bool = False,
+        has_button_press_event: bool = False,
     ) -> None:
         self.device_types = frozenset(device_types)
         self._capabilities = DeviceCapabilities(
@@ -47,6 +57,11 @@ class StaticDeviceHandler:
             is_lock=is_lock,
             is_camera=is_camera,
             is_phod=is_phod,
+            is_light=is_light,
+            is_valve=is_valve,
+            has_siren_settings=has_siren_settings,
+            has_doorbell_event=has_doorbell_event,
+            has_button_press_event=has_button_press_event,
         )
 
     def capabilities(self, device: Device) -> DeviceCapabilities:
@@ -142,22 +157,30 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "motion_cam_s_phod_am",
             "motion_cam_superior_phod",
             "motion_cam_video_base",
-            "motion_cam_video_doorbell",
             "motion_cam_video_indoor",
         ),
         ("motion_detected", "tamper", "delay_when_leaving"),
+    ),
+    StaticDeviceHandler(
+        ("motion_cam_video_doorbell",),
+        ("motion_detected", "tamper", "delay_when_leaving"),
+        has_doorbell_event=True,
     ),
     # VideoEdge
     StaticDeviceHandler(
         (
             "video_edge_bullet",
-            "video_edge_doorbell",
             "video_edge_indoor",
             "video_edge_minidome",
             "video_edge_turret",
             "video_edge_unknown",
         ),
         ("motion_detected", "tamper"),
+    ),
+    StaticDeviceHandler(
+        ("video_edge_doorbell",),
+        ("motion_detected", "tamper"),
+        has_doorbell_event=True,
     ),
     # CombiProtect
     StaticDeviceHandler(
@@ -232,7 +255,7 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
         ("leak_protect",),
         ("leak_detected", "tamper"),
     ),
-    # Sirens
+    # Sirens with writable common_siren_part settings
     StaticDeviceHandler(
         (
             "home_siren",
@@ -240,7 +263,6 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "home_siren_fibra",
             "home_siren_g3",
             "street_siren",
-            "street_siren_plus",
             "street_siren_fibra",
             "street_siren_plus_fibra",
             "street_siren_plus_g3",
@@ -250,8 +272,15 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "street_siren_double_deck_fibra",
         ),
         ("tamper",),
+        has_siren_settings=True,
     ),
-    # ReX / ReX 2 / LifeQuality / WaterStop — explicit no-capability handlers (#332)
+    # This legacy family has the same binary-sensor surface, but no writable
+    # common_siren_part settings and must remain outside the siren platforms.
+    StaticDeviceHandler(
+        ("street_siren_plus",),
+        ("tamper",),
+    ),
+    # ReX / ReX 2 / LifeQuality — explicit no-capability handlers (#332)
     StaticDeviceHandler(
         (
             "rex",
@@ -260,10 +289,13 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "range_extender_2",
             "life_quality",
             "life_quality_plus",
-            "water_stop",
-            "water_stop_base",
         ),
         (),
+    ),
+    StaticDeviceHandler(
+        ("water_stop", "water_stop_base"),
+        (),
+        is_valve=True,
     ),
     StaticDeviceHandler(
         ("range_extender_2_fire",),
@@ -326,6 +358,18 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "hub_superior",
         ),
         ("gsm_connected", "lid_opened"),
+    ),
+    # Device families that were previously unmapped. Their tamper-only
+    # binary-sensor behavior is made explicit before adding platform entities.
+    StaticDeviceHandler(
+        ("light_switch_dimmer",),
+        ("tamper",),
+        is_light=True,
+    ),
+    StaticDeviceHandler(
+        ("button",),
+        ("tamper",),
+        has_button_press_event=True,
     ),
 )
 

--- a/custom_components/aegis_ajax/event.py
+++ b/custom_components/aegis_ajax/event.py
@@ -11,15 +11,14 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.const import (
     ALL_EVENT_TYPES,
-    BUTTON_PRESS_DEVICE_TYPES,
     BUTTON_PRESS_EVENT_TYPE,
     DOMAIN,
-    DOORBELL_DEVICE_TYPES,
     DOORBELL_EVENT_TYPE,
     DOORBELL_RING_EVENT_TYPE,
     MANUFACTURER,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
@@ -41,12 +40,12 @@ async def async_setup_entry(
     doorbell_entities = [
         AjaxDoorbellEvent(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in DOORBELL_DEVICE_TYPES
+        if capabilities_for(device).has_doorbell_event
     ]
     button_entities = [
         AjaxButtonPressEvent(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in BUTTON_PRESS_DEVICE_TYPES
+        if capabilities_for(device).has_button_press_event
     ]
     async_add_entities([*entities, *doorbell_entities, *button_entities])
     for entity in entities:

--- a/custom_components/aegis_ajax/light.py
+++ b/custom_components/aegis_ajax/light.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -25,8 +26,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-LIGHT_DEVICE_TYPES = {"light_switch_dimmer"}
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -34,7 +33,7 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[AjaxLight] = []
     for device_id, device in coordinator.devices.items():
-        if device.device_type in LIGHT_DEVICE_TYPES:
+        if capabilities_for(device).is_light:
             entities.append(
                 AjaxLight(
                     coordinator=coordinator,

--- a/custom_components/aegis_ajax/number.py
+++ b/custom_components/aegis_ajax/number.py
@@ -26,9 +26,9 @@ from custom_components.aegis_ajax.const import (
     SIREN_ALARM_DURATION_MAX,
     SIREN_ALARM_DURATION_MIN,
     SIREN_ALARM_DURATION_STEP,
-    SIREN_DEVICE_TYPES,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -48,7 +48,7 @@ async def async_setup_entry(
     entities: list[NumberEntity] = [
         AjaxSirenAlarmDurationNumber(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in SIREN_DEVICE_TYPES
+        if capabilities_for(device).has_siren_settings
     ]
     async_add_entities(entities)
 

--- a/custom_components/aegis_ajax/select.py
+++ b/custom_components/aegis_ajax/select.py
@@ -22,12 +22,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.const import (
-    SIREN_DEVICE_TYPES,
     SIREN_VOLUME_LEVEL_KEY,
     SIREN_VOLUME_LEVEL_VALUES,
     SIREN_VOLUME_LEVELS,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ async def async_setup_entry(
     entities: list[SelectEntity] = [
         AjaxSirenVolumeSelect(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in SIREN_DEVICE_TYPES
+        if capabilities_for(device).has_siren_settings
     ]
     async_add_entities(entities)
 

--- a/custom_components/aegis_ajax/valve.py
+++ b/custom_components/aegis_ajax/valve.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -35,11 +36,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Ajax catalog ships two WaterStop buckets — `water_stop` (Jeweller, the
-# default wireless variant) and `water_stop_base` (Fibra, wired). Same
-# `WaterStopChannel` payload, same parser path, same entity surface.
-VALVE_DEVICE_TYPES: frozenset[str] = frozenset({"water_stop", "water_stop_base"})
-
 # The WaterStop exposes a single valve channel; on/off commands target it.
 _VALVE_CHANNEL = 1
 
@@ -50,7 +46,7 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[AjaxValve] = []
     for device_id, device in coordinator.devices.items():
-        if device.device_type in VALVE_DEVICE_TYPES:
+        if capabilities_for(device).is_valve:
             entities.append(AjaxValve(coordinator=coordinator, device_id=device_id))
     async_add_entities(entities)
 

--- a/tests/fixtures/binary_sensor_characterization.json
+++ b/tests/fixtures/binary_sensor_characterization.json
@@ -1,4 +1,44 @@
 {
+  "button": [
+    {
+      "unique_id": "aegis_ajax_test_device_tamper",
+      "device_class": "tamper",
+      "entity_category": null,
+      "enabled_by_default": true
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_connectivity",
+      "device_class": "connectivity",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_problem",
+      "device_class": "problem",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    }
+  ],
+  "light_switch_dimmer": [
+    {
+      "unique_id": "aegis_ajax_test_device_tamper",
+      "device_class": "tamper",
+      "entity_category": null,
+      "enabled_by_default": true
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_connectivity",
+      "device_class": "connectivity",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_problem",
+      "device_class": "problem",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    }
+  ],
   "door_protect": [
     {
       "unique_id": "aegis_ajax_test_device_door_opened",

--- a/tests/unit/test_characterization_binary_sensor.py
+++ b/tests/unit/test_characterization_binary_sensor.py
@@ -94,7 +94,7 @@ class TestBinarySensorCharacterization:
     async def test_new_platform_registration_preserves_unmapped_binary_sensor_shape(
         self, monkeypatch: pytest.MonkeyPatch, device_type: str
     ) -> None:
-        """New platform registrations retain the former tamper-only fallback."""
+        """New registrations retain the former tamper and standard-diagnostics fallback."""
         fixture_data = _load_fixture()
         monkeypatch.delitem(_DEVICE_HANDLERS, device_type)
 

--- a/tests/unit/test_characterization_binary_sensor.py
+++ b/tests/unit/test_characterization_binary_sensor.py
@@ -88,3 +88,53 @@ class TestBinarySensorCharacterization:
         ]
 
         assert actual_entities == expected_entities
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", ["button", "light_switch_dimmer"])
+    async def test_new_platform_registration_preserves_unmapped_binary_sensor_shape(
+        self, monkeypatch: pytest.MonkeyPatch, device_type: str
+    ) -> None:
+        """New platform registrations retain the former tamper-only fallback."""
+        fixture_data = _load_fixture()
+        monkeypatch.delitem(_DEVICE_HANDLERS, device_type)
+
+        device_id = "test_device"
+        mock_coordinator = MagicMock()
+        mock_coordinator.devices = {
+            device_id: Device(
+                id=device_id,
+                hub_id="hub_1",
+                name="Test Device",
+                device_type=device_type,
+                room_id="room_1",
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            )
+        }
+        mock_coordinator.spaces = {}
+        mock_coordinator.rooms = {}
+        mock_coordinator.hub_registry_id.return_value = "hub_reg_1"
+        entry = MagicMock(entry_id="entry_1", runtime_data=mock_coordinator)
+        added_entities: list = []
+
+        await async_setup_entry(MagicMock(), entry, added_entities.extend)
+
+        actual_entities = [
+            {
+                "unique_id": entity.unique_id,
+                "device_class": entity.device_class.value
+                if hasattr(entity.device_class, "value")
+                else entity.device_class,
+                "entity_category": entity.entity_category.value
+                if hasattr(entity.entity_category, "value")
+                else entity.entity_category,
+                "enabled_by_default": entity.entity_registry_enabled_default,
+            }
+            for entity in added_entities
+        ]
+
+        assert actual_entities == fixture_data[device_type]

--- a/tests/unit/test_device_handlers.py
+++ b/tests/unit/test_device_handlers.py
@@ -6,7 +6,12 @@ import pytest
 
 from custom_components.aegis_ajax import device_handlers
 from custom_components.aegis_ajax.api.models import Device
-from custom_components.aegis_ajax.const import DeviceState
+from custom_components.aegis_ajax.const import (
+    BUTTON_PRESS_DEVICE_TYPES,
+    DOORBELL_DEVICE_TYPES,
+    SIREN_DEVICE_TYPES,
+    DeviceState,
+)
 
 
 def _device(device_type: str) -> Device:
@@ -77,3 +82,52 @@ def test_phod_capability_is_registered(device_type: str) -> None:
 )
 def test_non_phod_motion_camera_has_no_phod_capability(device_type: str) -> None:
     assert not device_handlers.capabilities_for(_device(device_type)).is_phod
+
+
+@pytest.mark.parametrize(
+    ("device_type", "capability"),
+    [
+        ("light_switch_dimmer", "is_light"),
+        ("water_stop", "is_valve"),
+        ("water_stop_base", "is_valve"),
+        ("street_siren", "has_siren_settings"),
+        ("home_siren_g3", "has_siren_settings"),
+        ("video_edge_doorbell", "has_doorbell_event"),
+        ("motion_cam_video_doorbell", "has_doorbell_event"),
+        ("button", "has_button_press_event"),
+    ],
+)
+def test_platform_capability_is_registered(device_type: str, capability: str) -> None:
+    assert getattr(device_handlers.capabilities_for(_device(device_type)), capability)
+
+
+@pytest.mark.parametrize(
+    ("device_type", "capability"),
+    [
+        ("street_siren_plus", "has_siren_settings"),
+        ("motion_cam", "has_doorbell_event"),
+        ("door_protect", "has_button_press_event"),
+    ],
+)
+def test_platform_capability_does_not_overmatch(device_type: str, capability: str) -> None:
+    assert not getattr(device_handlers.capabilities_for(_device(device_type)), capability)
+
+
+def _device_types_with_capability(capability: str) -> set[str]:
+    return {
+        device_type
+        for device_type, handler in device_handlers._DEVICE_HANDLERS.items()
+        if getattr(handler.capabilities(_device(device_type)), capability)
+    }
+
+
+def test_siren_settings_capability_matches_existing_siren_types() -> None:
+    assert _device_types_with_capability("has_siren_settings") == SIREN_DEVICE_TYPES
+
+
+def test_doorbell_event_capability_matches_existing_doorbell_types() -> None:
+    assert _device_types_with_capability("has_doorbell_event") == DOORBELL_DEVICE_TYPES
+
+
+def test_button_press_capability_matches_existing_button_types() -> None:
+    assert _device_types_with_capability("has_button_press_event") == BUTTON_PRESS_DEVICE_TYPES

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -9,6 +9,7 @@ from custom_components.aegis_ajax.event import (
     AjaxButtonPressEvent,
     AjaxDoorbellEvent,
     AjaxSecurityEvent,
+    async_setup_entry,
 )
 
 
@@ -424,3 +425,34 @@ class TestAjaxButtonPressEvent:
         entity = self._make_button_entity()
         assert entity._attr_device_info is not None
         assert ("aegis_ajax", "313E5F32") in entity._attr_device_info["identifiers"]
+
+
+class TestEventSetup:
+    async def test_creates_device_events_for_registered_capabilities(self) -> None:
+        coordinator = MagicMock()
+        coordinator.spaces = {}
+        coordinator.rooms = {}
+        coordinator.devices = {
+            "video-doorbell": MagicMock(
+                id="video-doorbell",
+                hub_id="hub-1",
+                device_type="video_edge_doorbell",
+            ),
+            "motion-doorbell": MagicMock(
+                id="motion-doorbell",
+                hub_id="hub-1",
+                device_type="motion_cam_video_doorbell",
+            ),
+            "button": MagicMock(id="button", hub_id="hub-1", device_type="button"),
+            "other": MagicMock(id="other", hub_id="hub-1", device_type="door_protect"),
+        }
+        entry = MagicMock(runtime_data=coordinator)
+        added: list = []
+
+        await async_setup_entry(MagicMock(), entry, added.extend)
+
+        assert {entity.unique_id for entity in added} == {
+            "aegis_ajax_video-doorbell_doorbell_event",
+            "aegis_ajax_motion-doorbell_doorbell_event",
+            "aegis_ajax_button_button_press_event",
+        }

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from custom_components.aegis_ajax.const import ALL_EVENT_TYPES, HUB_EVENT_TAG_MAP
+from custom_components.aegis_ajax.api.models import Device
+from custom_components.aegis_ajax.const import ALL_EVENT_TYPES, HUB_EVENT_TAG_MAP, DeviceState
 from custom_components.aegis_ajax.event import (
     AjaxButtonPressEvent,
     AjaxDoorbellEvent,
@@ -429,22 +430,29 @@ class TestAjaxButtonPressEvent:
 
 class TestEventSetup:
     async def test_creates_device_events_for_registered_capabilities(self) -> None:
+        def device(device_id: str, device_type: str) -> Device:
+            return Device(
+                id=device_id,
+                hub_id="hub-1",
+                name=device_id,
+                device_type=device_type,
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            )
+
         coordinator = MagicMock()
         coordinator.spaces = {}
         coordinator.rooms = {}
         coordinator.devices = {
-            "video-doorbell": MagicMock(
-                id="video-doorbell",
-                hub_id="hub-1",
-                device_type="video_edge_doorbell",
-            ),
-            "motion-doorbell": MagicMock(
-                id="motion-doorbell",
-                hub_id="hub-1",
-                device_type="motion_cam_video_doorbell",
-            ),
-            "button": MagicMock(id="button", hub_id="hub-1", device_type="button"),
-            "other": MagicMock(id="other", hub_id="hub-1", device_type="door_protect"),
+            "video-doorbell": device("video-doorbell", "video_edge_doorbell"),
+            "motion-doorbell": device("motion-doorbell", "motion_cam_video_doorbell"),
+            "button": device("button", "button"),
+            "other": device("other", "door_protect"),
         }
         entry = MagicMock(runtime_data=coordinator)
         added: list = []

--- a/tests/unit/test_light.py
+++ b/tests/unit/test_light.py
@@ -6,12 +6,28 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.aegis_ajax.light import LIGHT_DEVICE_TYPES, AjaxLight
+from custom_components.aegis_ajax.api.models import Device
+from custom_components.aegis_ajax.const import DeviceState
+from custom_components.aegis_ajax.device_handlers import capabilities_for
+from custom_components.aegis_ajax.light import AjaxLight
 
 
 class TestLightDeviceTypes:
     def test_dimmer_is_light(self) -> None:
-        assert "light_switch_dimmer" in LIGHT_DEVICE_TYPES
+        device = Device(
+            id="d1",
+            hub_id="h1",
+            name="Dimmer",
+            device_type="light_switch_dimmer",
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+        assert capabilities_for(device).is_light
 
 
 class TestAjaxLight:

--- a/tests/unit/test_valve.py
+++ b/tests/unit/test_valve.py
@@ -13,7 +13,8 @@ from custom_components.aegis_ajax.const import (
     DeviceState,
     SecurityState,
 )
-from custom_components.aegis_ajax.valve import VALVE_DEVICE_TYPES, AjaxValve
+from custom_components.aegis_ajax.device_handlers import capabilities_for
+from custom_components.aegis_ajax.valve import AjaxValve
 
 
 def _make_device(device_type: str = "water_stop", **status_overrides: Any) -> Device:  # noqa: ANN401
@@ -55,12 +56,12 @@ def _make_coordinator(device: Device) -> MagicMock:
 
 class TestValveDeviceTypes:
     def test_water_stop_in_valve_types(self) -> None:
-        assert "water_stop" in VALVE_DEVICE_TYPES
+        assert capabilities_for(_make_device("water_stop")).is_valve
 
     def test_water_stop_base_in_valve_types(self) -> None:
         # `water_stop_base` is the Fibra (wired) sibling — same channel
         # status shape, same parser path, must surface a valve entity too.
-        assert "water_stop_base" in VALVE_DEVICE_TYPES
+        assert capabilities_for(_make_device("water_stop_base")).is_valve
 
 
 class TestAjaxValveState:


### PR DESCRIPTION
## Summary

Relates to #332.

Moves the existing light, valve, siren-settings, doorbell-event, and button-press-event device-family dispatch into `device_handlers.py`:

- `light.py`, `valve.py`, `number.py`, `select.py`, and `event.py` now select entities from consumed device capabilities.
- Preserves the existing family boundaries exactly: sirens with `common_siren_part`, the two WaterStop variants, the two doorbell families, and `button`.
- Keeps `street_siren_plus` explicitly outside siren settings, preserving its current behavior.
- Makes the formerly unmapped `button` and `light_switch_dimmer` binary-sensor fallback explicit, adds their committed snapshots, and proves neutrality by removing each registration in a test and asserting the snapshot stays identical.
- Adds equality checks between the existing siren/doorbell/button constants and their corresponding registry capability sets.

## Test plan

- [x] Focused handlers, platform and characterization suite: 319 passed
- [x] `ruff check` and `ruff format --check`
- [x] `mypy custom_components/aegis_ajax/ --ignore-missing-imports --exclude 'proto/'`
- [x] `vulture custom_components/aegis_ajax/ vulture_whitelist.py --exclude custom_components/aegis_ajax/proto/`

## Notes for the reviewer

The permanent binary-sensor fixture changes only for the two newly registered families that had previously taken the unmapped fallback. The reverse-registration tests make those fixture entries non-circular.