### PR TITLE
test: make the #332 neutrality proof permanent and cover the event platform setup

### DIFF
--- a/tests/unit/test_characterization_binary_sensor.py
+++ b/tests/unit/test_characterization_binary_sensor.py
@@ -88,3 +88,53 @@ class TestBinarySensorCharacterization:
         ]
 
         assert actual_entities == expected_entities
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("device_type", ["button", "light_switch_dimmer"])
+    async def test_new_platform_registration_preserves_unmapped_binary_sensor_shape(
+        self, monkeypatch: pytest.MonkeyPatch, device_type: str
+    ) -> None:
+        """New registrations retain the former tamper and standard-diagnostics fallback."""
+        fixture_data = _load_fixture()
+        monkeypatch.delitem(_DEVICE_HANDLERS, device_type)
+
+        device_id = "test_device"
+        mock_coordinator = MagicMock()
+        mock_coordinator.devices = {
+            device_id: Device(
+                id=device_id,
+                hub_id="hub_1",
+                name="Test Device",
+                device_type=device_type,
+                room_id="room_1",
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            )
+        }
+        mock_coordinator.spaces = {}
+        mock_coordinator.rooms = {}
+        mock_coordinator.hub_registry_id.return_value = "hub_reg_1"
+        entry = MagicMock(entry_id="entry_1", runtime_data=mock_coordinator)
+        added_entities: list = []
+
+        await async_setup_entry(MagicMock(), entry, added_entities.extend)
+
+        actual_entities = [
+            {
+                "unique_id": entity.unique_id,
+                "device_class": entity.device_class.value
+                if hasattr(entity.device_class, "value")
+                else entity.device_class,
+                "entity_category": entity.entity_category.value
+                if hasattr(entity.entity_category, "value")
+                else entity.entity_category,
+                "enabled_by_default": entity.entity_registry_enabled_default,
+            }
+            for entity in added_entities
+        ]
+
+        assert actual_entities == fixture_data[device_type]

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from custom_components.aegis_ajax.const import ALL_EVENT_TYPES, HUB_EVENT_TAG_MAP
+from custom_components.aegis_ajax.api.models import Device
+from custom_components.aegis_ajax.const import ALL_EVENT_TYPES, HUB_EVENT_TAG_MAP, DeviceState
 from custom_components.aegis_ajax.event import (
     AjaxButtonPressEvent,
     AjaxDoorbellEvent,
     AjaxSecurityEvent,
+    async_setup_entry,
 )
 
 
@@ -424,3 +426,41 @@ class TestAjaxButtonPressEvent:
         entity = self._make_button_entity()
         assert entity._attr_device_info is not None
         assert ("aegis_ajax", "313E5F32") in entity._attr_device_info["identifiers"]
+
+
+class TestEventSetup:
+    async def test_creates_device_events_for_registered_capabilities(self) -> None:
+        def device(device_id: str, device_type: str) -> Device:
+            return Device(
+                id=device_id,
+                hub_id="hub-1",
+                name=device_id,
+                device_type=device_type,
+                room_id=None,
+                group_id=None,
+                state=DeviceState.ONLINE,
+                malfunctions=0,
+                bypassed=False,
+                statuses={},
+                battery=None,
+            )
+
+        coordinator = MagicMock()
+        coordinator.spaces = {}
+        coordinator.rooms = {}
+        coordinator.devices = {
+            "video-doorbell": device("video-doorbell", "video_edge_doorbell"),
+            "motion-doorbell": device("motion-doorbell", "motion_cam_video_doorbell"),
+            "button": device("button", "button"),
+            "other": device("other", "door_protect"),
+        }
+        entry = MagicMock(runtime_data=coordinator)
+        added: list = []
+
+        await async_setup_entry(MagicMock(), entry, added.extend)
+
+        assert {entity.unique_id for entity in added} == {
+            "aegis_ajax_video-doorbell_doorbell_event",
+            "aegis_ajax_motion-doorbell_doorbell_event",
+            "aegis_ajax_button_button_press_event",
+        }


### PR DESCRIPTION
Two tests from @aavdberg's #478, which I raced without seeing it (see the note there). His PR reached the same conclusions as the merged PR-4 (#479) — same family boundaries, same `street_siren_plus` exclusion, same parity checks — and carried two things #479 did not.

**1. The neutrality proof, made permanent.** `test_new_platform_registration_preserves_unmapped_binary_sensor_shape` deletes the new registration for `button` / `light_switch_dimmer` at runtime and asserts the characterization entry still matches. #479 proved the same thing with a throwaway script while I was writing it; his version survives in the suite.

That difference is not theoretical, and I checked which mutation separates them:

| mutation | `test_device_type_entity_characterization` | his new test |
|---|---|---|
| register the dimmer with no binary sensors | **fails** | passes |
| do that *and* edit the fixture to match | passes | **fails** |

The second row is the circular move condition 2 on #332 exists to prevent — a contributor "fixing" the snapshot to agree with a wrong registration. Until now only a human reviewer noticing was in the way of it.

**2. `TestEventSetup`** — `event.async_setup_entry` had no setup test at all. It asserts doorbell entities for both doorbell families, a button-press entity for `button`, and nothing for a family carrying neither capability. #479 added setup tests for `light` and `valve` but left `event` on the registry-level tests only.

No production code changes; both files applied to `main` unmodified.
