### PR TITLE
fix(push): adopt a pre-1.19.0 FCM registration instead of re-registering (#487)

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -378,6 +378,26 @@ class AjaxNotificationListener:
             self._credentials.get("creds_hash") if isinstance(self._credentials, dict) else None
         )
 
+        # A cache written before 1.19.0 carries no fingerprint. It is ADOPTED,
+        # not discarded (#487): stamp the current fingerprint on it and keep the
+        # token. Discarding it forced every upgrading install through a fresh
+        # registration, and registration is the fragile step — a transient GCM
+        # failure there (the very failure #464 documents as common and
+        # retryable) takes push down on an install where it had been working
+        # for months. Adopting is exactly what 1.18.0 did with the same cache,
+        # so it cannot be worse, and from here on the fingerprint is present,
+        # which is what makes a real credential change detectable at all.
+        legacy_cache = bool(stored_token) and stored_creds_hash is None
+        if legacy_cache and isinstance(self._credentials, dict):
+            self._credentials["creds_hash"] = creds_hash
+            await self._store.async_save(self._credentials)
+            _LOGGER.info(
+                "cached push registration carries no credential fingerprint "
+                "(made before 1.19.0); adopting it for the configured credentials "
+                "instead of registering again"
+            )
+            stored_creds_hash = creds_hash
+
         valid_cache = (
             bool(stored_token)
             and isinstance(stored_creds_hash, str)
@@ -388,14 +408,6 @@ class AjaxNotificationListener:
             if self._credentials:
                 if not stored_token:
                     _LOGGER.info("Stored FCM registration has no token; registering again")
-                elif stored_creds_hash is None:
-                    # Pre-1.19.0 cache: made before registrations carried a
-                    # fingerprint. Every upgrading install sees this once; it
-                    # says nothing about whether the values changed (#464).
-                    _LOGGER.info(
-                        "cached push registration carries no credential fingerprint "
-                        "(made before 1.19.0); registering again once"
-                    )
                 else:
                     _LOGGER.info(
                         "cached push registration belongs to a different credential set; "

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1180,7 +1180,17 @@ class TestFcmCacheFingerprinting:
         assert listener.cache_creds_fingerprint == expected_hash[:16]
 
     @pytest.mark.asyncio
-    async def test_reregisters_when_stored_creds_hash_is_missing(self) -> None:
+    async def test_adopts_a_pre_1_19_cache_instead_of_reregistering(self) -> None:
+        """#487 — the working registration of an upgrading install is KEPT.
+
+        This asserts the opposite of what it used to: 1.19.0 discarded a cache
+        with no fingerprint and registered again, which put every upgrading
+        install through the one step that can fail. Two reporters lost push on
+        upgrade and got it back by reverting, because the old cache file was
+        still on disk for 1.18.0 to reuse. The fingerprint exists to detect a
+        *changed* credential set; absent, the 1.18.0 assumption — this token
+        belongs to the configured values — is the safe one.
+        """
         hass = MagicMock()
         hass.async_add_executor_job = AsyncMock(
             return_value={"fcm": {"registration": {"token": "new-token"}}}
@@ -1190,6 +1200,40 @@ class TestFcmCacheFingerprinting:
         listener._store.async_load = AsyncMock(
             return_value={"fcm": {"registration": {"token": "old-token"}}}
         )
+        listener._store.async_save = AsyncMock()
+        listener._register_push_token = AsyncMock()
+        register_cls = MagicMock(return_value=MagicMock(register=MagicMock()))
+
+        reg_inv, clr_inv, reg_miss, clr_miss = self._repair_patches()
+        with (
+            reg_inv,
+            clr_inv,
+            reg_miss,
+            clr_miss,
+            patch("firebase_messaging.fcmregister.FcmRegister", register_cls),
+            patch("firebase_messaging.FcmPushClient", MagicMock()),
+        ):
+            await listener.async_start()
+
+        register_cls.assert_not_called()
+        listener._register_push_token.assert_awaited_once_with("old-token")
+        # The fingerprint is stamped and persisted, so the next start is an
+        # ordinary cache hit and a real credential change stays detectable.
+        listener._store.async_save.assert_awaited_once_with(
+            {"fcm": {"registration": {"token": "old-token"}}, "creds_hash": expected_hash}
+        )
+        assert listener.cache_creds_fingerprint == expected_hash[:16]
+
+    @pytest.mark.asyncio
+    async def test_adoption_does_not_touch_a_cache_without_a_token(self) -> None:
+        """A cache with no token has nothing to adopt — it must still register."""
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            return_value={"fcm": {"registration": {"token": "new-token"}}}
+        )
+        listener = self._listener(hass)
+        expected_hash = self._expected_hash()
+        listener._store.async_load = AsyncMock(return_value={"fcm": {"registration": {}}})
         listener._store.async_save = AsyncMock()
         listener._register_push_token = AsyncMock()
         register_cls = MagicMock(return_value=MagicMock(register=MagicMock()))


### PR DESCRIPTION
Fixes the FCM half of #487. **No logs needed — the mechanism is visible in the 1.18.0 → 1.19.0 diff, and it explains both reporters exactly, including why reverting fixes it.**

## What happened

1.19.0 began stamping a credential fingerprint on the cached FCM registration, so that a *changed* credential set could be detected (#464). A cache written before 1.19.0 has no fingerprint, and the new check treated that as "not a valid cache":

```python
valid_cache = bool(stored_token) and isinstance(stored_creds_hash, str) and stored_creds_hash == creds_hash
if not valid_cache:
    ...
    self._credentials = None      # discard a working registration
```

So **every upgrading install was put through a fresh registration** — the one step in the flow that can fail. And it fails often enough that #464 exists entirely to document `gcm_register()` giving up as *transient and retryable* rather than a credential verdict.

That is the whole bug: nothing is wrong with these users' credentials. Their working token was thrown away, the re-registration hit a transient failure, and push went dead. Reverting to 1.18.0 fixes it because the old cache file is still on disk and 1.18.0 only ever checked for a token — so it reuses the registration that was working all along.

I wrote that discard deliberately, with the comment "Every upgrading install sees this once; it says nothing about whether the values changed". Two field reports say the once is not free.

## The fix

A missing fingerprint is **adopted**, not treated as invalid: stamp the current fingerprint on the cached registration, keep the token, persist it, carry on.

- It is exactly the assumption 1.18.0 made about the same file, so it cannot be worse than the version people are reverting to.
- From the next start the fingerprint is present, so the #464 detection it was added for still works — for a credential change made from 1.19.0 onwards, which is the only kind it can honestly detect.
- Re-registration still happens when a fingerprint is present and differs, and when there is no token to adopt.

## Verification

- `test_adopts_a_pre_1_19_cache_instead_of_reregistering` replaces `test_reregisters_when_stored_creds_hash_is_missing`, which pinned the behaviour being removed. It asserts the register class is never constructed, the cached token is the one handed to `_register_push_token`, and the fingerprint is stamped and persisted.
- `test_adoption_does_not_touch_a_cache_without_a_token` keeps the no-token path registering.
- **Mutation-checked**: restoring the old line (`legacy_cache = False`) fails both the new test and the migration-wording test.
- Dev image: ruff, format, mypy, vulture clean; 2699 unit tests pass; coverage 91.2%.

## What this does not fix

The NVR half of #487 is the `via_device_id` self-link, which is #489 and @aavdberg's #490 — a separate regression, present since 1.18.0.

Neither reporter has confirmed yet, so this is unit evidence plus a mechanism, not a field confirmation. Given it is a stable-release regression that takes push down, I would ship it in a `1.19.1` alongside #490 rather than wait — reverting to 1.18.0 is the only workaround people currently have.
