### PR TITLE
refactor: route device logic through handlers

### DIFF
--- a/custom_components/aegis_ajax/const.py
+++ b/custom_components/aegis_ajax/const.py
@@ -288,46 +288,6 @@ DEFAULT_BYPASS_SWITCHES = BYPASS_SWITCHES_AUTO
 BYPASS_REQUIRED_PERMISSION = "DEVICE_EDIT"
 
 # --- Siren settings entities (#310, #354) -------------------------------
-# Siren device families whose rich `StreamHubDevice` snapshot embeds a
-# writable `common_siren_part.siren_settings`. This is exactly the set of siren
-# `device` oneof cases our generated `HubDevice` proto models (verified: each
-# embeds `common_siren_part`) — a SKU missing from that oneof decodes as an
-# unknown case, so no settings can be read for it and creating its entities
-# would leave them permanently empty. Keep this set and the proto oneof in
-# step: extend one only alongside the other.
-#
-# The DoubleDeck / Fibra / S variants were added in #354. They carry *only*
-# `common_siren_part` on this API — no temperature, tamper or battery part —
-# which is why their internal temperature still comes from HTS 0x02 (see
-# HTS_TEMPERATURE_DEVICE_TYPES) rather than from this snapshot.
-#
-# Note the write path does not depend on any of this: `UpdateHubDevice`
-# addresses the device by `ObjectType`, so a SKU absent from the oneof was
-# always writable — it was only unreadable.
-#
-# `home_siren_plus` is intentionally absent: the proto now models that oneof
-# case, but `ObjectType` has no `home_siren_plus`, so `parse_device` can never
-# produce that device_type and listing it here would be dead weight. Add it if
-# and when the ObjectType appears.
-#
-# The settings refresh only streams the snapshot for these types, and the
-# `number`/`select` platforms create their entities for exactly these types.
-SIREN_DEVICE_TYPES = frozenset(
-    {
-        "street_siren",
-        "street_siren_plus_g3",
-        "street_siren_s",
-        "street_siren_fibra",
-        "street_siren_plus_fibra",
-        "street_siren_double_deck",
-        "street_siren_s_double_deck",
-        "street_siren_double_deck_fibra",
-        "home_siren",
-        "home_siren_g3",
-        "home_siren_s",
-        "home_siren_fibra",
-    }
-)
 # Status keys under which the writable siren settings are surfaced by the
 # device parser. `number`/`select` create their entities from the presence of
 # these keys, so every siren SKU that embeds a `common_siren_part` is covered
@@ -749,16 +709,6 @@ DEFAULT_PERSISTENT_NOTIFICATION_EVENTS: list[str] = [
 # startup) use it; kept generic so future runtime discovery can reuse it.
 SIGNAL_NEW_DEVICE = f"{DOMAIN}_new_device"
 
-# Device types that get their own per-device doorbell `event` entity on their
-# device card (#173). The ring event is also fired on the hub-level event
-# entity for backwards compatibility; this surfaces it where users look first.
-DOORBELL_DEVICE_TYPES: frozenset[str] = frozenset(
-    {
-        "video_edge_doorbell",
-        "motion_cam_video_doorbell",
-    }
-)
-
 # Internal routing key for doorbell pushes (used by the parser, the coordinator
 # dispatch, and the hub-level security event entity). Not the type the
 # doorbell-device-class entity emits — see DOORBELL_RING_EVENT_TYPE.
@@ -790,14 +740,13 @@ MOTION_EVENT_TYPE = "motion"
 # not push control-mode presses at all, confirmed on an install with push
 # configured, so no richer source exists to tell them apart.
 #
-# Only the single Button is included. The DoubleButton is panic-only and its
-# reporter confirmed pressing it emits nothing at all. Keyfobs
-# (`space_control`) do not carry this key: a press there produced no 0x39
-# whatsoever on a 13-device install, so this must stay gated by device type —
+# Only the single Button exposes the button-press capability. The DoubleButton
+# is panic-only and its reporter confirmed pressing it emits nothing at all.
+# Keyfobs (`space_control`) do not carry this key: a press there produced no
+# 0x39 whatsoever on a 13-device install, so this remains capability-gated —
 # the same sub-key means unrelated things on other families (on a DoorProtect
 # Plus it is a roller-shutter-online flag).
 BUTTON_PRESS_EVENT_TYPE = "pressed"
-BUTTON_PRESS_DEVICE_TYPES = frozenset({"button"})
 
 # Maps a DeviceCommand failure-oneof case (what the hub returned) to a
 # translated `exceptions.*` message key. Unmapped reasons fall back to

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -1238,6 +1238,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         changed = False
         for device_id, device in list(self.devices.items()):
+            # The const describes a gRPC temperature field; the capability
+            # describes a distinct, authoritative HTS temperature source.
             # Families sourced from HTS 0x02 (sirens #312, Curtain Plus/Base
             # #229) are authoritative there — don't fetch their gRPC board
             # temperature, which is wrong (runs hotter) and a wasted RPC.

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -50,7 +50,6 @@ from custom_components.aegis_ajax.api.session import (
 )
 from custom_components.aegis_ajax.api.spaces import SpacesApi
 from custom_components.aegis_ajax.const import (
-    BUTTON_PRESS_DEVICE_TYPES,
     BUTTON_PRESS_EVENT_TYPE,
     BYPASS_CONFIRM_DELAY,
     DEACTIVATED_KEY,
@@ -65,7 +64,6 @@ from custom_components.aegis_ajax.const import (
     SECURITY_EVENT_REFRESH_COOLDOWN,
     SIGNAL_NEW_DEVICE,
     SIREN_ALARM_DURATION_KEY,
-    SIREN_DEVICE_TYPES,
     SIREN_SETTINGS_CONFIRM_DELAY,
     SIREN_VOLUME_LEVEL_KEY,
     ChimeStatus,
@@ -1238,10 +1236,6 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         from dataclasses import replace as dc_replace  # noqa: PLC0415
 
-        from custom_components.aegis_ajax.api.hts.hub_state import (  # noqa: PLC0415
-            HTS_TEMPERATURE_DEVICE_TYPES,
-        )
-
         changed = False
         for device_id, device in list(self.devices.items()):
             # Families sourced from HTS 0x02 (sirens #312, Curtain Plus/Base
@@ -1249,7 +1243,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # temperature, which is wrong (runs hotter) and a wasted RPC.
             if (
                 device.device_type not in HUB_DEVICE_TEMPERATURE_DEVICE_TYPES
-                or device.device_type in HTS_TEMPERATURE_DEVICE_TYPES
+                or capabilities_for(device).has_hts_temperature
             ):
                 continue
             try:
@@ -1290,7 +1284,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         changed = False
         for device_id, device in list(self.devices.items()):
-            if device.device_type not in SIREN_DEVICE_TYPES:
+            if not capabilities_for(device).has_siren_settings:
                 continue
             changed = await self._async_fetch_and_merge_siren_settings(device_id) or changed
         if changed:
@@ -2041,9 +2035,9 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     ) -> None:
         """Fire the Button's press event when its activity epoch moves (#348).
 
-        Gated on device type: the same sub-key carries unrelated data on other
-        families, so a global read would fire phantom presses off a door
-        sensor's roller-shutter flag. See `BUTTON_PRESS_DEVICE_TYPES`.
+        Gated on the button-press capability: the same sub-key carries
+        unrelated data on other families, so a global read would fire phantom
+        presses off a door sensor's roller-shutter flag.
 
         Three guards, all of them there to avoid inventing a press:
 
@@ -2066,7 +2060,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         Runs on the event loop (HTS listen task), so touching entity state here
         needs no thread marshalling.
         """
-        if device.device_type not in BUTTON_PRESS_DEVICE_TYPES:
+        if not capabilities_for(device).is_button_press:
             return
         raw = kv.get(_HTS_BUTTON_PRESS_KEY)
         if raw is None or len(raw) != 4:
@@ -2265,20 +2259,20 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         merge in `_async_refresh_hub_device_temperatures`; the carry-forward in
         the device-snapshot path keeps it across gRPC refreshes.
 
-        Safe and live: only applies to families in `HTS_TEMPERATURE_DEVICE_TYPES`
-        (0x02 is authoritative for them) and refreshes on change so the reading
-        tracks the device rather than freezing at the first value (#312). An
-        unchanged 0x02 (re-reported on every STATUS_BODY probe) is a no-op.
-        Returns True when a value was applied. Runs on the loop (HTS listen task).
+        Safe and live: only applies to families with the HTS-temperature
+        capability (0x02 is authoritative for them) and refreshes on change so
+        the reading tracks the device rather than freezing at the first value
+        (#312). An unchanged 0x02 (re-reported on every STATUS_BODY probe) is
+        a no-op. Returns True when a value was applied. Runs on the loop (HTS
+        listen task).
         """
         from dataclasses import replace as dc_replace  # noqa: PLC0415
 
         from custom_components.aegis_ajax.api.hts.hub_state import (  # noqa: PLC0415
-            HTS_TEMPERATURE_DEVICE_TYPES,
             parse_device_temperature_c,
         )
 
-        if device.device_type not in HTS_TEMPERATURE_DEVICE_TYPES:
+        if not capabilities_for(device).has_hts_temperature:
             return False
         temperature = parse_device_temperature_c(device.device_type, kv)
         if temperature is None:
@@ -2943,7 +2937,7 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # not this stream — carry the merged values forward so a fresh light
             # snapshot doesn't wipe them (and the number/select entities) until
             # the next timer fire.
-            if existing is not None and device.device_type in SIREN_DEVICE_TYPES:
+            if existing is not None and capabilities_for(device).has_siren_settings:
                 carried = {
                     key: existing.statuses[key]
                     for key in (SIREN_ALARM_DURATION_KEY, SIREN_VOLUME_LEVEL_KEY)

--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -270,6 +270,21 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
         ("leak_detected", "tamper"),
     ),
     # Sirens
+    # These are the siren families whose `HubDevice` proto oneof includes a
+    # writable `common_siren_part.siren_settings`. A SKU missing from that
+    # oneof decodes as unknown, leaving its settings unreadable and its
+    # `number` / `select` entities permanently empty. Keep this registration
+    # aligned with the proto oneof.
+    #
+    # The DoubleDeck, Fibra, and S variants include only
+    # `common_siren_part`, not temperature, tamper, or battery parts, so their
+    # internal temperature comes from HTS 0x02 instead of this snapshot.
+    #
+    # Writing is independent of this capability: `UpdateHubDevice` addresses
+    # the device by `ObjectType`, so a SKU absent from the oneof remains
+    # writable but unreadable. `home_siren_plus` is intentionally absent:
+    # although its proto oneof exists, `ObjectType` has no corresponding
+    # value, so `parse_device` cannot produce that device type.
     StaticDeviceHandler(
         (
             "home_siren",
@@ -290,8 +305,7 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
     ),
     # `street_siren_plus` is a siren, but its oneof case is missing from the
     # HubDevice proto, so its settings are unreadable and `number` / `select`
-    # would sit permanently empty. Same binary sensors, no settings entities —
-    # see the `has_siren_settings` capability.
+    # would sit permanently empty. Same binary sensors, no settings entities.
     StaticDeviceHandler(
         ("street_siren_plus",),
         ("tamper",),

--- a/custom_components/aegis_ajax/device_handlers.py
+++ b/custom_components/aegis_ajax/device_handlers.py
@@ -291,7 +291,7 @@ _HANDLERS: tuple[DeviceHandler, ...] = (
     # `street_siren_plus` is a siren, but its oneof case is missing from the
     # HubDevice proto, so its settings are unreadable and `number` / `select`
     # would sit permanently empty. Same binary sensors, no settings entities —
-    # see SIREN_DEVICE_TYPES in const.py.
+    # see the `has_siren_settings` capability.
     StaticDeviceHandler(
         ("street_siren_plus",),
         ("tamper",),

--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -16,7 +16,6 @@ from homeassistant.util import dt as dt_util
 from custom_components.aegis_ajax import notification_event_parser
 from custom_components.aegis_ajax.const import (
     DOMAIN,
-    DOORBELL_DEVICE_TYPES,
     DOORBELL_EVENT_TYPE,
     FCM_REJECTED_STORAGE_KEY,
     FCM_STORAGE_VERSION,
@@ -26,6 +25,7 @@ from custom_components.aegis_ajax.const import (
     RAW_TAG_TO_SECURITY_STATE,
     SECURITY_STATE_EVENT_TYPES,
 )
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.notification_fcm_guard import (
     attach_fcm_log_guard,
     install_fcm_decrypt_guard,
@@ -1266,9 +1266,7 @@ class AjaxNotificationListener:
 
         if resolved is None and event_type == DOORBELL_EVENT_TYPE:
             doorbells = [
-                dev_id
-                for dev_id, dev in devices.items()
-                if getattr(dev, "device_type", None) in DOORBELL_DEVICE_TYPES
+                dev_id for dev_id, dev in devices.items() if capabilities_for(dev).is_doorbell
             ]
             if len(doorbells) == 1:
                 resolved = doorbells[0]

--- a/custom_components/aegis_ajax/number.py
+++ b/custom_components/aegis_ajax/number.py
@@ -3,13 +3,13 @@
 Currently exposes the siren **alarm duration** (seconds). An entity is created
 for every siren device type the rich `StreamHubDevice` proto models a
 `common_siren_part` for (`has_siren_settings` in the device-handler registry,
-pinned against `SIREN_DEVICE_TYPES`) — the entity is created at setup
-regardless of whether its current value has been fetched yet, so it appears on
-first boot without waiting for the background settings refresh (it reads
-`unknown` until the first snapshot merges the value). Writes go through the
-shared `UpdateHubDevice` command path (`DeviceCommand.set_siren_settings`),
-which the account can only perform with device-edit permission — a hub
-rejection is surfaced as a translated `HomeAssistantError`.
+the single source of truth) — the entity is created at setup regardless of
+whether its current value has been fetched yet, so it appears on first boot
+without waiting for the background settings refresh (it reads `unknown` until
+the first snapshot merges the value). Writes go through the shared
+`UpdateHubDevice` command path (`DeviceCommand.set_siren_settings`), which the
+account can only perform with device-edit permission — a hub rejection is
+surfaced as a translated `HomeAssistantError`.
 """
 
 from __future__ import annotations

--- a/custom_components/aegis_ajax/select.py
+++ b/custom_components/aegis_ajax/select.py
@@ -2,14 +2,13 @@
 
 Currently exposes the siren **volume level**. An entity is created for every
 siren device type the rich `StreamHubDevice` proto models a `common_siren_part`
-for (`has_siren_settings` in the device-handler registry, pinned against
-`SIREN_DEVICE_TYPES`) — created at setup regardless of whether its current
-value has been fetched yet, so it appears on first boot without waiting for the
-background settings refresh (it reads no selected option until the first
-snapshot merges the value). Writes go through the shared `UpdateHubDevice`
-command path (`DeviceCommand.set_siren_settings`); a hub rejection (e.g. the
-account lacks device-edit permission) is surfaced as a translated
-`HomeAssistantError`.
+for (`has_siren_settings` in the device-handler registry, the single source of
+truth) — created at setup regardless of whether its current value has been
+fetched yet, so it appears on first boot without waiting for the background
+settings refresh (it reads no selected option until the first snapshot merges
+the value). Writes go through the shared `UpdateHubDevice` command path
+(`DeviceCommand.set_siren_settings`); a hub rejection (e.g. the account lacks
+device-edit permission) is surfaced as a translated `HomeAssistantError`.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_device_handlers.py
+++ b/tests/unit/test_device_handlers.py
@@ -139,8 +139,8 @@ def test_street_siren_plus_has_no_siren_settings() -> None:
     """It is a siren, but its oneof case is missing from the HubDevice proto.
 
     Its settings are unreadable, so `number` / `select` would sit permanently
-    empty — which is why it is excluded from `SIREN_DEVICE_TYPES` and must stay
-    excluded here. Its binary sensors are unaffected.
+    empty — which is why it has no siren-settings capability. Its binary
+    sensors are unaffected.
     """
     capabilities = device_handlers.capabilities_for(_device("street_siren_plus"))
     assert not capabilities.has_siren_settings
@@ -156,38 +156,6 @@ def test_newly_registered_family_keeps_the_unmapped_binary_sensors(device_type: 
     default = device_handlers.DefaultDeviceHandler().capabilities(_device(device_type))
     registered = device_handlers.capabilities_for(_device(device_type))
     assert registered.binary_sensor_keys == default.binary_sensor_keys == ("tamper",)
-
-
-class TestCapabilityParityWithConstSets:
-    """`coordinator` and `notification` still gate on the `const.py` sets.
-
-    Until those move too, the registry and the sets are two sources of truth
-    for the same families, so pin them against each other: adding a family to
-    one and not the other is the drift this catches.
-    """
-
-    @staticmethod
-    def _types_with(capability: str) -> set[str]:
-        return {
-            device_type
-            for device_type, handler in device_handlers._DEVICE_HANDLERS.items()
-            if getattr(handler.capabilities(_device(device_type)), capability)
-        }
-
-    def test_siren_settings_matches_siren_device_types(self) -> None:
-        from custom_components.aegis_ajax.const import SIREN_DEVICE_TYPES
-
-        assert self._types_with("has_siren_settings") == set(SIREN_DEVICE_TYPES)
-
-    def test_doorbell_matches_doorbell_device_types(self) -> None:
-        from custom_components.aegis_ajax.const import DOORBELL_DEVICE_TYPES
-
-        assert self._types_with("is_doorbell") == set(DOORBELL_DEVICE_TYPES)
-
-    def test_button_press_matches_button_press_device_types(self) -> None:
-        from custom_components.aegis_ajax.const import BUTTON_PRESS_DEVICE_TYPES
-
-        assert self._types_with("is_button_press") == set(BUTTON_PRESS_DEVICE_TYPES)
 
 
 class TestHtsDerivedCapabilities:

--- a/tests/unit/test_siren_settings.py
+++ b/tests/unit/test_siren_settings.py
@@ -14,16 +14,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # Wire up the proto search path before any `systems.*` import.
+from custom_components.aegis_ajax import device_handlers
 from custom_components.aegis_ajax.api import _proto_path as _proto_path  # noqa: F401
 from custom_components.aegis_ajax.api.devices import DeviceCommandError, DevicesApi
 from custom_components.aegis_ajax.api.devices_parser import parse_hub_device_siren_settings
 from custom_components.aegis_ajax.api.models import Device, DeviceCommand
 from custom_components.aegis_ajax.const import (
     SIREN_ALARM_DURATION_KEY,
-    SIREN_DEVICE_TYPES,
     SIREN_VOLUME_LEVEL_KEY,
     DeviceState,
 )
+from custom_components.aegis_ajax.device_handlers import capabilities_for
 from custom_components.aegis_ajax.number import (
     AjaxSirenAlarmDurationNumber,
 )
@@ -86,12 +87,21 @@ def _make_device(
     )
 
 
+_SIREN_SETTINGS_DEVICE_TYPES = tuple(
+    sorted(
+        device_type
+        for device_type in device_handlers._DEVICE_HANDLERS
+        if capabilities_for(_make_device({}, device_type=device_type)).has_siren_settings
+    )
+)
+
+
 class TestSirenSkuCoverage:
     """#354: the SKUs whose oneof case the HubDevice proto used to be missing.
 
     A SKU absent from the `device` oneof decodes as an unknown case, so its
     settings were unreadable and its entities would have sat permanently empty
-    — which is why they were excluded from `SIREN_DEVICE_TYPES`.
+    — which is why they have no siren-settings capability.
     """
 
     NEW_SKUS = (
@@ -133,11 +143,11 @@ class TestSirenSkuCoverage:
         }
 
     @pytest.mark.parametrize("device_type", NEW_SKUS)
-    def test_device_type_is_in_siren_device_types(self, device_type: str) -> None:
+    def test_device_type_has_siren_settings_capability(self, device_type: str) -> None:
         """The proto oneof and the entity gate have to move together."""
-        assert device_type in SIREN_DEVICE_TYPES
+        assert capabilities_for(_make_device({}, device_type=device_type)).has_siren_settings
 
-    @pytest.mark.parametrize("device_type", sorted(SIREN_DEVICE_TYPES))
+    @pytest.mark.parametrize("device_type", _SIREN_SETTINGS_DEVICE_TYPES)
     def test_every_gated_type_is_a_real_object_type(self, device_type: str) -> None:
         """A device_type that `ObjectType` doesn't know can never be produced.
 
@@ -150,7 +160,7 @@ class TestSirenSkuCoverage:
 
         assert hasattr(object_type_pb2.ObjectType(), device_type)
 
-    @pytest.mark.parametrize("device_type", sorted(SIREN_DEVICE_TYPES))
+    @pytest.mark.parametrize("device_type", _SIREN_SETTINGS_DEVICE_TYPES)
     def test_every_gated_type_can_be_decoded(self, device_type: str) -> None:
         """Guard against the inverse drift: gated here but missing from the oneof."""
         from systems.ajax.api.ecosystem.v2.hubsvc.commonmodels.device import hub_device_pb2


### PR DESCRIPTION
## Summary

Relates to #332, PR-6.

- route coordinator siren-settings refresh and snapshot carry-forward through `has_siren_settings`
- route Button activity epochs through `is_button_press`
- route HTS temperature decoding and gRPC-temperature exclusion through `has_hts_temperature`
- route single-doorbell push fallback through `is_doorbell`
- remove the now-unused `SIREN_DEVICE_TYPES`, `DOORBELL_DEVICE_TYPES`, and `BUTTON_PRESS_DEVICE_TYPES` duplicates from `const.py`
- derive siren proto-coverage test cases directly from the handler registry

This completes the remaining non-platform routing migration identified after PR-5. No device families or capabilities change: the existing registry remains the sole source for declared platform/routing capabilities, while the HTS table remains the source for the derived HTS-temperature capability.

## Validation

- [x] PR-6-focused tests: 597 passed
- [x] Ruff check and format check
- [x] mypy
- [x] vulture
- [x] Full unit suite: 2,688 passed, 1 skipped; 7 pre-existing Windows FCM logging failures, unchanged from the baseline