### PR TITLE
test(registry): assert no device is ever its own parent, for every family (#489)

### DIFF
--- a/custom_components/aegis_ajax/entity.py
+++ b/custom_components/aegis_ajax/entity.py
@@ -26,6 +26,20 @@ if TYPE_CHECKING:
 # 2027.8 removes both (#444). Older cores reject the new key with a TypeError
 # deep inside `async_get_or_create`, so the key the running core understands is
 # detected once here and every via link goes through `via_device_fields`.
+#
+# ⚠️ THE `via_device_id` BRANCH CANNOT BE RUN AGAINST A CORE THAT HAS IT.
+# The newest `homeassistant` on PyPI is 2026.2.x, so CI — and any local dev
+# image — resolves a core where `via_device_id` is absent from `DeviceInfo` and
+# this flag is always False. The branch that every user on 2026.8+ actually
+# takes is only ever exercised with the flag patched, against our idea of the
+# API rather than the API. That is not a hypothetical: #489 shipped in 1.18.0
+# and 1.19.0 with NVR-bridged Video Edge cameras silently orphaned, through
+# fully green CI, because a device whose `hub_id` is its own id was handed
+# itself as its parent and only a real 2026.8 core rejects that.
+# So changes here are reasoned about, not merely tested. What guards them is an
+# invariant rather than a version: `TestNoDeviceIsEverItsOwnParent` asserts,
+# for every device family and both branches, that no via link ever points at
+# the device's own identity — and it fails if the #489 fix below is removed.
 _VIA_DEVICE_ID_SUPPORTED = "via_device_id" in (
     DeviceInfo.__required_keys__ | DeviceInfo.__optional_keys__
 )

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from custom_components.aegis_ajax.api.models import Device, Room
 from custom_components.aegis_ajax.const import DOMAIN, DeviceState
 from custom_components.aegis_ajax.entity import (
@@ -256,3 +258,107 @@ class TestAsyncGetRegisteredDevice:
 
         assert found == "entry"
         registry.async_get_device.assert_called_once_with(identifiers={(DOMAIN, "HUB7")})
+
+
+class TestNoDeviceIsEverItsOwnParent:
+    """#489, generalised: the self-parent bug, caught for every family.
+
+    The Video Edge regression was not really about Video Edge. It was about a
+    device whose `hub_id` equals its own id — which the parser does deliberately
+    whenever Ajax gives a device no hub parent — being handed its own registry
+    entry as `via_device_id`. Home Assistant refuses a device that is its own
+    parent and stops the platform providing its entities, which is how two
+    releases shipped with the NVR-bridged cameras silently orphaned.
+
+    A test naming `video_edge_turret` would not have caught it in advance. This
+    one asserts the property instead, over every device family the registry
+    knows plus an unmapped one, on both device-registry APIs.
+
+    ⚠️ Neither branch can be run against a Home Assistant that actually has the
+    2026.8 API: the newest `homeassistant` on PyPI is 2026.2.x, so CI resolves a
+    core where `via_device_id` does not exist in `DeviceInfo` and
+    `_VIA_DEVICE_ID_SUPPORTED` is always False. Patching the flag is therefore
+    the only way to exercise the branch every modern user actually runs, which
+    is exactly why the invariant has to be asserted rather than assumed.
+    """
+
+    @staticmethod
+    def _families() -> list[str]:
+        from custom_components.aegis_ajax.device_handlers import _DEVICE_HANDLERS
+
+        return [*sorted(_DEVICE_HANDLERS), "unmapped_unknown_device"]
+
+    @pytest.mark.parametrize("via_device_id_supported", [True, False])
+    def test_a_parentless_device_gets_no_via_link_at_all(
+        self, *, via_device_id_supported: bool
+    ) -> None:
+        for device_type in self._families():
+            device = _make_device(device_type=device_type, device_id="SELF1", hub_id="SELF1")
+            with patch(
+                "custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED",
+                via_device_id_supported,
+            ):
+                info = build_device_info(device, via_device_id="reg-SELF1")
+            assert "via_device_id" not in info, device_type
+            assert "via_device" not in info, device_type
+
+    @pytest.mark.parametrize("via_device_id_supported", [True, False])
+    def test_a_device_with_a_real_hub_keeps_its_link(
+        self, *, via_device_id_supported: bool
+    ) -> None:
+        """The guard must not cost the ordinary case its parent."""
+        device = _make_device(device_type="door_protect", device_id="DEV1", hub_id="HUB1")
+        with patch(
+            "custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED",
+            via_device_id_supported,
+        ):
+            info = build_device_info(device, via_device_id="reg-HUB1")
+        if via_device_id_supported:
+            assert info["via_device_id"] == "reg-HUB1"
+        else:
+            assert info["via_device"] == (DOMAIN, "HUB1")
+
+    def test_a_via_link_never_points_at_the_devices_own_identity(self) -> None:
+        """The invariant stated directly, whichever key carries the link."""
+        for device_type in self._families():
+            for hub_id, registry_id in (("SELF1", "reg-SELF1"), ("HUB1", "reg-HUB1")):
+                device = _make_device(device_type=device_type, device_id="SELF1", hub_id=hub_id)
+                for supported in (True, False):
+                    with patch(
+                        "custom_components.aegis_ajax.entity._VIA_DEVICE_ID_SUPPORTED", supported
+                    ):
+                        info = build_device_info(device, via_device_id=registry_id)
+                    assert info.get("via_device") != (DOMAIN, device.id), (device_type, supported)
+                    assert info.get("via_device_id") != "reg-SELF1" or hub_id != "SELF1", (
+                        device_type,
+                        supported,
+                    )
+
+
+class TestFeatureDetectionMatchesTheInstalledCore:
+    """`_VIA_DEVICE_ID_SUPPORTED` is a claim about the running Home Assistant.
+
+    If the detection ever stops matching reality — HA renames the key, or the
+    `TypedDict` stops exposing `__optional_keys__` — every via link silently
+    takes the wrong branch, and on a modern core that means `via_device` tuples
+    HA has removed. Asserting it against the installed core is cheap and it is
+    the one part of #444 that CI *can* verify at whatever version it resolves.
+    """
+
+    def test_detection_agrees_with_device_info(self) -> None:
+        from homeassistant.helpers.device_registry import DeviceInfo
+
+        from custom_components.aegis_ajax import entity
+
+        actual = "via_device_id" in (DeviceInfo.__required_keys__ | DeviceInfo.__optional_keys__)
+        assert entity._VIA_DEVICE_ID_SUPPORTED is actual
+
+    def test_the_old_key_still_exists_while_we_fall_back_to_it(self) -> None:
+        """The fallback branch is only safe while HA still accepts `via_device`."""
+        from homeassistant.helpers.device_registry import DeviceInfo
+
+        from custom_components.aegis_ajax import entity
+
+        if entity._VIA_DEVICE_ID_SUPPORTED:
+            return
+        assert "via_device" in (DeviceInfo.__required_keys__ | DeviceInfo.__optional_keys__)


### PR DESCRIPTION
Closes the gap #489 came through. #490 fixed the device; this pins the class, and writes down why the obvious fix — "test against a newer Home Assistant" — is not available.

## What the gap actually is

`entity.py` branches on `_VIA_DEVICE_ID_SUPPORTED`, detected from the running core, because HA 2026.8 replaced the identifier-tuple `via_device` with `via_device_id` (#444). **The newest `homeassistant` on PyPI is 2026.2.x.** So CI — and the dev image — resolve a core where `via_device_id` does not exist in `DeviceInfo`, the flag is always `False`, and the branch that every user on 2026.8+ actually runs is only ever exercised with the flag patched: against our idea of the API rather than the API.

That is exactly how #489 shipped twice through green CI. `test_non_hub_device_keeps_identifier_link_on_new_ha` "covered" the new branch, but a patched constant cannot tell you that a real 2026.8 core rejects a device that is its own parent.

## What is fixable today, and what is not

**Not fixable:** a CI job on a core with the 2026.8 API. There is no such release on PyPI to install. Pulling core from git for one job is possible but heavy and fragile, and I would rather not pretend a green job means the API matched.

**Fixable, and the better guard anyway:** assert the *invariant* instead of the version. The bug was never about Video Edge — it was about a device whose `hub_id` equals its own id, which the parser does deliberately whenever Ajax gives a device no hub parent. A test naming `video_edge_turret` could not have predicted it.

`TestNoDeviceIsEverItsOwnParent` sweeps **every family in the handler registry plus an unmapped one**, on **both** registry APIs, and asserts:

- a parentless device gets no via link at all, under either key;
- no via link ever points at the device's own identity;
- and the ordinary hub link still survives the guard — a fix that dropped every parent link would satisfy the first two.

Removing #490's guard fails 5 tests, 3 of them these. So this would have caught #489 before 1.18.0.

`TestFeatureDetectionMatchesTheInstalledCore` covers the half CI *can* verify at any version: that the detection agrees with the installed core, and that `via_device` still exists while we fall back to it. If HA renames the key, or the `TypedDict` stops exposing `__optional_keys__`, every via link would silently take the wrong branch — that now fails loudly instead.

The ceiling itself is documented at the detection site, so the next person to touch this knows the branch they are editing is unverifiable in CI and has to be reasoned about.

Tests only; no production change. Dev image: ruff, format, mypy, vulture clean; 2710 unit tests pass.
