### PR TITLE
refactor: serve the sensor platform's electrical and temperature gates from device handlers (#332 PR-5)

### DIFF
--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
+
+from custom_components.aegis_ajax.api.hts.hub_state import (
+    DIRECT_POWER_DEVICE_TYPES,
+    ELECTRICAL_DEVICE_TYPES,
+    HTS_TEMPERATURE_DEVICE_TYPES,
+)
 
 if TYPE_CHECKING:
     from custom_components.aegis_ajax.api.models import Device
@@ -22,6 +29,9 @@ class DeviceCapabilities:
     is_doorbell: bool = False
     is_button_press: bool = False
     has_siren_settings: bool = False
+    has_electrical_readings: bool = False
+    has_direct_power: bool = False
+    has_hts_temperature: bool = False
 
 
 class DeviceHandler(Protocol):
@@ -406,6 +416,32 @@ def get_device_handler(device_type: str) -> DeviceHandler:
     return _DEVICE_HANDLERS.get(device_type, _DEFAULT_HANDLER)
 
 
+# These three capabilities are deliberately NOT declared in `_HANDLERS`: the
+# fact each one encodes already lives in the HTS layer, and retyping the family
+# list here is exactly the drift this registry exists to remove.
+#
+# Which families report electrical readings is decided by the per-family sub-key
+# map in `api/hts/hub_state.py` — a family with no key map has nothing to read,
+# and a family added to the key map already carries everything its sensors need.
+# `DIRECT_POWER_DEVICE_TYPES` is the subset whose firmware reports instantaneous
+# power instead of leaving it to be derived, and `HTS_TEMPERATURE_DEVICE_TYPES`
+# is the set whose internal temperature has no gRPC source at all (see #229,
+# #269, #312). So the flags are derived from those tables: add a family there
+# and its sensor entities follow, with nothing to keep in step by hand.
+
+
 def capabilities_for(device: Device) -> DeviceCapabilities:
     """Return device capabilities for the given device."""
-    return get_device_handler(device.device_type).capabilities(device)
+    capabilities = get_device_handler(device.device_type).capabilities(device)
+    device_type = device.device_type
+    if device_type in ELECTRICAL_DEVICE_TYPES:
+        capabilities = dataclasses.replace(
+            capabilities,
+            has_electrical_readings=True,
+            # A subset of the electrical families: the rest leave `power_w`
+            # empty and get the derived-from-current sensor instead.
+            has_direct_power=device_type in DIRECT_POWER_DEVICE_TYPES,
+        )
+    if device_type in HTS_TEMPERATURE_DEVICE_TYPES:
+        capabilities = dataclasses.replace(capabilities, has_hts_temperature=True)
+    return capabilities

--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -17,6 +17,11 @@ class DeviceCapabilities:
     is_lock: bool = False
     is_camera: bool = False
     is_phod: bool = False
+    is_light: bool = False
+    is_valve: bool = False
+    is_doorbell: bool = False
+    is_button_press: bool = False
+    has_siren_settings: bool = False
 
 
 class DeviceHandler(Protocol):
@@ -40,6 +45,11 @@ class StaticDeviceHandler:
         is_lock: bool = False,
         is_camera: bool = False,
         is_phod: bool = False,
+        is_light: bool = False,
+        is_valve: bool = False,
+        is_doorbell: bool = False,
+        is_button_press: bool = False,
+        has_siren_settings: bool = False,
     ) -> None:
         self.device_types = frozenset(device_types)
         self._capabilities = DeviceCapabilities(
@@ -47,6 +57,11 @@ class StaticDeviceHandler:
             is_lock=is_lock,
             is_camera=is_camera,
             is_phod=is_phod,
+            is_light=is_light,
+            is_valve=is_valve,
+            is_doorbell=is_doorbell,
+            is_button_press=is_button_press,
+            has_siren_settings=has_siren_settings,
         )
 
     def capabilities(self, device: Device) -> DeviceCapabilities:
@@ -142,22 +157,34 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "motion_cam_s_phod_am",
             "motion_cam_superior_phod",
             "motion_cam_video_base",
-            "motion_cam_video_doorbell",
             "motion_cam_video_indoor",
         ),
         ("motion_detected", "tamper", "delay_when_leaving"),
+    ),
+    # Split out of the group above only to carry `is_doorbell`; the binary
+    # sensors are identical.
+    StaticDeviceHandler(
+        ("motion_cam_video_doorbell",),
+        ("motion_detected", "tamper", "delay_when_leaving"),
+        is_doorbell=True,
     ),
     # VideoEdge
     StaticDeviceHandler(
         (
             "video_edge_bullet",
-            "video_edge_doorbell",
             "video_edge_indoor",
             "video_edge_minidome",
             "video_edge_turret",
             "video_edge_unknown",
         ),
         ("motion_detected", "tamper"),
+    ),
+    # Split out of the group above only to carry `is_doorbell`; the binary
+    # sensors are identical.
+    StaticDeviceHandler(
+        ("video_edge_doorbell",),
+        ("motion_detected", "tamper"),
+        is_doorbell=True,
     ),
     # CombiProtect
     StaticDeviceHandler(
@@ -240,7 +267,6 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "home_siren_fibra",
             "home_siren_g3",
             "street_siren",
-            "street_siren_plus",
             "street_siren_fibra",
             "street_siren_plus_fibra",
             "street_siren_plus_g3",
@@ -249,6 +275,15 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "street_siren_s_double_deck",
             "street_siren_double_deck_fibra",
         ),
+        ("tamper",),
+        has_siren_settings=True,
+    ),
+    # `street_siren_plus` is a siren, but its oneof case is missing from the
+    # HubDevice proto, so its settings are unreadable and `number` / `select`
+    # would sit permanently empty. Same binary sensors, no settings entities —
+    # see SIREN_DEVICE_TYPES in const.py.
+    StaticDeviceHandler(
+        ("street_siren_plus",),
         ("tamper",),
     ),
     # ReX / ReX 2 / LifeQuality / WaterStop — explicit no-capability handlers (#332)
@@ -260,10 +295,16 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
             "range_extender_2",
             "life_quality",
             "life_quality_plus",
-            "water_stop",
-            "water_stop_base",
         ),
         (),
+    ),
+    # WaterStop — no binary sensors, one valve entity. Ajax ships two buckets,
+    # `water_stop` (Jeweller, wireless) and `water_stop_base` (Fibra, wired):
+    # same `WaterStopChannel` payload, same parser path, same entity surface.
+    StaticDeviceHandler(
+        ("water_stop", "water_stop_base"),
+        (),
+        is_valve=True,
     ),
     StaticDeviceHandler(
         ("range_extender_2_fire",),
@@ -287,6 +328,21 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
     StaticDeviceHandler(
         ("wire_input_mt",),
         ("tamper", "wire_input_alert", "external_contact_open"),
+    ),
+    # LightSwitch dimmer — previously unmapped, so it fell through to the
+    # tamper-only default. Registered with that same tamper-only set so the
+    # binary sensors do not move; the registration exists to carry `is_light`.
+    StaticDeviceHandler(
+        ("light_switch_dimmer",),
+        ("tamper",),
+        is_light=True,
+    ),
+    # Button — previously unmapped, same tamper-only default preserved; the
+    # registration exists to carry `is_button_press`.
+    StaticDeviceHandler(
+        ("button",),
+        ("tamper",),
+        is_button_press=True,
     ),
     # Keypads
     StaticDeviceHandler(

--- a/custom_components/aegis_ajax/event.py
+++ b/custom_components/aegis_ajax/event.py
@@ -11,15 +11,14 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.const import (
     ALL_EVENT_TYPES,
-    BUTTON_PRESS_DEVICE_TYPES,
     BUTTON_PRESS_EVENT_TYPE,
     DOMAIN,
-    DOORBELL_DEVICE_TYPES,
     DOORBELL_EVENT_TYPE,
     DOORBELL_RING_EVENT_TYPE,
     MANUFACTURER,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import build_device_info
 
 if TYPE_CHECKING:
@@ -41,12 +40,12 @@ async def async_setup_entry(
     doorbell_entities = [
         AjaxDoorbellEvent(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in DOORBELL_DEVICE_TYPES
+        if capabilities_for(device).is_doorbell
     ]
     button_entities = [
         AjaxButtonPressEvent(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in BUTTON_PRESS_DEVICE_TYPES
+        if capabilities_for(device).is_button_press
     ]
     async_add_entities([*entities, *doorbell_entities, *button_entities])
     for entity in entities:

--- a/custom_components/aegis_ajax/light.py
+++ b/custom_components/aegis_ajax/light.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -25,8 +26,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-LIGHT_DEVICE_TYPES = {"light_switch_dimmer"}
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -34,7 +33,7 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[AjaxLight] = []
     for device_id, device in coordinator.devices.items():
-        if device.device_type in LIGHT_DEVICE_TYPES:
+        if capabilities_for(device).is_light:
             entities.append(
                 AjaxLight(
                     coordinator=coordinator,

--- a/custom_components/aegis_ajax/number.py
+++ b/custom_components/aegis_ajax/number.py
@@ -2,7 +2,8 @@
 
 Currently exposes the siren **alarm duration** (seconds). An entity is created
 for every siren device type the rich `StreamHubDevice` proto models a
-`common_siren_part` for (`SIREN_DEVICE_TYPES`) — the entity is created at setup
+`common_siren_part` for (`has_siren_settings` in the device-handler registry,
+pinned against `SIREN_DEVICE_TYPES`) — the entity is created at setup
 regardless of whether its current value has been fetched yet, so it appears on
 first boot without waiting for the background settings refresh (it reads
 `unknown` until the first snapshot merges the value). Writes go through the
@@ -26,9 +27,9 @@ from custom_components.aegis_ajax.const import (
     SIREN_ALARM_DURATION_MAX,
     SIREN_ALARM_DURATION_MIN,
     SIREN_ALARM_DURATION_STEP,
-    SIREN_DEVICE_TYPES,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -48,7 +49,7 @@ async def async_setup_entry(
     entities: list[NumberEntity] = [
         AjaxSirenAlarmDurationNumber(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in SIREN_DEVICE_TYPES
+        if capabilities_for(device).has_siren_settings
     ]
     async_add_entities(entities)
 

--- a/custom_components/aegis_ajax/select.py
+++ b/custom_components/aegis_ajax/select.py
@@ -2,7 +2,8 @@
 
 Currently exposes the siren **volume level**. An entity is created for every
 siren device type the rich `StreamHubDevice` proto models a `common_siren_part`
-for (`SIREN_DEVICE_TYPES`) — created at setup regardless of whether its current
+for (`has_siren_settings` in the device-handler registry, pinned against
+`SIREN_DEVICE_TYPES`) — created at setup regardless of whether its current
 value has been fetched yet, so it appears on first boot without waiting for the
 background settings refresh (it reads no selected option until the first
 snapshot merges the value). Writes go through the shared `UpdateHubDevice`
@@ -22,12 +23,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.const import (
-    SIREN_DEVICE_TYPES,
     SIREN_VOLUME_LEVEL_KEY,
     SIREN_VOLUME_LEVEL_VALUES,
     SIREN_VOLUME_LEVELS,
 )
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -47,7 +48,7 @@ async def async_setup_entry(
     entities: list[SelectEntity] = [
         AjaxSirenVolumeSelect(coordinator=coordinator, device_id=device_id)
         for device_id, device in coordinator.devices.items()
-        if device.device_type in SIREN_DEVICE_TYPES
+        if capabilities_for(device).has_siren_settings
     ]
     async_add_entities(entities)
 

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -23,13 +23,9 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aegis_ajax.api.hts.hub_state import (
-    DIRECT_POWER_DEVICE_TYPES,
-    ELECTRICAL_DEVICE_TYPES,
-    HTS_TEMPERATURE_DEVICE_TYPES,
-)
 from custom_components.aegis_ajax.api.models import MonitoringCompanyStatus
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import build_device_info
 
 # Fallback voltage used to derive instantaneous power when the device
@@ -146,7 +142,7 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
 
     def _should_create_status_sensor(device: Device, key: str) -> bool:
-        if key == "temperature" and device.device_type in HTS_TEMPERATURE_DEVICE_TYPES:
+        if key == "temperature" and capabilities_for(device).has_hts_temperature:
             return True
         return key in device.statuses
 
@@ -201,11 +197,12 @@ async def async_setup_entry(
     # and Outlet Type E / F (#179, calibrated in 1.5.3-beta.11).
     _remove_orphan_outlet_power_derived(hass, coordinator)
     for device_id, device in coordinator.devices.items():
-        if device.device_type in ELECTRICAL_DEVICE_TYPES:
+        capabilities = capabilities_for(device)
+        if capabilities.has_electrical_readings:
             entities.append(AjaxDeviceCurrentSensor(coordinator, device_id))
             entities.append(AjaxDeviceVoltageSensor(coordinator, device_id))
             entities.append(AjaxDeviceEnergyConsumedSensor(coordinator, device_id))
-            if device.device_type in DIRECT_POWER_DEVICE_TYPES:
+            if capabilities.has_direct_power:
                 entities.append(AjaxDevicePowerSensor(coordinator, device_id))
             else:
                 entities.append(AjaxDeviceDerivedPowerSensor(coordinator, device_id))
@@ -220,14 +217,14 @@ def _remove_orphan_outlet_power_derived(
 
     Between `1.4.0` (when the WallSwitch family's derived-power entity
     first shipped) and `1.5.3-beta.1` (when the Outlet was excluded
-    from `ELECTRICAL_DEVICE_TYPES` while we figured out its sub-key
+    from the electrical-readings key map while we figured out its sub-key
     map), users on Outlets got a `_power_derived` entity registered
     with WallSwitch-shaped (and incorrect) parsing behind it. From
     `1.5.3-beta.11` the Outlet emits a real `_power` sensor instead;
     the legacy `_power_derived` lingers in the entity registry as
     `unavailable` until the user deletes it by hand. This helper
     sweeps the registry once per setup and removes it cleanly.
-    Touches only devices currently in `DIRECT_POWER_DEVICE_TYPES`;
+    Touches only devices whose `has_direct_power` capability is set;
     WallSwitch family's own `_power_derived` is untouched.
     """
     from homeassistant.helpers import entity_registry as er  # noqa: PLC0415
@@ -235,7 +232,7 @@ def _remove_orphan_outlet_power_derived(
     registry = er.async_get(hass)
     removed = 0
     for device_id, device in coordinator.devices.items():
-        if device.device_type not in DIRECT_POWER_DEVICE_TYPES:
+        if not capabilities_for(device).has_direct_power:
             continue
         unique_id = f"aegis_ajax_{device_id}_power_derived"
         entity_id = registry.async_get_entity_id("sensor", "aegis_ajax", unique_id)

--- a/custom_components/aegis_ajax/translations/it.json
+++ b/custom_components/aegis_ajax/translations/it.json
@@ -170,62 +170,62 @@
             }
         },
         "set_photo_on_demand_mode": {
-            "name": "Set Photo on Demand mode",
-            "description": "Enable or disable Photo on Demand mode on a hub. Two independent channels can be toggled separately — user requests (whether hub users can request photos from the Ajax app) and scenarios (whether scenarios / automations can trigger captures). Leave a field unset to keep its current value. At least one is required.",
+            "name": "Imposta la modalità Foto su richiesta",
+            "description": "Attiva o disattiva la modalità Foto su richiesta su un hub. Si possono commutare separatamente due canali indipendenti: le richieste degli utenti (se gli utenti dell'hub possono richiedere foto dall'app Ajax) e gli scenari (se scenari e automazioni possono avviare gli scatti). Lascia un campo non impostato per mantenerne il valore attuale. Almeno uno è obbligatorio.",
             "fields": {
                 "user": {
-                    "name": "User requests",
-                    "description": "When set, enables or disables on-demand photo requests initiated by hub users. Leave unset to keep the current value."
+                    "name": "Richieste degli utenti",
+                    "description": "Se impostato, attiva o disattiva le richieste di foto avviate dagli utenti dell'hub. Lascia non impostato per mantenere il valore attuale."
                 },
                 "scenario": {
-                    "name": "Scenarios",
-                    "description": "When set, enables or disables Photo on Demand captures triggered by Ajax scenarios / automations. Leave unset to keep the current value."
+                    "name": "Scenari",
+                    "description": "Se impostato, attiva o disattiva gli scatti Foto su richiesta avviati da scenari o automazioni Ajax. Lascia non impostato per mantenere il valore attuale."
                 },
                 "entity_id": {
-                    "name": "Entity",
-                    "description": "Alarm panel entity for the space whose hub mode to update. If omitted, applies to every configured space."
+                    "name": "Entità",
+                    "description": "Pannello allarme dello spazio di cui aggiornare la modalità dell'hub. Se omesso, si applica a tutti gli spazi configurati."
                 }
             }
         },
         "list_client_sessions": {
-            "name": "List account sessions",
-            "description": "Return active Ajax account sessions for manual inspection on demand. This service calls an internal Ajax endpoint that may rate limit frequent requests; do not poll it in automations. The currently active Aegis session is marked is_current when it can be identified.",
+            "name": "Elenca le sessioni dell'account",
+            "description": "Restituisce su richiesta le sessioni attive dell'account Ajax, per un'ispezione manuale. Questo servizio chiama un endpoint interno di Ajax che può limitare la frequenza delle richieste: non interrogarlo ciclicamente nelle automazioni. La sessione Aegis attualmente attiva è contrassegnata con is_current quando è identificabile.",
             "fields": {
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID voce di configurazione",
+                    "description": "Necessario quando è configurato più di un account Aegis."
                 }
             }
         },
         "terminate_client_session": {
-            "name": "Terminate account session",
-            "description": "Immediately log the selected other device out of the Ajax account. Obtain its session ID through list_client_sessions. The integration never terminates its own session.",
+            "name": "Disconnetti una sessione dell'account",
+            "description": "Disconnette immediatamente dall'account Ajax il dispositivo selezionato. Ottieni il suo ID sessione con list_client_sessions. L'integrazione non disconnette mai la propria sessione.",
             "fields": {
                 "session_id": {
-                    "name": "Session ID",
-                    "description": "Session ID returned by list_client_sessions."
+                    "name": "ID sessione",
+                    "description": "ID sessione restituito da list_client_sessions."
                 },
                 "confirm": {
-                    "name": "Confirm termination",
-                    "description": "Must be true to immediately terminate the selected session."
+                    "name": "Conferma disconnessione",
+                    "description": "Deve essere true per disconnettere immediatamente la sessione selezionata."
                 },
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID voce di configurazione",
+                    "description": "Necessario quando è configurato più di un account Aegis."
                 }
             }
         },
         "terminate_other_client_sessions": {
-            "name": "Terminate all other account sessions",
-            "description": "Immediately log all other devices out of the Ajax account. This signs out other active Ajax mobile and desktop apps. The integration never terminates its own session.",
+            "name": "Disconnetti tutte le altre sessioni dell'account",
+            "description": "Disconnette immediatamente dall'account Ajax tutti gli altri dispositivi. Fa uscire le altre app Ajax mobili e desktop attive. L'integrazione non disconnette mai la propria sessione.",
             "fields": {
                 "confirm": {
-                    "name": "Confirm termination",
-                    "description": "Must be true to immediately terminate all other sessions."
+                    "name": "Conferma disconnessione",
+                    "description": "Deve essere true per disconnettere immediatamente tutte le altre sessioni."
                 },
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID voce di configurazione",
+                    "description": "Necessario quando è configurato più di un account Aegis."
                 }
             }
         }

--- a/custom_components/aegis_ajax/valve.py
+++ b/custom_components/aegis_ajax/valve.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aegis_ajax.api.models import DeviceCommand
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import async_send_device_command, build_device_info
 
 if TYPE_CHECKING:
@@ -35,11 +36,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Ajax catalog ships two WaterStop buckets — `water_stop` (Jeweller, the
-# default wireless variant) and `water_stop_base` (Fibra, wired). Same
-# `WaterStopChannel` payload, same parser path, same entity surface.
-VALVE_DEVICE_TYPES: frozenset[str] = frozenset({"water_stop", "water_stop_base"})
-
 # The WaterStop exposes a single valve channel; on/off commands target it.
 _VALVE_CHANNEL = 1
 
@@ -50,7 +46,7 @@ async def async_setup_entry(
     coordinator: AjaxCobrandedCoordinator = entry.runtime_data
     entities: list[AjaxValve] = []
     for device_id, device in coordinator.devices.items():
-        if device.device_type in VALVE_DEVICE_TYPES:
+        if capabilities_for(device).is_valve:
             entities.append(AjaxValve(coordinator=coordinator, device_id=device_id))
     async_add_entities(entities)
 

--- a/tests/fixtures/binary_sensor_characterization.json
+++ b/tests/fixtures/binary_sensor_characterization.json
@@ -4049,6 +4049,46 @@
       "enabled_by_default": false
     }
   ],
+  "light_switch_dimmer": [
+    {
+      "unique_id": "aegis_ajax_test_device_tamper",
+      "device_class": "tamper",
+      "entity_category": null,
+      "enabled_by_default": true
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_connectivity",
+      "device_class": "connectivity",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_problem",
+      "device_class": "problem",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    }
+  ],
+  "button": [
+    {
+      "unique_id": "aegis_ajax_test_device_tamper",
+      "device_class": "tamper",
+      "entity_category": null,
+      "enabled_by_default": true
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_connectivity",
+      "device_class": "connectivity",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    },
+    {
+      "unique_id": "aegis_ajax_test_device_problem",
+      "device_class": "problem",
+      "entity_category": "diagnostic",
+      "enabled_by_default": false
+    }
+  ],
   "unmapped_unknown_device": [
     {
       "unique_id": "aegis_ajax_test_device_tamper",

--- a/tests/unit/test_device_handlers.py
+++ b/tests/unit/test_device_handlers.py
@@ -188,3 +188,97 @@ class TestCapabilityParityWithConstSets:
         from custom_components.aegis_ajax.const import BUTTON_PRESS_DEVICE_TYPES
 
         assert self._types_with("is_button_press") == set(BUTTON_PRESS_DEVICE_TYPES)
+
+
+class TestHtsDerivedCapabilities:
+    """#332 PR-5: the sensor platform's three gates, derived from the HTS tables.
+
+    They are not declared in `_HANDLERS` on purpose — `api/hts/hub_state.py`
+    already decides which families have electrical readings and which have no
+    gRPC temperature — so what these tests pin is that the derivation happens
+    and that it adds nothing else.
+    """
+
+    @pytest.mark.parametrize(
+        "device_type",
+        ["wall_switch", "relay", "socket", "socket_outlet_type_e", "socket_outlet_type_f"],
+    )
+    def test_electrical_family_has_electrical_readings(self, device_type: str) -> None:
+        assert device_handlers.capabilities_for(_device(device_type)).has_electrical_readings
+
+    @pytest.mark.parametrize("device_type", ["socket_outlet_type_e", "socket_outlet_type_f"])
+    def test_outlet_reports_power_directly(self, device_type: str) -> None:
+        assert device_handlers.capabilities_for(_device(device_type)).has_direct_power
+
+    @pytest.mark.parametrize("device_type", ["wall_switch", "relay", "socket"])
+    def test_wallswitch_family_power_is_derived_not_direct(self, device_type: str) -> None:
+        capabilities = device_handlers.capabilities_for(_device(device_type))
+        assert capabilities.has_electrical_readings
+        assert not capabilities.has_direct_power
+
+    def test_direct_power_is_a_subset_of_electrical(self) -> None:
+        """`capabilities_for` only reaches `has_direct_power` inside the electrical branch."""
+        from custom_components.aegis_ajax.api.hts.hub_state import (
+            DIRECT_POWER_DEVICE_TYPES,
+            ELECTRICAL_DEVICE_TYPES,
+        )
+
+        assert DIRECT_POWER_DEVICE_TYPES <= ELECTRICAL_DEVICE_TYPES
+
+    @pytest.mark.parametrize(
+        "device_type",
+        ["street_siren", "motion_protect_outdoor", "motion_protect_curtain_outdoor_plus"],
+    )
+    def test_hts_temperature_family_is_flagged(self, device_type: str) -> None:
+        assert device_handlers.capabilities_for(_device(device_type)).has_hts_temperature
+
+    @pytest.mark.parametrize("device_type", ["door_protect", "keypad_combi", "motion_protect"])
+    def test_grpc_temperature_family_is_not_flagged(self, device_type: str) -> None:
+        """Families that already get temperature over gRPC must not gain the HTS gate."""
+        assert not device_handlers.capabilities_for(_device(device_type)).has_hts_temperature
+
+    def test_derivation_matches_the_hts_tables_exactly(self) -> None:
+        from custom_components.aegis_ajax.api.hts.hub_state import (
+            DIRECT_POWER_DEVICE_TYPES,
+            ELECTRICAL_DEVICE_TYPES,
+            HTS_TEMPERATURE_DEVICE_TYPES,
+        )
+
+        candidates = (
+            set(device_handlers._DEVICE_HANDLERS)
+            | set(ELECTRICAL_DEVICE_TYPES)
+            | set(HTS_TEMPERATURE_DEVICE_TYPES)
+        )
+        electrical = set()
+        direct = set()
+        hts_temperature = set()
+        for device_type in candidates:
+            capabilities = device_handlers.capabilities_for(_device(device_type))
+            if capabilities.has_electrical_readings:
+                electrical.add(device_type)
+            if capabilities.has_direct_power:
+                direct.add(device_type)
+            if capabilities.has_hts_temperature:
+                hts_temperature.add(device_type)
+        assert electrical == set(ELECTRICAL_DEVICE_TYPES)
+        assert direct == set(DIRECT_POWER_DEVICE_TYPES)
+        assert hts_temperature == set(HTS_TEMPERATURE_DEVICE_TYPES)
+
+    @pytest.mark.parametrize(
+        "device_type", ["wall_switch", "socket_outlet_type_e", "street_siren", "door_protect"]
+    )
+    def test_derivation_does_not_disturb_the_declared_capabilities(self, device_type: str) -> None:
+        """The derived flags are added on top; nothing declared may change."""
+        declared = device_handlers.get_device_handler(device_type).capabilities(
+            _device(device_type)
+        )
+        derived = device_handlers.capabilities_for(_device(device_type))
+        assert derived.binary_sensor_keys == declared.binary_sensor_keys
+        assert derived.is_lock == declared.is_lock
+        assert derived.is_camera == declared.is_camera
+        assert derived.is_phod == declared.is_phod
+        assert derived.is_light == declared.is_light
+        assert derived.is_valve == declared.is_valve
+        assert derived.is_doorbell == declared.is_doorbell
+        assert derived.is_button_press == declared.is_button_press
+        assert derived.has_siren_settings == declared.has_siren_settings

--- a/tests/unit/test_device_handlers.py
+++ b/tests/unit/test_device_handlers.py
@@ -77,3 +77,114 @@ def test_phod_capability_is_registered(device_type: str) -> None:
 )
 def test_non_phod_motion_camera_has_no_phod_capability(device_type: str) -> None:
     assert not device_handlers.capabilities_for(_device(device_type)).is_phod
+
+
+@pytest.mark.parametrize("device_type", ["water_stop", "water_stop_base"])
+def test_valve_capability_is_registered(device_type: str) -> None:
+    assert device_handlers.capabilities_for(_device(device_type)).is_valve
+
+
+@pytest.mark.parametrize("device_type", ["life_quality", "rex_2", "leak_protect"])
+def test_non_valve_has_no_valve_capability(device_type: str) -> None:
+    assert not device_handlers.capabilities_for(_device(device_type)).is_valve
+
+
+def test_light_capability_is_registered() -> None:
+    assert device_handlers.capabilities_for(_device("light_switch_dimmer")).is_light
+
+
+@pytest.mark.parametrize("device_type", ["door_protect", "keypad_combi", "home_siren"])
+def test_other_registered_family_has_no_light_capability(device_type: str) -> None:
+    assert not device_handlers.capabilities_for(_device(device_type)).is_light
+
+
+@pytest.mark.parametrize("device_type", ["motion_cam_video_doorbell", "video_edge_doorbell"])
+def test_doorbell_capability_is_registered(device_type: str) -> None:
+    assert device_handlers.capabilities_for(_device(device_type)).is_doorbell
+
+
+@pytest.mark.parametrize(
+    "device_type", ["motion_cam_video_indoor", "video_edge_indoor", "motion_cam"]
+)
+def test_non_doorbell_camera_has_no_doorbell_capability(device_type: str) -> None:
+    """The doorbells were split out of larger camera groups; the rest must not move."""
+    assert not device_handlers.capabilities_for(_device(device_type)).is_doorbell
+
+
+def test_button_press_capability_is_registered() -> None:
+    assert device_handlers.capabilities_for(_device("button")).is_button_press
+
+
+@pytest.mark.parametrize("device_type", ["door_protect", "keypad_combi"])
+def test_other_registered_family_has_no_button_press_capability(device_type: str) -> None:
+    assert not device_handlers.capabilities_for(_device(device_type)).is_button_press
+
+
+def test_unmapped_family_has_none_of_the_new_capabilities() -> None:
+    """Keyfobs, relays and sockets are still unmapped and must stay capability-free."""
+    capabilities = device_handlers.capabilities_for(_device("unmapped_unknown_device"))
+    assert not capabilities.is_light
+    assert not capabilities.is_valve
+    assert not capabilities.is_doorbell
+    assert not capabilities.is_button_press
+    assert not capabilities.has_siren_settings
+
+
+@pytest.mark.parametrize("device_type", ["home_siren", "street_siren_double_deck_fibra"])
+def test_siren_settings_capability_is_registered(device_type: str) -> None:
+    assert device_handlers.capabilities_for(_device(device_type)).has_siren_settings
+
+
+def test_street_siren_plus_has_no_siren_settings() -> None:
+    """It is a siren, but its oneof case is missing from the HubDevice proto.
+
+    Its settings are unreadable, so `number` / `select` would sit permanently
+    empty — which is why it is excluded from `SIREN_DEVICE_TYPES` and must stay
+    excluded here. Its binary sensors are unaffected.
+    """
+    capabilities = device_handlers.capabilities_for(_device("street_siren_plus"))
+    assert not capabilities.has_siren_settings
+    assert capabilities.binary_sensor_keys == ("tamper",)
+
+
+@pytest.mark.parametrize("device_type", ["light_switch_dimmer", "button"])
+def test_newly_registered_family_keeps_the_unmapped_binary_sensors(device_type: str) -> None:
+    """These two were unmapped before (#332 PR-4), so they fell through to the
+    tamper-only default. The registration exists only to carry a capability;
+    the binary sensors must be exactly what the default handler produced.
+    """
+    default = device_handlers.DefaultDeviceHandler().capabilities(_device(device_type))
+    registered = device_handlers.capabilities_for(_device(device_type))
+    assert registered.binary_sensor_keys == default.binary_sensor_keys == ("tamper",)
+
+
+class TestCapabilityParityWithConstSets:
+    """`coordinator` and `notification` still gate on the `const.py` sets.
+
+    Until those move too, the registry and the sets are two sources of truth
+    for the same families, so pin them against each other: adding a family to
+    one and not the other is the drift this catches.
+    """
+
+    @staticmethod
+    def _types_with(capability: str) -> set[str]:
+        return {
+            device_type
+            for device_type, handler in device_handlers._DEVICE_HANDLERS.items()
+            if getattr(handler.capabilities(_device(device_type)), capability)
+        }
+
+    def test_siren_settings_matches_siren_device_types(self) -> None:
+        from custom_components.aegis_ajax.const import SIREN_DEVICE_TYPES
+
+        assert self._types_with("has_siren_settings") == set(SIREN_DEVICE_TYPES)
+
+    def test_doorbell_matches_doorbell_device_types(self) -> None:
+        from custom_components.aegis_ajax.const import DOORBELL_DEVICE_TYPES
+
+        assert self._types_with("is_doorbell") == set(DOORBELL_DEVICE_TYPES)
+
+    def test_button_press_matches_button_press_device_types(self) -> None:
+        from custom_components.aegis_ajax.const import BUTTON_PRESS_DEVICE_TYPES
+
+        assert self._types_with("is_button_press") == set(BUTTON_PRESS_DEVICE_TYPES)

--- a/tests/unit/test_light.py
+++ b/tests/unit/test_light.py
@@ -6,12 +6,43 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.aegis_ajax.light import LIGHT_DEVICE_TYPES, AjaxLight
+from custom_components.aegis_ajax.api.models import Device
+from custom_components.aegis_ajax.const import DeviceState
+from custom_components.aegis_ajax.light import AjaxLight, async_setup_entry
 
 
-class TestLightDeviceTypes:
-    def test_dimmer_is_light(self) -> None:
-        assert "light_switch_dimmer" in LIGHT_DEVICE_TYPES
+def _device(device_id: str, device_type: str) -> Device:
+    return Device(
+        id=device_id,
+        hub_id="h1",
+        name="Device",
+        device_type=device_type,
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses={},
+        battery=None,
+    )
+
+
+class TestLightSetup:
+    @pytest.mark.asyncio
+    async def test_setup_adds_only_the_light_capability(self) -> None:
+        coordinator = MagicMock()
+        coordinator.devices = {
+            "dimmer": _device("dimmer", "light_switch_dimmer"),
+            "not-a-light": _device("not-a-light", "door_protect"),
+        }
+        coordinator.rooms = {}
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+
+        await async_setup_entry(MagicMock(), entry, lambda new: added.extend(new))
+
+        assert [entity._device_id for entity in added] == ["dimmer"]
 
 
 class TestAjaxLight:

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from custom_components.aegis_ajax.api.hts.hub_state import (
+    DIRECT_POWER_DEVICE_TYPES,
+    ELECTRICAL_DEVICE_TYPES,
     HTS_TEMPERATURE_DEVICE_TYPES,
     HubNetworkState,
 )
@@ -1232,3 +1234,89 @@ class TestTemperatureSensorCreationGate:
         assert "aegis_ajax_s1_humidity" not in unique_ids
         assert "aegis_ajax_s1_co2" not in unique_ids
         assert "aegis_ajax_s1_signal_strength" not in unique_ids
+
+
+class TestElectricalSensorCreationGate:
+    """Which families grow the electrical sensors, and which power entity they get.
+
+    This gate had no test at all before #332 PR-5: deleting the condition
+    outright left the whole suite green, so a refactor could have dropped every
+    WallSwitch / Socket / Outlet electrical entity on a live install without CI
+    noticing. The families come from the HTS sub-key map, so sweeping the set
+    keeps a family added there covered without anyone extending a list here.
+    """
+
+    @staticmethod
+    def _make_device(device_id: str, device_type: str) -> Device:
+        return Device(
+            id=device_id,
+            hub_id="hub-1",
+            name=f"Device {device_id}",
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    @staticmethod
+    async def _setup(devices: dict[str, Device]) -> list:
+        from custom_components.aegis_ajax.sensor import async_setup_entry
+
+        coordinator = MagicMock()
+        coordinator.devices = devices
+        coordinator.rooms = {}
+        coordinator.spaces = {}
+        coordinator.sim_info = {}
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+
+        with patch("custom_components.aegis_ajax.sensor._remove_orphan_outlet_power_derived"):
+            await async_setup_entry(MagicMock(), entry, added.extend)
+        return added
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", sorted(ELECTRICAL_DEVICE_TYPES))
+    async def test_every_electrical_family_gets_the_three_readings(self, device_type: str) -> None:
+        added = await self._setup({"e1": self._make_device("e1", device_type)})
+
+        unique_ids = {e.unique_id for e in added}
+        assert "aegis_ajax_e1_current" in unique_ids
+        assert "aegis_ajax_e1_voltage" in unique_ids
+        assert "aegis_ajax_e1_energy_consumed" in unique_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", sorted(DIRECT_POWER_DEVICE_TYPES))
+    async def test_direct_power_family_gets_a_real_power_sensor(self, device_type: str) -> None:
+        """The Outlet reports `power_w`, so it must not get the derived placeholder."""
+        added = await self._setup({"e1": self._make_device("e1", device_type)})
+
+        unique_ids = {e.unique_id for e in added}
+        assert "aegis_ajax_e1_power" in unique_ids
+        assert "aegis_ajax_e1_power_derived" not in unique_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "device_type", sorted(ELECTRICAL_DEVICE_TYPES - DIRECT_POWER_DEVICE_TYPES)
+    )
+    async def test_wallswitch_family_gets_the_derived_power_sensor(self, device_type: str) -> None:
+        """No `power_w` in the firmware's readings, so power is current × voltage."""
+        added = await self._setup({"e1": self._make_device("e1", device_type)})
+
+        unique_ids = {e.unique_id for e in added}
+        assert "aegis_ajax_e1_power_derived" in unique_ids
+        assert "aegis_ajax_e1_power" not in unique_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", ["door_protect", "home_siren", "light_switch_dimmer"])
+    async def test_non_electrical_family_gets_no_electrical_sensors(self, device_type: str) -> None:
+        added = await self._setup({"d1": self._make_device("d1", device_type)})
+
+        unique_ids = {e.unique_id for e in added}
+        for suffix in ("current", "voltage", "energy_consumed", "power", "power_derived"):
+            assert f"aegis_ajax_d1_{suffix}" not in unique_ids

--- a/tests/unit/test_valve.py
+++ b/tests/unit/test_valve.py
@@ -13,7 +13,7 @@ from custom_components.aegis_ajax.const import (
     DeviceState,
     SecurityState,
 )
-from custom_components.aegis_ajax.valve import VALVE_DEVICE_TYPES, AjaxValve
+from custom_components.aegis_ajax.valve import AjaxValve, async_setup_entry
 
 
 def _make_device(device_type: str = "water_stop", **status_overrides: Any) -> Device:  # noqa: ANN401
@@ -53,14 +53,29 @@ def _make_coordinator(device: Device) -> MagicMock:
     return coordinator
 
 
-class TestValveDeviceTypes:
-    def test_water_stop_in_valve_types(self) -> None:
-        assert "water_stop" in VALVE_DEVICE_TYPES
+class TestValveSetup:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", ["water_stop", "water_stop_base"])
+    async def test_setup_adds_a_valve_for_both_water_stop_buckets(self, device_type: str) -> None:
+        device = _make_device(device_type=device_type)
+        entry = MagicMock()
+        entry.runtime_data = _make_coordinator(device)
+        added: list = []
 
-    def test_water_stop_base_in_valve_types(self) -> None:
-        # `water_stop_base` is the Fibra (wired) sibling — same channel
-        # status shape, same parser path, must surface a valve entity too.
-        assert "water_stop_base" in VALVE_DEVICE_TYPES
+        await async_setup_entry(MagicMock(), entry, lambda new: added.extend(new))
+
+        assert [entity._device_id for entity in added] == [device.id]
+
+    @pytest.mark.asyncio
+    async def test_setup_skips_a_family_without_the_valve_capability(self) -> None:
+        device = _make_device(device_type="life_quality")
+        entry = MagicMock()
+        entry.runtime_data = _make_coordinator(device)
+        added: list = []
+
+        await async_setup_entry(MagicMock(), entry, lambda new: added.extend(new))
+
+        assert added == []
 
 
 class TestAjaxValveState:


### PR DESCRIPTION
PR-5 of the #332 series, the last platform still gating on a device-type table of its own. **Stacked on #479 (PR-4)** — base is that branch, so review only the second commit; rebase onto `main` is trivial once PR-4 lands.

`sensor.py` no longer imports `ELECTRICAL_DEVICE_TYPES`, `DIRECT_POWER_DEVICE_TYPES` or `HTS_TEMPERATURE_DEVICE_TYPES`; it asks for `has_electrical_readings`, `has_direct_power` and `has_hts_temperature`.

**These three are derived, not declared — the one place this departs from PR-1..PR-4, and I would rather defend it than sneak it through.** The fact each flag encodes already lives in the HTS layer: which families report electrical readings is decided by the per-family sub-key map in `api/hts/hub_state.py`. A family with no key map has nothing to read, and a family added to the map already carries everything its sensors need. Retyping those lists into `_HANDLERS` would create exactly the drift this refactor exists to remove — the registry would then be a *second* place to remember. So `capabilities_for` folds the flags on top of the declared capabilities, and `test_derivation_matches_the_hts_tables_exactly` pins the result against the tables. Same for `has_hts_temperature`, where the table is the set of families with no gRPC temperature at all (#229, #269, #312).

Consequences, both good: nothing new is registered, so `_DEVICE_HANDLERS` is unchanged and the characterization fixture needs no entry; and adding a family to the key map now grows its sensor entities with no second edit.

**The finding this PR turned up, which matters more than the refactor.** The electrical creation gate had **no test at all**. Replacing the condition with `if False` left all 2674 tests green — so this refactor could have dropped every WallSwitch / Socket / Outlet current, voltage, energy and power entity on a live install and CI would have reported success. That is the same class of hole the characterization fixture was built to close for `binary_sensor`, still open on `sensor`.

`TestElectricalSensorCreationGate` now covers it, sweeping the HTS sets rather than hard-coding families:

- the three readings for every family in the key map,
- a real `_power` and no `_power_derived` for the Outlets,
- `_power_derived` and no `_power` for the WallSwitch family,
- neither for anything else.

With it in place the same mutation fails 18 tests, and inverting the direct-power branch fails too.

Verified in the dev image: `ruff`, `ruff format`, `mypy`, `vulture` clean, 2695 unit tests pass, coverage 91.1%.