### PR TITLE
chore(i18n): translate the three session action blocks into Spanish (#475)

### DIFF
--- a/custom_components/aegis_ajax/translations/es.json
+++ b/custom_components/aegis_ajax/translations/es.json
@@ -188,44 +188,44 @@
             }
         },
         "list_client_sessions": {
-            "name": "List account sessions",
-            "description": "Return active Ajax account sessions for manual inspection on demand. This service calls an internal Ajax endpoint that may rate limit frequent requests; do not poll it in automations. The currently active Aegis session is marked is_current when it can be identified.",
+            "name": "Listar sesiones de la cuenta",
+            "description": "Devuelve bajo demanda las sesiones activas de la cuenta Ajax, para inspeccionarlas manualmente. Este servicio llama a un endpoint interno de Ajax que puede limitar la frecuencia de las peticiones: no lo consultes de forma periódica en automatizaciones. La sesión de Aegis actualmente activa se marca con is_current cuando se puede identificar.",
             "fields": {
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID de entrada de configuración",
+                    "description": "Obligatorio cuando hay más de una cuenta de Aegis configurada."
                 }
             }
         },
         "terminate_client_session": {
-            "name": "Terminate account session",
-            "description": "Immediately log the selected other device out of the Ajax account. Obtain its session ID through list_client_sessions. The integration never terminates its own session.",
+            "name": "Cerrar una sesión de la cuenta",
+            "description": "Cierra inmediatamente la sesión del dispositivo seleccionado en la cuenta Ajax. Obtén su ID de sesión con list_client_sessions. La integración nunca cierra su propia sesión.",
             "fields": {
                 "session_id": {
-                    "name": "Session ID",
-                    "description": "Session ID returned by list_client_sessions."
+                    "name": "ID de sesión",
+                    "description": "ID de sesión devuelto por list_client_sessions."
                 },
                 "confirm": {
-                    "name": "Confirm termination",
-                    "description": "Must be true to immediately terminate the selected session."
+                    "name": "Confirmar cierre",
+                    "description": "Debe ser true para cerrar inmediatamente la sesión seleccionada."
                 },
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID de entrada de configuración",
+                    "description": "Obligatorio cuando hay más de una cuenta de Aegis configurada."
                 }
             }
         },
         "terminate_other_client_sessions": {
-            "name": "Terminate all other account sessions",
-            "description": "Immediately log all other devices out of the Ajax account. This signs out other active Ajax mobile and desktop apps. The integration never terminates its own session.",
+            "name": "Cerrar todas las demás sesiones de la cuenta",
+            "description": "Cierra inmediatamente la sesión de todos los demás dispositivos en la cuenta Ajax. Esto expulsa a las demás apps de Ajax móviles y de escritorio que estén activas. La integración nunca cierra su propia sesión.",
             "fields": {
                 "confirm": {
-                    "name": "Confirm termination",
-                    "description": "Must be true to immediately terminate all other sessions."
+                    "name": "Confirmar cierre",
+                    "description": "Debe ser true para cerrar inmediatamente todas las demás sesiones."
                 },
                 "entry_id": {
-                    "name": "Config entry ID",
-                    "description": "Required when more than one Aegis account is configured."
+                    "name": "ID de entrada de configuración",
+                    "description": "Obligatorio cuando hay más de una cuenta de Aegis configurada."
                 }
             }
         }


### PR DESCRIPTION
**#475's own premise was wrong about Spanish, and I only found it while auditing what @aavdberg's Dutch PR (#483) left.** The issue says the four action blocks are affected in "12 of the 13 non-English languages (`es` already has them)". Spanish had exactly one of the four — `set_photo_on_demand_mode` — and the three session actions were still English. Those are the two irreversible sign-out actions plus their listing, so it was the worst block in the file to be wrong about.

18 values, keys untouched, `test_translation_parity` green (29 passed).

The choices, so they can be argued with rather than accepted:

- Vocabulary from the existing `es.json`: `espacio`, `dispositivo`, `Entidad`, `Foto bajo demanda`.
- `Confirmar cierre` follows the existing `Confirmar pánico`, which is why it has no article.
- Names stay imperative like their neighbours (`Forzar armado`, `Pulsar botón de pánico`, `Configurar modo Foto bajo demanda`).
- **`Terminate` → `Cerrar (la) sesión`, not `Terminar`.** What the action does is log a device out, and "cerrar sesión" is the phrase a Spanish user reads for that everywhere else. This is the same reasoning wip3out3r gave for Italian (`Disconnetti`, not `Termina`) and it lands in the same place independently. Say the word if you would rather have `Terminar sesión` and I will swap it everywhere in the three blocks.
- `ID de entrada de configuración` is not invented: it is Home Assistant core's own Spanish for that exact string on `homeassistant.reload_config_entry`, read from the shipped core translations. The same check confirms wip3out3r's Italian claim (`ID voce di configurazione`) verbatim — worth knowing his sourcing held up under an independent look.

**Current state of #475 after this and #483** — the four blocks, 26 values each:

| done | remaining |
|---|---|
| `it` (wip3out3r), `nl` (aavdberg), `uk`, `es` (here) | `ca`, `cs`, `de`, `fr`, `pl`, `pt`, `pt-BR`, `ro`, `tr` |

`uk` needs no work: all 26 values are already there and in Cyrillic, not the Latin transliteration #474 fixed elsewhere — so #483's note about leaving Ukrainian for a native-speaker review can be discharged. Nine languages left, all needing a native speaker.
