### PR TITLE
fix(registry): avoid Video Edge self-links

### DIFF
--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -99,7 +99,10 @@ def build_device_info(
         ),
         serial_number=device.id,
     )
-    if not is_hub:
+    # Video Edge channels have no Ajax hub parent. Their parser deliberately
+    # uses their own id as `hub_id`, so linking them through that id would make
+    # the HA device entry its own parent (#489).
+    if not is_hub and device.hub_id != device.id:
         info.update(cast("DeviceInfo", via_device_fields(device.hub_id, via_device_id)))
     if rooms and device.room_id:
         room = rooms.get(device.room_id) if isinstance(rooms, dict) else None

--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -99,9 +99,9 @@ def build_device_info(
         ),
         serial_number=device.id,
     )
-    # Video Edge channels have no Ajax hub parent. Their parser deliberately
-    # uses their own id as `hub_id`, so linking them through that id would make
-    # the HA device entry its own parent (#489).
+    # Video Edge channels and boxes have no Ajax hub parent. Their parser
+    # deliberately uses their own id as `hub_id`, so linking them through that
+    # id would make the HA device entry its own parent (#489).
     if not is_hub and device.hub_id != device.id:
         info.update(cast("DeviceInfo", via_device_fields(device.hub_id, via_device_id)))
     if rooms and device.room_id:

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -64,6 +64,22 @@ class TestBuildDeviceInfo:
         assert "via_device_id" not in info
         assert "via_device" not in info
 
+    def test_video_edge_channel_has_no_self_via_link_on_new_ha(self) -> None:
+        # Video Edge channels have no hub-side parent; their parser uses the
+        # channel id as hub_id. Passing its own registered id as via_device_id
+        # makes HA reject the child device as its own parent (#489).
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", True):
+            info = build_device_info(
+                _make_device(
+                    device_type="video_edge_turret",
+                    device_id="camera-1",
+                    hub_id="camera-1",
+                ),
+                via_device_id="reg-camera-1",
+            )
+        assert "via_device_id" not in info
+        assert "via_device" not in info
+
     def test_non_hub_device_keeps_identifier_link_on_old_ha(self) -> None:
         # Before 2026.8 `DeviceInfo` has no `via_device_id` key and passing one
         # is a TypeError inside HA, so the identifier tuple stays in use there.
@@ -73,6 +89,19 @@ class TestBuildDeviceInfo:
             )
         assert info["via_device"] == (DOMAIN, "HUB7")
         assert "via_device_id" not in info
+
+    def test_video_edge_channel_has_no_self_via_link_on_old_ha(self) -> None:
+        with patch("custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", False):
+            info = build_device_info(
+                _make_device(
+                    device_type="video_edge_turret",
+                    device_id="camera-1",
+                    hub_id="camera-1",
+                ),
+                via_device_id="reg-camera-1",
+            )
+        assert "via_device_id" not in info
+        assert "via_device" not in info
 
     def test_hub_device_has_no_via_link(self) -> None:
         for supported in (True, False):


### PR DESCRIPTION
## Summary
- prevent Video Edge channels from receiving a self-referential device-registry parent link
- preserve the ordinary hub parent link for Ajax devices that have a real hub parent
- cover NVR/Video Edge channel device information on both modern and legacy Home Assistant registry APIs

Fixes #489.

## Root cause

Ajax does not provide a hub parent for Video Edge channels, so their parser intentionally sets `hub_id` to the channel's own ID. Before #444 this produced a self-referential `via_device` tuple. On modern Home Assistant, #444 looks up that identifier and passes the existing channel device entry as `via_device_id`; Home Assistant rejects the resulting self-parent relationship and stops the platform from re-providing its entities.

Channels now remain root devices, which restores their existing Motion and Case tampering entities without changing their unique IDs.

## Validation
- [x] Video Edge/entity registry tests: 53 passed
- [x] Ruff check and format check
- [x] mypy
- [x] vulture
- [x] Full unit suite: 2,693 passed, 1 skipped; 7 pre-existing Windows FCM logging failures, unchanged from baseline