### PR TITLE
refactor: serve the sensor platform's electrical and temperature gates from device handlers (#332 PR-5)

### DIFF
--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
+
+from custom_components.aegis_ajax.api.hts.hub_state import (
+    DIRECT_POWER_DEVICE_TYPES,
+    ELECTRICAL_DEVICE_TYPES,
+    HTS_TEMPERATURE_DEVICE_TYPES,
+)
 
 if TYPE_CHECKING:
     from custom_components.aegis_ajax.api.models import Device
@@ -22,6 +29,9 @@ class DeviceCapabilities:
     is_doorbell: bool = False
     is_button_press: bool = False
     has_siren_settings: bool = False
+    has_electrical_readings: bool = False
+    has_direct_power: bool = False
+    has_hts_temperature: bool = False
 
 
 class DeviceHandler(Protocol):
@@ -406,6 +416,32 @@ def get_device_handler(device_type: str) -> DeviceHandler:
     return _DEVICE_HANDLERS.get(device_type, _DEFAULT_HANDLER)
 
 
+# These three capabilities are deliberately NOT declared in `_HANDLERS`: the
+# fact each one encodes already lives in the HTS layer, and retyping the family
+# list here is exactly the drift this registry exists to remove.
+#
+# Which families report electrical readings is decided by the per-family sub-key
+# map in `api/hts/hub_state.py` — a family with no key map has nothing to read,
+# and a family added to the key map already carries everything its sensors need.
+# `DIRECT_POWER_DEVICE_TYPES` is the subset whose firmware reports instantaneous
+# power instead of leaving it to be derived, and `HTS_TEMPERATURE_DEVICE_TYPES`
+# is the set whose internal temperature has no gRPC source at all (see #229,
+# #269, #312). So the flags are derived from those tables: add a family there
+# and its sensor entities follow, with nothing to keep in step by hand.
+
+
 def capabilities_for(device: Device) -> DeviceCapabilities:
     """Return device capabilities for the given device."""
-    return get_device_handler(device.device_type).capabilities(device)
+    capabilities = get_device_handler(device.device_type).capabilities(device)
+    device_type = device.device_type
+    if device_type in ELECTRICAL_DEVICE_TYPES:
+        capabilities = dataclasses.replace(
+            capabilities,
+            has_electrical_readings=True,
+            # A subset of the electrical families: the rest leave `power_w`
+            # empty and get the derived-from-current sensor instead.
+            has_direct_power=device_type in DIRECT_POWER_DEVICE_TYPES,
+        )
+    if device_type in HTS_TEMPERATURE_DEVICE_TYPES:
+        capabilities = dataclasses.replace(capabilities, has_hts_temperature=True)
+    return capabilities

--- a/custom_components/aegis_ajax/sensor.py
+++ b/custom_components/aegis_ajax/sensor.py
@@ -23,13 +23,9 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aegis_ajax.api.hts.hub_state import (
-    DIRECT_POWER_DEVICE_TYPES,
-    ELECTRICAL_DEVICE_TYPES,
-    HTS_TEMPERATURE_DEVICE_TYPES,
-)
 from custom_components.aegis_ajax.api.models import MonitoringCompanyStatus
 from custom_components.aegis_ajax.coordinator import AjaxCobrandedCoordinator
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.entity import build_device_info
 
 # Fallback voltage used to derive instantaneous power when the device
@@ -146,7 +142,7 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
 
     def _should_create_status_sensor(device: Device, key: str) -> bool:
-        if key == "temperature" and device.device_type in HTS_TEMPERATURE_DEVICE_TYPES:
+        if key == "temperature" and capabilities_for(device).has_hts_temperature:
             return True
         return key in device.statuses
 
@@ -201,11 +197,12 @@ async def async_setup_entry(
     # and Outlet Type E / F (#179, calibrated in 1.5.3-beta.11).
     _remove_orphan_outlet_power_derived(hass, coordinator)
     for device_id, device in coordinator.devices.items():
-        if device.device_type in ELECTRICAL_DEVICE_TYPES:
+        capabilities = capabilities_for(device)
+        if capabilities.has_electrical_readings:
             entities.append(AjaxDeviceCurrentSensor(coordinator, device_id))
             entities.append(AjaxDeviceVoltageSensor(coordinator, device_id))
             entities.append(AjaxDeviceEnergyConsumedSensor(coordinator, device_id))
-            if device.device_type in DIRECT_POWER_DEVICE_TYPES:
+            if capabilities.has_direct_power:
                 entities.append(AjaxDevicePowerSensor(coordinator, device_id))
             else:
                 entities.append(AjaxDeviceDerivedPowerSensor(coordinator, device_id))
@@ -220,14 +217,14 @@ def _remove_orphan_outlet_power_derived(
 
     Between `1.4.0` (when the WallSwitch family's derived-power entity
     first shipped) and `1.5.3-beta.1` (when the Outlet was excluded
-    from `ELECTRICAL_DEVICE_TYPES` while we figured out its sub-key
+    from the electrical-readings key map while we figured out its sub-key
     map), users on Outlets got a `_power_derived` entity registered
     with WallSwitch-shaped (and incorrect) parsing behind it. From
     `1.5.3-beta.11` the Outlet emits a real `_power` sensor instead;
     the legacy `_power_derived` lingers in the entity registry as
     `unavailable` until the user deletes it by hand. This helper
     sweeps the registry once per setup and removes it cleanly.
-    Touches only devices currently in `DIRECT_POWER_DEVICE_TYPES`;
+    Touches only devices whose `has_direct_power` capability is set;
     WallSwitch family's own `_power_derived` is untouched.
     """
     from homeassistant.helpers import entity_registry as er  # noqa: PLC0415
@@ -235,7 +232,7 @@ def _remove_orphan_outlet_power_derived(
     registry = er.async_get(hass)
     removed = 0
     for device_id, device in coordinator.devices.items():
-        if device.device_type not in DIRECT_POWER_DEVICE_TYPES:
+        if not capabilities_for(device).has_direct_power:
             continue
         unique_id = f"aegis_ajax_{device_id}_power_derived"
         entity_id = registry.async_get_entity_id("sensor", "aegis_ajax", unique_id)

--- a/tests/unit/test_device_handlers.py
+++ b/tests/unit/test_device_handlers.py
@@ -188,3 +188,97 @@ class TestCapabilityParityWithConstSets:
         from custom_components.aegis_ajax.const import BUTTON_PRESS_DEVICE_TYPES
 
         assert self._types_with("is_button_press") == set(BUTTON_PRESS_DEVICE_TYPES)
+
+
+class TestHtsDerivedCapabilities:
+    """#332 PR-5: the sensor platform's three gates, derived from the HTS tables.
+
+    They are not declared in `_HANDLERS` on purpose — `api/hts/hub_state.py`
+    already decides which families have electrical readings and which have no
+    gRPC temperature — so what these tests pin is that the derivation happens
+    and that it adds nothing else.
+    """
+
+    @pytest.mark.parametrize(
+        "device_type",
+        ["wall_switch", "relay", "socket", "socket_outlet_type_e", "socket_outlet_type_f"],
+    )
+    def test_electrical_family_has_electrical_readings(self, device_type: str) -> None:
+        assert device_handlers.capabilities_for(_device(device_type)).has_electrical_readings
+
+    @pytest.mark.parametrize("device_type", ["socket_outlet_type_e", "socket_outlet_type_f"])
+    def test_outlet_reports_power_directly(self, device_type: str) -> None:
+        assert device_handlers.capabilities_for(_device(device_type)).has_direct_power
+
+    @pytest.mark.parametrize("device_type", ["wall_switch", "relay", "socket"])
+    def test_wallswitch_family_power_is_derived_not_direct(self, device_type: str) -> None:
+        capabilities = device_handlers.capabilities_for(_device(device_type))
+        assert capabilities.has_electrical_readings
+        assert not capabilities.has_direct_power
+
+    def test_direct_power_is_a_subset_of_electrical(self) -> None:
+        """`capabilities_for` only reaches `has_direct_power` inside the electrical branch."""
+        from custom_components.aegis_ajax.api.hts.hub_state import (
+            DIRECT_POWER_DEVICE_TYPES,
+            ELECTRICAL_DEVICE_TYPES,
+        )
+
+        assert DIRECT_POWER_DEVICE_TYPES <= ELECTRICAL_DEVICE_TYPES
+
+    @pytest.mark.parametrize(
+        "device_type",
+        ["street_siren", "motion_protect_outdoor", "motion_protect_curtain_outdoor_plus"],
+    )
+    def test_hts_temperature_family_is_flagged(self, device_type: str) -> None:
+        assert device_handlers.capabilities_for(_device(device_type)).has_hts_temperature
+
+    @pytest.mark.parametrize("device_type", ["door_protect", "keypad_combi", "motion_protect"])
+    def test_grpc_temperature_family_is_not_flagged(self, device_type: str) -> None:
+        """Families that already get temperature over gRPC must not gain the HTS gate."""
+        assert not device_handlers.capabilities_for(_device(device_type)).has_hts_temperature
+
+    def test_derivation_matches_the_hts_tables_exactly(self) -> None:
+        from custom_components.aegis_ajax.api.hts.hub_state import (
+            DIRECT_POWER_DEVICE_TYPES,
+            ELECTRICAL_DEVICE_TYPES,
+            HTS_TEMPERATURE_DEVICE_TYPES,
+        )
+
+        candidates = (
+            set(device_handlers._DEVICE_HANDLERS)
+            | set(ELECTRICAL_DEVICE_TYPES)
+            | set(HTS_TEMPERATURE_DEVICE_TYPES)
+        )
+        electrical = set()
+        direct = set()
+        hts_temperature = set()
+        for device_type in candidates:
+            capabilities = device_handlers.capabilities_for(_device(device_type))
+            if capabilities.has_electrical_readings:
+                electrical.add(device_type)
+            if capabilities.has_direct_power:
+                direct.add(device_type)
+            if capabilities.has_hts_temperature:
+                hts_temperature.add(device_type)
+        assert electrical == set(ELECTRICAL_DEVICE_TYPES)
+        assert direct == set(DIRECT_POWER_DEVICE_TYPES)
+        assert hts_temperature == set(HTS_TEMPERATURE_DEVICE_TYPES)
+
+    @pytest.mark.parametrize(
+        "device_type", ["wall_switch", "socket_outlet_type_e", "street_siren", "door_protect"]
+    )
+    def test_derivation_does_not_disturb_the_declared_capabilities(self, device_type: str) -> None:
+        """The derived flags are added on top; nothing declared may change."""
+        declared = device_handlers.get_device_handler(device_type).capabilities(
+            _device(device_type)
+        )
+        derived = device_handlers.capabilities_for(_device(device_type))
+        assert derived.binary_sensor_keys == declared.binary_sensor_keys
+        assert derived.is_lock == declared.is_lock
+        assert derived.is_camera == declared.is_camera
+        assert derived.is_phod == declared.is_phod
+        assert derived.is_light == declared.is_light
+        assert derived.is_valve == declared.is_valve
+        assert derived.is_doorbell == declared.is_doorbell
+        assert derived.is_button_press == declared.is_button_press
+        assert derived.has_siren_settings == declared.has_siren_settings

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from custom_components.aegis_ajax.api.hts.hub_state import (
+    DIRECT_POWER_DEVICE_TYPES,
+    ELECTRICAL_DEVICE_TYPES,
     HTS_TEMPERATURE_DEVICE_TYPES,
     HubNetworkState,
 )
@@ -1232,3 +1234,89 @@ class TestTemperatureSensorCreationGate:
         assert "aegis_ajax_s1_humidity" not in unique_ids
         assert "aegis_ajax_s1_co2" not in unique_ids
         assert "aegis_ajax_s1_signal_strength" not in unique_ids
+
+
+class TestElectricalSensorCreationGate:
+    """Which families grow the electrical sensors, and which power entity they get.
+
+    This gate had no test at all before #332 PR-5: deleting the condition
+    outright left the whole suite green, so a refactor could have dropped every
+    WallSwitch / Socket / Outlet electrical entity on a live install without CI
+    noticing. The families come from the HTS sub-key map, so sweeping the set
+    keeps a family added there covered without anyone extending a list here.
+    """
+
+    @staticmethod
+    def _make_device(device_id: str, device_type: str) -> Device:
+        return Device(
+            id=device_id,
+            hub_id="hub-1",
+            name=f"Device {device_id}",
+            device_type=device_type,
+            room_id=None,
+            group_id=None,
+            state=DeviceState.ONLINE,
+            malfunctions=0,
+            bypassed=False,
+            statuses={},
+            battery=None,
+        )
+
+    @staticmethod
+    async def _setup(devices: dict[str, Device]) -> list:
+        from custom_components.aegis_ajax.sensor import async_setup_entry
+
+        coordinator = MagicMock()
+        coordinator.devices = devices
+        coordinator.rooms = {}
+        coordinator.spaces = {}
+        coordinator.sim_info = {}
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        added: list = []
+
+        with patch("custom_components.aegis_ajax.sensor._remove_orphan_outlet_power_derived"):
+            await async_setup_entry(MagicMock(), entry, added.extend)
+        return added
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", sorted(ELECTRICAL_DEVICE_TYPES))
+    async def test_every_electrical_family_gets_the_three_readings(self, device_type: str) -> None:
+        added = await self._setup({"e1": self._make_device("e1", device_type)})
+
+        unique_ids = {e.unique_id for e in added}
+        assert "aegis_ajax_e1_current" in unique_ids
+        assert "aegis_ajax_e1_voltage" in unique_ids
+        assert "aegis_ajax_e1_energy_consumed" in unique_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", sorted(DIRECT_POWER_DEVICE_TYPES))
+    async def test_direct_power_family_gets_a_real_power_sensor(self, device_type: str) -> None:
+        """The Outlet reports `power_w`, so it must not get the derived placeholder."""
+        added = await self._setup({"e1": self._make_device("e1", device_type)})
+
+        unique_ids = {e.unique_id for e in added}
+        assert "aegis_ajax_e1_power" in unique_ids
+        assert "aegis_ajax_e1_power_derived" not in unique_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "device_type", sorted(ELECTRICAL_DEVICE_TYPES - DIRECT_POWER_DEVICE_TYPES)
+    )
+    async def test_wallswitch_family_gets_the_derived_power_sensor(self, device_type: str) -> None:
+        """No `power_w` in the firmware's readings, so power is current × voltage."""
+        added = await self._setup({"e1": self._make_device("e1", device_type)})
+
+        unique_ids = {e.unique_id for e in added}
+        assert "aegis_ajax_e1_power_derived" in unique_ids
+        assert "aegis_ajax_e1_power" not in unique_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", ["door_protect", "home_siren", "light_switch_dimmer"])
+    async def test_non_electrical_family_gets_no_electrical_sensors(self, device_type: str) -> None:
+        added = await self._setup({"d1": self._make_device("d1", device_type)})
+
+        unique_ids = {e.unique_id for e in added}
+        for suffix in ("current", "voltage", "energy_consumed", "power", "power_derived"):
+            assert f"aegis_ajax_d1_{suffix}" not in unique_ids


### PR DESCRIPTION
PR-5 of the #332 series — same commit as #480, re-cut onto `main` after PR-4 (#479) was squash-merged, which left the stacked branch conflicting. #480 is closed in favour of this one; it had no review comments to preserve.

`sensor.py` no longer imports `ELECTRICAL_DEVICE_TYPES`, `DIRECT_POWER_DEVICE_TYPES` or `HTS_TEMPERATURE_DEVICE_TYPES`; it asks for `has_electrical_readings`, `has_direct_power` and `has_hts_temperature`.

**These three are derived, not declared in `_HANDLERS` — the one deliberate departure from PR-1..PR-4.** The fact each flag encodes already lives in the HTS layer: which families report electrical readings is decided by the per-family sub-key map in `api/hts/hub_state.py`. A family with no key map has nothing to read, and a family added to the map already carries everything its sensors need. Retyping those lists into the registry would create a second place to remember — exactly the drift this refactor exists to remove. So `capabilities_for` folds the flags on top of the declared capabilities, and `test_derivation_matches_the_hts_tables_exactly` pins the result against the tables. Nothing new is registered, so `_DEVICE_HANDLERS` is unchanged and the characterization fixture needs no entry.

**The finding that matters more than the refactor.** The electrical creation gate had **no test at all**: replacing the condition with `if False` left all 2674 tests green. This refactor could have dropped every WallSwitch / Socket / Outlet current, voltage, energy and power entity on a live install and CI would have reported success. `TestElectricalSensorCreationGate` now covers it, sweeping the HTS sets rather than hard-coding families — the three readings for every electrical family, a real `_power` for the Outlets, `_power_derived` for the WallSwitch family, neither for anything else. With it in place the same mutation fails 18 tests.

Verified in the dev image: ruff, ruff format, mypy, vulture clean, 2695 unit tests, coverage 91.1%.