### PR TITLE
fix(push): #494 scope doorbell attribution to its own space

### DIFF
--- a/custom_components/aegis_ajax/notification.py
+++ b/custom_components/aegis_ajax/notification.py
@@ -1188,12 +1188,17 @@ class AjaxNotificationListener:
                 # every event took the fallback below and was delivered to every
                 # space. Don't reintroduce a byte scan here.
                 target_space = self._find_space_for_event(raw)
+                # The space this push was actually delivered to, or None when it
+                # could not be routed. Device attribution below is scoped to it
+                # so a ring can never surface on another space's doorbell (#494).
+                delivered_space: str | None = None
                 photo_context = (
                     notification_event_parser.extract_alarm_photo_context(raw, notification_id)
                     if event_type == "alarm" and notification_id
                     else None
                 )
                 if target_space:
+                    delivered_space = target_space
                     self._dispatch_to_loop(
                         self._coordinator.fire_push_event, target_space, event_type, event_data
                     )
@@ -1209,6 +1214,7 @@ class AjaxNotificationListener:
                     # One space: the destination is unambiguous even when the
                     # payload didn't name it, so route there rather than drop.
                     only_space = self._coordinator._space_ids[0]
+                    delivered_space = only_space
                     self._dispatch_to_loop(
                         self._coordinator.fire_push_event, only_space, event_type, event_data
                     )
@@ -1258,22 +1264,56 @@ class AjaxNotificationListener:
                     self._dispatch_to_loop(self._coordinator.request_security_snapshot_refresh)
                 # Surface doorbell ring / motion on the source device's own
                 # card, in addition to the hub-level event entity (#173).
-                self._dispatch_event_to_device(event_type, event_data, raw)
+                self._dispatch_event_to_device(event_type, event_data, raw, delivered_space)
         except Exception:
             _LOGGER.debug("Failed to parse event from push notification", exc_info=True)
 
+    def _doorbell_fallback_candidates(
+        self, devices: dict[str, Any], space_id: str | None
+    ) -> list[str]:
+        """Doorbells eligible to receive a ring the push did not attribute (#494).
+
+        A doorbell belongs to the space whose hub it is paired to, so the
+        candidates are the doorbells sharing the delivered space's `hub_id`.
+        When the push could not be routed at all, guessing is only safe on an
+        account with a single space — there the account-wide set *is* that
+        space's set, which is what kept #173's single-doorbell case working.
+        """
+        doorbells = [dev_id for dev_id, dev in devices.items() if capabilities_for(dev).is_doorbell]
+        spaces = getattr(self._coordinator, "spaces", {}) or {}
+        if space_id and space_id in spaces:
+            hub_id = spaces[space_id].hub_id
+            return [dev_id for dev_id in doorbells if devices[dev_id].hub_id == hub_id]
+        if len(getattr(self._coordinator, "_space_ids", []) or []) > 1:
+            _LOGGER.debug(
+                "Unrouted doorbell push on a %d-space account: not guessing a device",
+                len(self._coordinator._space_ids),
+            )
+            return []
+        return doorbells
+
     def _dispatch_event_to_device(
-        self, event_type: str, event_data: dict[str, Any], raw: bytes
+        self,
+        event_type: str,
+        event_data: dict[str, Any],
+        raw: bytes,
+        space_id: str | None = None,
     ) -> None:
         """Mirror a doorbell ring / motion push onto the source device (#173).
 
         Resolves the source device from the `device_id` carried in the push
         (`_extract_source_info`). For doorbell rings, when no usable device id
-        is present we fall back to the sole doorbell device in the install —
-        the common single-doorbell case — so users still see the ring on the
-        doorbell card. Motion has no such fallback: the `motion` event_type is
-        shared with PIR detectors, so an unattributed motion push must not be
-        guessed onto an arbitrary device.
+        is present we fall back to the sole doorbell device of the space the push
+        was delivered to — the common single-doorbell case — so users still
+        see the ring on the doorbell card. Motion has no such fallback: the
+        `motion` event_type is shared with PIR detectors, so an unattributed
+        motion push must not be guessed onto an arbitrary device.
+
+        The fallback is scoped because it used to search every device on the
+        account (#494). A PRO account managing several client spaces with one
+        registered doorbell between them attributed every unrouted ring to that
+        doorbell, so a press at one client fired the ring on another client's
+        entity. Same shape as #358: invisible with a single space.
 
         The instrumentation log below is intentional: it records exactly what
         device attribution the parser resolved (or failed to), so if a user's
@@ -1298,9 +1338,7 @@ class AjaxNotificationListener:
                 resolved = alias
 
         if resolved is None and event_type == DOORBELL_EVENT_TYPE:
-            doorbells = [
-                dev_id for dev_id, dev in devices.items() if capabilities_for(dev).is_doorbell
-            ]
+            doorbells = self._doorbell_fallback_candidates(devices, space_id)
             if len(doorbells) == 1:
                 resolved = doorbells[0]
 

--- a/custom_components/aegis_ajax/notification_event_parser.py
+++ b/custom_components/aegis_ajax/notification_event_parser.py
@@ -113,15 +113,38 @@ def extract_alarm_photo_context(raw: bytes, notification_id: str) -> tuple[str, 
 
 
 def extract_notification_id(encoded_data: str) -> str | None:
-    """Extract notification_id from base64-encoded push notification data."""
+    """Return `Notification.id` from a base64-encoded push payload, or None.
+
+    Read structurally, for the reason spelled out in `extract_space_id`: an id
+    is just text, and a substring search cannot tell one id from another that
+    happens to sit earlier in the payload. This function used to return the
+    first 64-character hex run it could find, which is the real id only while
+    the real id happens to be 64 hex characters and first. When it is not — a
+    video/NVR-sourced push is one shape where it is not — the scan returns some
+    other, often per-device constant, blob. That is worse than nothing here: the
+    value keys the 5 s duplicate window, so a constant makes two genuinely
+    different presses look like one delivery and silently drops the second
+    (#494).
+
+    The hex scan is kept as a fallback for payloads the structural read cannot
+    decode at all, which is what it was really covering.
+    """
     try:
         raw = base64.b64decode(encoded_data)
-        # PushNotificationDispatchEvent field 1 (Notification) is at tag 0x0a
-        # Inside Notification, field 1 (id) is also tag 0x0a
-        # We look for a 64-char hex string which is the notification ID format
+    except Exception:
+        _LOGGER.debug("Failed to extract notification_id from push")
+        return None
+
+    notification = _dispatch_notification(raw)
+    if notification is not None and notification.id:
+        structural: str = notification.id
+        return structural
+
+    try:
         matches = re.findall(rb"[0-9A-Fa-f]{64}", raw)
         if matches:
             result: str = matches[0].decode("ascii")
+            _LOGGER.debug("Push carried no readable Notification.id; using the hex scan instead")
             return result
     except Exception:
         _LOGGER.debug("Failed to extract notification_id from push")

--- a/tests/unit/test_doorbell_space_attribution.py
+++ b/tests/unit/test_doorbell_space_attribution.py
@@ -1,0 +1,223 @@
+"""A doorbell push must never be attributed across a space boundary (#494).
+
+Two independent defects, both invisible on a single-space install and both
+reported together by a PRO account managing several client spaces:
+
+1. The single-doorbell fallback in `_dispatch_event_to_device` searched every
+   device the config entry knows about. With one doorbell in the account and
+   several spaces, every unattributed ring resolved to that one doorbell — so a
+   press in one client's space fired the ring on another client's entity.
+2. `extract_notification_id` scanned the payload for the first 64-character hex
+   run instead of reading `Notification.id`. When the real id is not 64 hex
+   characters the scan returns some other, often constant, blob, which makes the
+   5-second duplicate window swallow genuinely different presses.
+
+This is the same family as #358: per-space behaviour that cannot be tested with
+one space. Every test here therefore uses at least two.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+from custom_components.aegis_ajax.api.models import Device, Space
+from custom_components.aegis_ajax.const import ConnectionStatus, DeviceState, SecurityState
+from custom_components.aegis_ajax.notification import AjaxNotificationListener
+from tests.unit.test_notification import _FCM_KWARGS
+
+
+def _doorbell(device_id: str, hub_id: str) -> Device:
+    return Device(
+        id=device_id,
+        hub_id=hub_id,
+        name="Doorbell",
+        device_type="video_edge_doorbell",
+        room_id=None,
+        group_id=None,
+        state=DeviceState.ONLINE,
+        malfunctions=0,
+        bypassed=False,
+        statuses={},
+        battery=None,
+    )
+
+
+def _space(space_id: str, hub_id: str) -> Space:
+    return Space(
+        id=space_id,
+        hub_id=hub_id,
+        name="Client space",
+        security_state=SecurityState.DISARMED,
+        connection_status=ConnectionStatus.ONLINE,
+        malfunctions_count=0,
+    )
+
+
+class _Harness:
+    """A listener wired to a coordinator with real Device/Space objects.
+
+    The existing routing tests use `MagicMock` device stand-ins, which cannot
+    express "this doorbell belongs to that hub" — the very fact this fix turns
+    on. Real dataclasses are used here for that reason.
+    """
+
+    def __init__(self, devices: dict[str, Device], spaces: dict[str, Space]) -> None:
+        self.hass = MagicMock()
+        self.hass.loop = MagicMock()
+        self.hass.loop.is_running.return_value = True
+        self.hass.loop.call_soon_threadsafe.side_effect = lambda cb, *a: cb(*a)
+        self.coordinator = MagicMock()
+        self.coordinator.devices = devices
+        self.coordinator.spaces = spaces
+        self.coordinator._space_ids = list(spaces)
+        self.coordinator.doorbell_twin_aliases = {}
+        self.coordinator.fire_push_device_event = MagicMock(return_value=True)
+        self.listener = AjaxNotificationListener(
+            hass=self.hass, coordinator=self.coordinator, **_FCM_KWARGS
+        )
+
+    def ring(self, routed_space: str | None, source: dict | None = None) -> None:
+        encoded = base64.b64encode(b"any-payload").decode()
+        with (
+            patch.object(
+                self.listener,
+                "_extract_event_from_proto",
+                return_value=("doorbell_pressed", {"raw_tag": "ring_button_pressed"}),
+            ),
+            patch.object(self.listener, "_extract_source_info", return_value=source or {}),
+            patch.object(self.listener, "_find_space_for_event", return_value=routed_space),
+        ):
+            self.listener._parse_and_fire_event(encoded)
+
+    @property
+    def attributed_to(self) -> str | None:
+        if not self.coordinator.fire_push_device_event.called:
+            return None
+        target: str = self.coordinator.fire_push_device_event.call_args[0][0]
+        return target
+
+
+class TestDoorbellFallbackIsScopedToItsSpace:
+    def test_ring_in_one_space_is_not_attributed_to_another_spaces_doorbell(self) -> None:
+        """The #494 report: press in space A, ring fires on space B's entity."""
+        harness = _Harness(
+            devices={"bell-b": _doorbell("bell-b", "HUB-B")},
+            spaces={"space-a": _space("space-a", "HUB-A"), "space-b": _space("space-b", "HUB-B")},
+        )
+
+        harness.ring(routed_space="space-a")
+
+        assert harness.attributed_to is None
+
+    def test_ring_still_resolves_to_the_single_doorbell_of_its_own_space(self) -> None:
+        harness = _Harness(
+            devices={"bell-b": _doorbell("bell-b", "HUB-B")},
+            spaces={"space-a": _space("space-a", "HUB-A"), "space-b": _space("space-b", "HUB-B")},
+        )
+
+        harness.ring(routed_space="space-b")
+
+        assert harness.attributed_to == "bell-b"
+
+    def test_two_doorbells_in_one_space_are_still_not_guessed_between(self) -> None:
+        harness = _Harness(
+            devices={
+                "bell-1": _doorbell("bell-1", "HUB-A"),
+                "bell-2": _doorbell("bell-2", "HUB-A"),
+            },
+            spaces={"space-a": _space("space-a", "HUB-A")},
+        )
+
+        harness.ring(routed_space="space-a")
+
+        assert harness.attributed_to is None
+
+    def test_an_unroutable_ring_is_not_guessed_on_a_multi_space_account(self) -> None:
+        """No space resolved and several spaces configured: refuse to guess.
+
+        Guessing here is what produced the cross-client ring in #494, and an
+        unattributed push still fires the hub-level event entity.
+        """
+        harness = _Harness(
+            devices={"bell-b": _doorbell("bell-b", "HUB-B")},
+            spaces={"space-a": _space("space-a", "HUB-A"), "space-b": _space("space-b", "HUB-B")},
+        )
+
+        harness.ring(routed_space=None)
+
+        assert harness.attributed_to is None
+
+    def test_an_unroutable_ring_still_resolves_on_a_single_space_account(self) -> None:
+        """The #173 case must keep working: one space, one doorbell, no source id."""
+        harness = _Harness(
+            devices={"bell-a": _doorbell("bell-a", "HUB-A")},
+            spaces={"space-a": _space("space-a", "HUB-A")},
+        )
+
+        harness.ring(routed_space=None)
+
+        assert harness.attributed_to == "bell-a"
+
+    def test_an_explicit_source_id_is_honoured_regardless_of_space(self) -> None:
+        """Only the *fallback* is scoped. An id the push actually carries wins.
+
+        Narrowing this too would break installs whose push names a device whose
+        hub attribution we read differently, which is a regression, not a fix.
+        """
+        harness = _Harness(
+            devices={"bell-b": _doorbell("bell-b", "HUB-B")},
+            spaces={"space-a": _space("space-a", "HUB-A"), "space-b": _space("space-b", "HUB-B")},
+        )
+
+        harness.ring(routed_space="space-a", source={"device_id": "bell-b"})
+
+        assert harness.attributed_to == "bell-b"
+
+
+class TestNotificationIdIsReadStructurally:
+    """`Notification.id` is the id; the first 64-hex run in the payload is not."""
+
+    @staticmethod
+    def _push(notification_id: str, decoy: str) -> str:
+        from systems.ajax.api.ecosystem.v2.communicationsvc.mobile.service.push_notification_dispatch import (  # noqa: E501
+            event_pb2,
+        )
+
+        dispatch = event_pb2.PushNotificationDispatchEvent()
+        notification = dispatch.notification
+        notification.id = notification_id
+        # A 64-hex blob that is not the id, positioned after it in the payload.
+        notification.content.hub_notification_content.source.name = decoy
+        return base64.b64encode(dispatch.SerializeToString()).decode()
+
+    def test_an_id_that_is_not_64_hex_characters_is_still_returned(self) -> None:
+        decoy = "a" * 64
+        encoded = self._push("ring-000123", decoy)
+
+        result = AjaxNotificationListener.extract_notification_id(encoded)
+
+        assert result == "ring-000123"
+        assert result != decoy
+
+    def test_a_64_hex_id_is_unchanged_by_the_structural_read(self) -> None:
+        real_id = "4842536662915600AABB112233445566778899" + "00A1B2C3D4000001"[:10] + "0" * 16
+        assert len(real_id) == 64
+        encoded = self._push(real_id, "b" * 64)
+
+        assert AjaxNotificationListener.extract_notification_id(encoded) == real_id
+
+    def test_two_different_ids_do_not_collapse_onto_one_value(self) -> None:
+        """The duplicate window keys on this value, so a constant is a lost press."""
+        decoy = "c" * 64
+        first = AjaxNotificationListener.extract_notification_id(self._push("ring-1", decoy))
+        second = AjaxNotificationListener.extract_notification_id(self._push("ring-2", decoy))
+
+        assert first != second
+
+    def test_a_payload_that_is_not_a_dispatch_event_still_uses_the_hex_scan(self) -> None:
+        """The scan stays as a fallback for shapes the structural read can't decode."""
+        scanned = "d" * 64
+        encoded = base64.b64encode(b"\xff\xfe not a dispatch event " + scanned.encode()).decode()
+
+        assert AjaxNotificationListener.extract_notification_id(encoded) == scanned


### PR DESCRIPTION
Fixes #494.

Two defects, both invisible on a single-space install, both surfaced together by @Sven2410's PRO account managing several client spaces. Same family as #358: per-space behaviour cannot be tested with one space, so every new test here uses at least two.

## 1. The single-doorbell fallback was account-wide

When a doorbell push carries no usable source device id, `_dispatch_event_to_device` fell back to "the only doorbell in the install". That list was built from every device the config entry knows about, across every space. An account with one registered doorbell between several client spaces therefore attributed **every** unattributed ring to that one doorbell, which is the reported symptom: a press at one client fires the ring event on another client's entity.

The fallback now considers only doorbells that share the delivered space's `hub_id`, and refuses to guess at all when the push could not be routed to a known space and more than one space is configured. Deliberately narrow:

- A single-space account keeps exactly the previous behaviour. That is what #173 relies on, and it is covered by a test.
- An id the push actually carries still wins regardless of space. Only the *guess* is scoped; narrowing the explicit path too would be a regression, not a fix.
- Motion still has no fallback at all, unchanged.

## 2. `extract_notification_id` was a byte scan

It returned the first 64-character hex run found anywhere in the payload. That is the real id only while the real id happens to be 64 hex characters and happens to come first. A video/NVR-sourced push is one shape where it is not, and the scan then returns some other blob, often constant per device — which is what the reporter observed, the same id byte-for-byte across three presses minutes apart.

That value keys the 5-second duplicate window, so a constant makes two genuinely different presses look like one delivery and silently drops the second. The reporter predicted this consequence himself before I looked at the code.

It is now read structurally via the existing `_dispatch_notification` unwrap, which already handles both the plain `notification` and `media_enriched_notification` shapes. The hex scan stays as a fallback for payloads the structural read cannot decode, which is what it was really covering. `extract_space_id` already carried the comment explaining why ids must not be scanned for; this function was simply never migrated.

Side benefit: it makes the alarm-image push path merged in #496 reliable. `extract_alarm_photo_context` cross-checks the id against the payload and returns `None` on a mismatch, so a scanned blob would have silently disabled that path on affected installs.

## Network call delta

**Zero.** Both changes are parsing and attribution only. No request is added, removed or retimed.

## Validation

- 2764 unit tests pass; ruff, format, mypy and vulture clean.
- The four new assertions that describe the fix were written first and **fail on `main`**: cross-space attribution, the unroutable multi-space guess, a non-64-hex id, and two distinct ids collapsing onto one value.
- Six further tests pin the behaviour that must not change: same-space resolution, two doorbells in one space still not guessed between, the single-space #173 case, an explicit source id winning, a 64-hex id unchanged by the structural read, and the hex-scan fallback for undecodable payloads.

**Not field-validated.** The misattribution needs a multi-space PRO account with a doorbell to reproduce, which nobody here has. @Sven2410 has three client spaces plus real Video Edge and NVR hardware and offered to test, so this goes out as a beta for him to confirm before it reaches stable.

## Also in the report, not addressed here

The reporter noted ring events firing roughly five times a minute on 1.17 with nobody pressing. That is consistent with defect 1 delivering other spaces' presses onto his entity, but it is a separate claim about an older version and I would rather confirm it disappeared than assert it was the same cause. His ONVIF "no registered handler" line is a different integration and out of scope.