### PR TITLE
refactor: move light, valve, siren-settings, doorbell and button capabilities to device handlers (#332 PR-4)

### DIFF
--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -17,6 +17,11 @@ class DeviceCapabilities:
     is_lock: bool = False
     is_camera: bool = False
     is_phod: bool = False
+    is_light: bool = False
+    is_valve: bool = False
+    is_doorbell: bool = False
+    is_button_press: bool = False
+    has_siren_settings: bool = False
 
 
 class DeviceHandler(Protocol):
@@ -40,6 +45,11 @@ class StaticDeviceHandler:
         is_lock: bool = False,
         is_camera: bool = False,
         is_phod: bool = False,
+        is_light: bool = False,
+        is_valve: bool = False,
+        is_doorbell: bool = False,
+        is_button_press: bool = False,
+        has_siren_settings: bool = False,
     ) -> None:
         self.device_types = frozenset(device_types)
         self._capabilities = DeviceCapabilities(
@@ -47,6 +57,11 @@ class StaticDeviceHandler:
             is_lock=is_lock,
             is_camera=is_camera,
             is_phod=is_phod,
+            is_light=is_light,
+            is_valve=is_valve,
+            is_doorbell=is_doorbell,
+            is_button_press=is_button_press,
+            has_siren_settings=has_siren_settings,
         )
 
     def capabilities(self, device: Device) -> DeviceCapabilities:
@@ -142,22 +157,34 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "motion_cam_s_phod_am",
             "motion_cam_superior_phod",
             "motion_cam_video_base",
-            "motion_cam_video_doorbell",
             "motion_cam_video_indoor",
         ),
         ("motion_detected", "tamper", "delay_when_leaving"),
+    ),
+    # Split out of the group above only to carry `is_doorbell`; the binary
+    # sensors are identical.
+    StaticDeviceHandler(
+        ("motion_cam_video_doorbell",),
+        ("motion_detected", "tamper", "delay_when_leaving"),
+        is_doorbell=True,
     ),
     # VideoEdge
     StaticDeviceHandler(
         (
             "video_edge_bullet",
-            "video_edge_doorbell",
             "video_edge_indoor",
             "video_edge_minidome",
             "video_edge_turret",
             "video_edge_unknown",
         ),
         ("motion_detected", "tamper"),
+    ),
+    # Split out of the group above only to carry `is_doorbell`; the binary
+    # sensors are identical.
+    StaticDeviceHandler(
+        ("video_edge_doorbell",),
+        ("motion_detected", "tamper"),
+        is_doorbell=True,
     ),
     # CombiProtect
     StaticDeviceHandler(
@@ -240,7 +267,6 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "home_siren_fibra",
             "home_siren_g3",
             "street_siren",
-            "street_siren_plus",
             "street_siren_fibra",
             "street_siren_plus_fibra",
             "street_siren_plus_g3",
@@ -249,6 +275,15 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "street_siren_s_double_deck",
             "street_siren_double_deck_fibra",
         ),
+        ("tamper",),
+        has_siren_settings=True,
+    ),
+    # `street_siren_plus` is a siren, but its oneof case is missing from the
+    # HubDevice proto, so its settings are unreadable and `number` / `select`
+    # would sit permanently empty. Same binary sensors, no settings entities —
+    # see SIREN_DEVICE_TYPES in const.py.
+    StaticDeviceHandler(
+        ("street_siren_plus",),
         ("tamper",),
     ),
     # ReX / ReX 2 / LifeQuality / WaterStop — explicit no-capability handlers (#332)
@@ -260,10 +295,16 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "range_extender_2",
             "life_quality",
             "life_quality_plus",
-            "water_stop",
-            "water_stop_base",
         ),
         (),
+    ),
+    # WaterStop — no binary sensors, one valve entity. Ajax ships two buckets,
+    # `water_stop` (Jeweller, wireless) and `water_stop_base` (Fibra, wired):
+    # same `WaterStopChannel` payload, same parser path, same entity surface.
+    StaticDeviceHandler(
+        ("water_stop", "water_stop_base"),
+        (),
+        is_valve=True,
     ),
     StaticDeviceHandler(
         ("range_extender_2_fire",),
@@ -287,6 +328,21 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
     StaticDeviceHandler(
         ("wire_input_mt",),
         ("tamper", "wire_input_alert", "external_contact_open"),
+    ),
+    # LightSwitch dimmer — previously unmapped, so it fell through to the
+    # tamper-only default. Registered with that same tamper-only set so the
+    # binary sensors do not move; the registration exists to carry `is_light`.
+    StaticDeviceHandler(
+        ("light_switch_dimmer",),
+        ("tamper",),
+        is_light=True,
+    ),
+    # Button — previously unmapped, same tamper-only default preserved; the
+    # registration exists to carry `is_button_press`.
+    StaticDeviceHandler(
+        ("button",),
+        ("tamper",),
+        is_button_press=True,
     ),
     # Keypads
     StaticDeviceHandler(

--- a/custom_components/aegis_ajax/event.py
+++ b/custom_components/aegis_ajax/event.py
@@ -11,15 +11,14 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.const import (
     ALL_EVENT_TYPES,
-    BUTTON_PRESS_DEVICE_TYPES,
     BUTTON_PRESS_EVENT_TYPE,
     DOMAIN,
-    DOORBELL_DEVICE_TYPES,
     DOORBELL_EVENT_TYPE,
     DOORBELL_RING_EVENT_TYPE,
     MANUFACTURER,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
@@ -41,12 +40,12 @@ async def async_setup_entry(
     doorbell_entities = [
         AjaxDoorbellEvent(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in DOORBELL_DEVICE_TYPES
+        if capabilities_for(device).is_doorbell
     ]
     button_entities = [
         AjaxButtonPressEvent(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in BUTTON_PRESS_DEVICE_TYPES
+        if capabilities_for(device).is_button_press
     ]
     async_add_entities([*entities, *doorbell_entities, *button_entities])
     for entity in entities:

--- a/custom_components/aegis_ajax/light.py
+++ b/custom_components/aegis_ajax/light.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -25,8 +26,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-LIGHT_DEVICE_TYPES = {"light_switch_dimmer"}
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -34,7 +33,7 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[AjaxLight] = []
     for device_id, device in coordinator.devices.items():
-        if device.device_type in LIGHT_DEVICE_TYPES:
+        if capabilities_for(device).is_light:
             entities.append(
                 AjaxLight(
                     coordinator=coordinator,

--- a/custom_components/aegis_ajax/number.py
+++ b/custom_components/aegis_ajax/number.py
@@ -2,7 +2,8 @@
 
 Currently exposes the siren **alarm duration** (seconds). An entity is created
 for every siren device type the rich `StreamHubDevice` proto models a
-`common_siren_part` for (`SIREN_DEVICE_TYPES`) — the entity is created at setup
+`common_siren_part` for (`has_siren_settings` in the device-handler registry,
+pinned against `SIREN_DEVICE_TYPES`) — the entity is created at setup
 regardless of whether its current value has been fetched yet, so it appears on
 first boot without waiting for the background settings refresh (it reads
 `unknown` until the first snapshot merges the value). Writes go through the
@@ -26,9 +27,9 @@ from custom_components.aegis_ajax.const import (
     SIREN_ALARM_DURATION_MAX,
     SIREN_ALARM_DURATION_MIN,
     SIREN_ALARM_DURATION_STEP,
-    SIREN_DEVICE_TYPES,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -48,7 +49,7 @@ async def async_setup_entry(
     entities: list[NumberEntity] = [
         AjaxSirenAlarmDurationNumber(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in SIREN_DEVICE_TYPES
+        if capabilities_for(device).has_siren_settings
     ]
     async_add_entities(entities)
 

--- a/custom_components/aegis_ajax/select.py
+++ b/custom_components/aegis_ajax/select.py
@@ -2,7 +2,8 @@
 
 Currently exposes the siren **volume level**. An entity is created for every
 siren device type the rich `StreamHubDevice` proto models a `common_siren_part`
-for (`SIREN_DEVICE_TYPES`) — created at setup regardless of whether its current
+for (`has_siren_settings` in the device-handler registry, pinned against
+`SIREN_DEVICE_TYPES`) — created at setup regardless of whether its current
 value has been fetched yet, so it appears on first boot without waiting for the
 background settings refresh (it reads no selected option until the first
 snapshot merges the value). Writes go through the shared `UpdateHubDevice`
@@ -22,12 +23,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.const import (
-    SIREN_DEVICE_TYPES,
     SIREN_VOLUME_LEVEL_KEY,
     SIREN_VOLUME_LEVEL_VALUES,
     SIREN_VOLUME_LEVELS,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -47,7 +48,7 @@ async def async_setup_entry(
     entities: list[SelectEntity] = [
         AjaxSirenVolumeSelect(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in SIREN_DEVICE_TYPES
+        if capabilities_for(device).has_siren_settings
     ]
     async_add_entities(entities)
 

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -170,62 +170,62 @@
             }
         },
         "set_photo_on_demand_mode": {
-            "name": "Set Photo on Demand mode",
-            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "name": "Imposta la modalità Foto su richiesta",
+            "description": "Attiva o disattiva la modalità Foto su richiesta su un hub. Si possono commutare separatamente due canali indipendenti: le richieste degli utenti (se gli utenti dell'hub possono richiedere foto dall'app Ajax) e gli scenari (se scenari e automazioni possono avviare gli scatti). Lascia un campo non impostato per mantenerne il valore attuale. Almeno uno è obbligatorio.",
             "fields": {
                 "user": {
-                    "name": "User requests",
-                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                    "name": "Richieste degli utenti",
+                    "description": "Se impostato, attiva o disattiva le richieste di foto avviate dagli utenti dell'hub. Lascia non impostato per mantenere il valore attuale."
                 },
                 "scenario": {
-                    "name": "Scenarios",
-                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                    "name": "Scenari",
+                    "description": "Se impostato, attiva o disattiva gli scatti Foto su richiesta avviati da scenari o automazioni Ajax. Lascia non impostato per mantenere il valore attuale."
                 },
                 "entity_id": {
-                    "name": "Entity",
-                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                    "name": "Entità",
+                    "description": "Pannello allarme dello spazio di cui aggiornare la modalità dell'hub. Se omesso, si applica a tutti gli spazi configurati."
                 }
             }
         },
         "list_client_sessions": {
-            "name": "List account sessions",
-            "description": "Return active Ajax account sessions for manual inspection on demand. This service calls an internal Ajax endpoint that may rate limit frequent requests; do not poll it in automations. The currently active Aegis session is marked is_current when it can be identified.",
+            "name": "Elenca le sessioni dell'account",
+            "description": "Restituisce su richiesta le sessioni attive dell'account Ajax, per un'ispezione manuale. Questo servizio chiama un endpoint interno di Ajax che può limitare la frequenza delle richieste: non interrogarlo ciclicamente nelle automazioni. La sessione Aegis attualmente attiva è contrassegnata con is_current quando è identificabile.",
             "fields": {
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID voce di configurazione",
+                    "description": "Necessario quando è configurato più di un account Aegis."
                 }
             }
         },
         "terminate_client_session": {
-            "name": "Terminate account session",
-            "description": "Immediately log the selected other device out of the Ajax account. Obtain its session ID through list_client_sessions. The integration never terminates its own session.",
+            "name": "Disconnetti una sessione dell'account",
+            "description": "Disconnette immediatamente dall'account Ajax il dispositivo selezionato. Ottieni il suo ID sessione con list_client_sessions. L'integrazione non disconnette mai la propria sessione.",
             "fields": {
                 "session_id": {
-                    "name": "Session ID",
-                    "description": "Session ID returned by list_client_sessions."
+                    "name": "ID sessione",
+                    "description": "ID sessione restituito da list_client_sessions."
                 },
                 "confirm": {
-                    "name": "Confirm termination",
-                    "description": "Must be true to immediately terminate the selected session."
+                    "name": "Conferma disconnessione",
+                    "description": "Deve essere true per disconnettere immediatamente la sessione selezionata."
                 },
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID voce di configurazione",
+                    "description": "Necessario quando è configurato più di un account Aegis."
                 }
             }
         },
         "terminate_other_client_sessions": {
-            "name": "Terminate all other account sessions",
-            "description": "Immediately log all other devices out of the Ajax account. This signs out other active Ajax mobile and desktop apps. The integration never terminates its own session.",
+            "name": "Disconnetti tutte le altre sessioni dell'account",
+            "description": "Disconnette immediatamente dall'account Ajax tutti gli altri dispositivi. Fa uscire le altre app Ajax mobili e desktop attive. L'integrazione non disconnette mai la propria sessione.",
             "fields": {
                 "confirm": {
-                    "name": "Confirm termination",
-                    "description": "Must be true to immediately terminate all other sessions."
+                    "name": "Conferma disconnessione",
+                    "description": "Deve essere true per disconnettere immediatamente tutte le altre sessioni."
                 },
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID voce di configurazione",
+                    "description": "Necessario quando è configurato più di un account Aegis."
                 }
             }
         }

--- a/custom_components/aegis_ajax/valve.py
+++ b/custom_components/aegis_ajax/valve.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -35,11 +36,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Ajax catalog ships two WaterStop buckets — `water_stop` (Jeweller, the
-# default wireless variant) and `water_stop_base` (Fibra, wired). Same
-# `WaterStopChannel` payload, same parser path, same entity surface.
-VALVE_DEVICE_TYPES: frozenset[str] = frozenset({"water_stop", "water_stop_base"})
-
 # The WaterStop exposes a single valve channel; on/off commands target it.
 _VALVE_CHANNEL = 1
 
@@ -50,7 +46,7 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[AjaxValve] = []
     for device_id, device in coordinator.devices.items():
-        if device.device_type in VALVE_DEVICE_TYPES:
+        if capabilities_for(device).is_valve:
             entities.append(AjaxValve(coordinator=coordinator, device_id=device_id))
     async_add_entities(entities)
 

--- a/tests/fixtures/binary_sensor_characterization.json
+++ b/tests/fixtures/binary_sensor_characterization.json
@@ -4049,6 +4049,46 @@
       "enabled_by_default": false
     }
   ],
+  "light_switch_dimmer": [
+    {
+      "unique_id": "aegis_ajax_test_device_tamper",
+      "device_class": "tamper",
+      "entity_category": null,
+      "enabled_by_default": true
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_connectivity",
+      "device_class": "connectivity",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_problem",
+      "device_class": "problem",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    }
+  ],
+  "button": [
+    {
+      "unique_id": "aegis_ajax_test_device_tamper",
+      "device_class": "tamper",
+      "entity_category": null,
+      "enabled_by_default": true
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_connectivity",
+      "device_class": "connectivity",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_problem",
+      "device_class": "problem",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    }
+  ],
   "unmapped_unknown_device": [
     {
       "unique_id": "aegis_ajax_test_device_tamper",

--- a/tests/unit/test_device_handlers.py
+++ b/tests/unit/test_device_handlers.py
@@ -77,3 +77,114 @@ def test_phod_capability_is_registered(device_type: str) -> None:
 )
 def test_non_phod_motion_camera_has_no_phod_capability(device_type: str) -> None:
     assert not device_handlers.capabilities_for(_device(device_type)).is_phod
+
+
+@pytest.mark.parametrize("device_type", ["water_stop", "water_stop_base"])
+def test_valve_capability_is_registered(device_type: str) -> None:
+    assert device_handlers.capabilities_for(_device(device_type)).is_valve
+
+
+@pytest.mark.parametrize("device_type", ["life_quality", "rex_2", "leak_protect"])
+def test_non_valve_has_no_valve_capability(device_type: str) -> None:
+    assert not device_handlers.capabilities_for(_device(device_type)).is_valve
+
+
+def test_light_capability_is_registered() -> None:
+    assert device_handlers.capabilities_for(_device("light_switch_dimmer")).is_light
+
+
+@pytest.mark.parametrize("device_type", ["door_protect", "keypad_combi", "home_siren"])
+def test_other_registered_family_has_no_light_capability(device_type: str) -> None:
+    assert not device_handlers.capabilities_for(_device(device_type)).is_light
+
+
+@pytest.mark.parametrize("device_type", ["motion_cam_video_doorbell", "video_edge_doorbell"])
+def test_doorbell_capability_is_registered(device_type: str) -> None:
+    assert device_handlers.capabilities_for(_device(device_type)).is_doorbell
+
+
+@pytest.mark.parametrize(
+    "device_type", ["motion_cam_video_indoor", "video_edge_indoor", "motion_cam"]
+)
+def test_non_doorbell_camera_has_no_doorbell_capability(device_type: str) -> None:
+    """The doorbells were split out of larger camera groups; the rest must not move."""
+    assert not device_handlers.capabilities_for(_device(device_type)).is_doorbell
+
+
+def test_button_press_capability_is_registered() -> None:
+    assert device_handlers.capabilities_for(_device("button")).is_button_press
+
+
+@pytest.mark.parametrize("device_type", ["door_protect", "keypad_combi"])
+def test_other_registered_family_has_no_button_press_capability(device_type: str) -> None:
+    assert not device_handlers.capabilities_for(_device(device_type)).is_button_press
+
+
+def test_unmapped_family_has_none_of_the_new_capabilities() -> None:
+    """Keyfobs, relays and sockets are still unmapped and must stay capability-free."""
+    capabilities = device_handlers.capabilities_for(_device("unmapped_unknown_device"))
+    assert not capabilities.is_light
+    assert not capabilities.is_valve
+    assert not capabilities.is_doorbell
+    assert not capabilities.is_button_press
+    assert not capabilities.has_siren_settings
+
+
+@pytest.mark.parametrize("device_type", ["home_siren", "street_siren_double_deck_fibra"])
+def test_siren_settings_capability_is_registered(device_type: str) -> None:
+    assert device_handlers.capabilities_for(_device(device_type)).has_siren_settings
+
+
+def test_street_siren_plus_has_no_siren_settings() -> None:
+    """It is a siren, but its oneof case is missing from the HubDevice proto.
+
+    Its settings are unreadable, so `number` / `select` would sit permanently
+    empty — which is why it is excluded from `SIREN_DEVICE_TYPES` and must stay
+    excluded here. Its binary sensors are unaffected.
+    """
+    capabilities = device_handlers.capabilities_for(_device("street_siren_plus"))
+    assert not capabilities.has_siren_settings
+    assert capabilities.binary_sensor_keys == ("tamper",)
+
+
+@pytest.mark.parametrize("device_type", ["light_switch_dimmer", "button"])
+def test_newly_registered_family_keeps_the_unmapped_binary_sensors(device_type: str) -> None:
+    """These two were unmapped before (#332 PR-4), so they fell through to the
+    tamper-only default. The registration exists only to carry a capability;
+    the binary sensors must be exactly what the default handler produced.
+    """
+    default = device_handlers.DefaultDeviceHandler().capabilities(_device(device_type))
+    registered = device_handlers.capabilities_for(_device(device_type))
+    assert registered.binary_sensor_keys == default.binary_sensor_keys == ("tamper",)
+
+
+class TestCapabilityParityWithConstSets:
+    """`coordinator` and `notification` still gate on the `const.py` sets.
+
+    Until those move too, the registry and the sets are two sources of truth
+    for the same families, so pin them against each other: adding a family to
+    one and not the other is the drift this catches.
+    """
+
+    @staticmethod
+    def _types_with(capability: str) -> set[str]:
+        return {
+            device_type
+            for device_type, handler in device_handlers._DEVICE_HANDLERS.items()
+            if getattr(handler.capabilities(_device(device_type)), capability)
+        }
+
+    def test_siren_settings_matches_siren_device_types(self) -> None:
+        from custom_components.aegis_ajax.const import SIREN_DEVICE_TYPES
+
+        assert self._types_with("has_siren_settings") == set(SIREN_DEVICE_TYPES)
+
+    def test_doorbell_matches_doorbell_device_types(self) -> None:
+        from custom_components.aegis_ajax.const import DOORBELL_DEVICE_TYPES
+
+        assert self._types_with("is_doorbell") == set(DOORBELL_DEVICE_TYPES)
+
+    def test_button_press_matches_button_press_device_types(self) -> None:
+        from custom_components.aegis_ajax.const import BUTTON_PRESS_DEVICE_TYPES
+
+        assert self._types_with("is_button_press") == set(BUTTON_PRESS_DEVICE_TYPES)

--- a/tests/unit/test_light.py
+++ b/tests/unit/test_light.py
@@ -6,12 +6,43 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.aegis_ajax.light import LIGHT_DEVICE_TYPES, AjaxLight
+from custom_components.aegis_ajax.api.models import Device
+from custom_components.aegis_ajax.const import DeviceState
+from custom_components.aegis_ajax.light import AjaxLight, async_setup_entry
 
 
-class TestLightDeviceTypes:
-    def test_dimmer_is_light(self) -> None:
-        assert "light_switch_dimmer" in LIGHT_DEVICE_TYPES
+def _device(device_id: str, device_type: str) -> Device:
+    return Device(
+        id=device_id,
+        hub_id="h1",
+        name="Device",
+        device_type=device_type,
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses={},
+        battery=None,
+    )
+
+
+class TestLightSetup:
+    @pytest.mark.asyncio
+    async def test_setup_adds_only_the_light_capability(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {
+            "dimmer": _device("dimmer", "light_switch_dimmer"),
+            "not-a-light": _device("not-a-light", "door_protect"),
+        }
+        coordinator.rooms = {}
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+
+        await async_setup_entry(MagicMock(), entry, lambda new: added.extend(new))
+
+        assert [entity._device_id for entity in added] == ["dimmer"]
 
 
 class TestAjaxLight:

--- a/tests/unit/test_valve.py
+++ b/tests/unit/test_valve.py
@@ -13,7 +13,7 @@ from custom_components.aegis_ajax.const import (
     DeviceState,
     SecurityState,
 )
-from custom_components.aegis_ajax.valve import VALVE_DEVICE_TYPES, AjaxValve
+from custom_components.aegis_ajax.valve import AjaxValve, async_setup_entry
 
 
 def _make_device(device_type: str = "water_stop", **status_overrides: Any) -> Device:  # noqa: ANN401
@@ -53,14 +53,29 @@ def _make_coordinator(device: Device) -> MagicMock:
     return coordinator
 
 
-class TestValveDeviceTypes:
-    def test_water_stop_in_valve_types(self) -> None:
-        assert "water_stop" in VALVE_DEVICE_TYPES
+class TestValveSetup:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", ["water_stop", "water_stop_base"])
+    async def test_setup_adds_a_valve_for_both_water_stop_buckets(self, device_type: str) -> None:
+        device = _make_device(device_type=device_type)
+        entry = MagicMock()
+        entry.runtime_data = _make_coordinator(device)
+        added: list = []
 
-    def test_water_stop_base_in_valve_types(self) -> None:
-        # `water_stop_base` is the Fibra (wired) sibling — same channel
-        # status shape, same parser path, must surface a valve entity too.
-        assert "water_stop_base" in VALVE_DEVICE_TYPES
+        await async_setup_entry(MagicMock(), entry, lambda new: added.extend(new))
+
+        assert [entity._device_id for entity in added] == [device.id]
+
+    @pytest.mark.asyncio
+    async def test_setup_skips_a_family_without_the_valve_capability(self) -> None:
+        device = _make_device(device_type="life_quality")
+        entry = MagicMock()
+        entry.runtime_data = _make_coordinator(device)
+        added: list = []
+
+        await async_setup_entry(MagicMock(), entry, lambda new: added.extend(new))
+
+        assert added == []
 
 
 class TestAjaxValveState:


### PR DESCRIPTION
PR-4 of the #332 handler-registry series. `light`, `valve`, `number`, `select` and `event` each decided which families they serve from their own table; they now read the registry, like `binary_sensor`, `lock`, `camera` and `button` already do.

Five capabilities, each consumed here: `is_light` (light.py), `is_valve` (valve.py), `has_siren_settings` (number.py + select.py), `is_doorbell` and `is_button_press` (event.py). The local `LIGHT_DEVICE_TYPES` and `VALVE_DEVICE_TYPES` are gone.

**Against the four conditions on #332:**

1. **Characterization fixture** — two entries added, because the PR registers two families that were genuinely unmapped: `light_switch_dimmer` and `button`. Both are registered with the tamper-only set the default handler already gave them.
2. **Neutrality of a new registration, proved rather than asserted** — the snapshot for those two was generated twice, once with the new registration and once with it removed, and compared: identical. A fixture entry this PR wrote would otherwise be circular.
3. **Every capability consumed** — all five, in this commit; `vulture` is clean with no whitelist entry.
4. **Family sets preserved exactly** — three groups were split *purely* to carry a capability, with byte-identical binary-sensor tuples on both sides of each split: the video doorbell out of the MotionCam video group, the VideoEdge doorbell out of the VideoEdge group, and WaterStop out of the shared no-capability group.

**One naming decision worth arguing about.** It is `has_siren_settings`, not `is_siren`, because the gate is not "this device is a siren" — it is "the `HubDevice` proto models a `common_siren_part` for it, so its settings are readable". `street_siren_plus` is the case that makes the difference: it is a siren, its oneof case is missing from the proto, and `number` / `select` would sit permanently empty for it. It keeps its binary sensors and gets its own registration with a comment saying why it carries no settings capability. Calling the flag `is_siren` would invite someone to "fix" that.

**Two sources of truth, deliberately, for now.** `coordinator.py` and `notification.py` still gate on `SIREN_DEVICE_TYPES`, `DOORBELL_DEVICE_TYPES` and `BUTTON_PRESS_DEVICE_TYPES` — moving those is not an entity-platform change and does not belong in this PR. `TestCapabilityParityWithConstSets` pins the registry against all three sets, so adding a family to one and not the other fails instead of drifting silently.

Verified in the dev image: `ruff`, `ruff format`, `mypy`, `vulture` clean, 2652 unit tests pass, coverage 91%. The new tests were mutation-checked — dropping `is_light=True` and `is_doorbell=True` fails 3 tests.