### PR TITLE
fix(keyfobs): #504 recognise keyfob rows a newer hub firmware extends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.1] - unreleased
+
+### Fixed
+- **Keyfob entities no longer disappear when the hub updates its firmware (#504).** SpaceControl keyfobs are not part of the device list Ajax serves over the normal API; they are recognised by matching the shape of a row in the hub's settings stream, and that match required the row to carry exactly the fields seen when it was written. A newer hub firmware adds one field to it, which stopped every keyfob on such a hub being recognised at once — and since Home Assistant never removes an entity a platform stops providing, the sensors created on an earlier firmware were left reading `unavailable` with nothing in the log to explain it. Found on a hub running `2.42.120` with six keyfobs whose entities had been reporting since June. The match now requires the fields it knows and ignores the ones it does not, so a hub on the older firmware behaves exactly as before and the restored entities keep their identifiers, and their history, rather than arriving as duplicates. A row that looks like a keyfob but is still not recognised is now reported once as a warning naming which fields differ, and recorded in the diagnostics dump: what it took to work this out was a debug capture from a live hub, and the next firmware that changes the row should be answerable from a diagnostics file instead. Sub-field names only, never their values — the row carries the keyfob's name as text. Whether the flag these entities expose really means "active" is still unconfirmed and stays on #311. **Requests to Ajax:** none added. This changes how a row already arriving on the hub's existing stream is read.
+
 ## [1.20.0] - 2026-09-11
 
 A MotionCam that cannot take a photo on demand now has a camera entity worth looking at, the

--- a/custom_components/aegis_ajax/api/hts/keyfobs.py
+++ b/custom_components/aegis_ajax/api/hts/keyfobs.py
@@ -21,8 +21,8 @@ row, and the modeled path already surfaces the device properly. The
 coordinator's `_log_hts_space_control_settings` probe is where that class is
 observed.
 
-Empirically (live capture, 6 keyfobs) every keyfob row carries an identical
-15-sub-key set; only the name (`0x02`) and a per-device index (`0x0a`) differ:
+Empirically (live capture, 6 keyfobs) every keyfob row carries the same
+sub-key set; only the name (`0x02`) and a per-device index (`0x0a`) differ:
 
     0x02 = name (UTF-8)                 the keyfob's display name
     0x0a = per-device index/handle      sequential, distinct per keyfob
@@ -30,6 +30,12 @@ Empirically (live capture, 6 keyfobs) every keyfob row carries an identical
     0x07/0x08  = 00000000ffffffff       constant placeholders
     0x09/0x10/0x11/0x0f/0x13/0x14 = zeros
     0x16 = ffff
+    0x17 = 0000                         firmware 2.42.120 and later only
+
+`KEYFOB_SHAPE` is the set a row must CONTAIN, not equal (#504): `0x17` appeared
+with a hub firmware update and, while the match was an equality, it dropped
+every keyfob on that hub — six entities that had been reporting since June went
+`unavailable`, and the only trace was the DEBUG candidate line below.
 
 **The "active" flag is EXPERIMENTAL/unverified.** Every observed keyfob reads
 `0x0b == 0x01`; we have no `inactive` sample. Only a CRA admin can deactivate a
@@ -47,8 +53,9 @@ import dataclasses
 
 from custom_components.aegis_ajax.api.hts.hub_state import _bool_val, _int_be_val, _str_val
 
-# The exact sub-key set every captured keyfob row shares. No other device row,
-# user/member row, or section marker observed in SETTINGS_BODY collides with it.
+# The sub-keys every captured keyfob row carries. A row must CONTAIN all of
+# them (#504) — later firmwares add their own, e.g. `0x17`. No other device row,
+# user/member row, or section marker observed in SETTINGS_BODY carries them all.
 KEYFOB_SHAPE: frozenset[int] = frozenset(
     {0x02, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x13, 0x14, 0x16}
 )
@@ -97,13 +104,32 @@ def _flags_hex(kv: dict[int, bytes]) -> str:
 def parse_keyfob(device_id_hex: str, hub_id: str, kv: dict[int, bytes]) -> Keyfob | None:
     """Return a `Keyfob` iff *kv* is a keyfob row, else `None`.
 
-    Classification is install-independent and relies on the unique 15-sub-key
-    shape plus a printable name — no dependence on the device-id prefix (which
-    was coincidental). The caller (`coordinator._on_hts_device_kv`) only reaches
+    Classification is install-independent and relies on the known sub-key set
+    plus a printable name — no dependence on the device-id prefix (which was
+    coincidental). The caller (`coordinator._on_hts_device_kv`) only reaches
     this for rows absent from the gRPC device snapshot, so modeled devices and
     the hub are already excluded; this adds the user-row and marker guards.
+
+    **The match is a superset, not an equality (#504).** Every key in
+    `KEYFOB_SHAPE` must be present; keys beyond it are ignored. It was an
+    equality until a hub firmware update (`2.42.120`) added a sixteenth
+    sub-key, `0x17`, to the row — and every keyfob on that install stopped
+    being recognised at once, taking its entity with it. Requiring the known
+    keys keeps the discriminating power (no other observed row in a
+    SETTINGS_BODY carries all of them) while a field the vendor adds costs
+    nothing. Unknown keys are never read: each value below comes from a named
+    sub-key.
+
+    The rule is deliberately one-directional. A row that *drops* a known key is
+    still rejected, because that is a different shape and worth seeing rather
+    than absorbing — `looks_like_keyfob_candidate` catches it for the caller to
+    report (coordinator warns once per row and records it in diagnostics).
     """
-    if frozenset(kv) != KEYFOB_SHAPE:
+    if not frozenset(kv) >= KEYFOB_SHAPE:
+        return None
+    # A member row that happened to carry every keyfob key would otherwise pass
+    # now that extra keys are tolerated; the user markers still exclude it.
+    if frozenset(kv) >= _USER_ROW_MARKER_SUBKEYS:
         return None
     try:
         if int(device_id_hex, 16) < _MIN_DEVICE_ID:

--- a/custom_components/aegis_ajax/coordinator.py
+++ b/custom_components/aegis_ajax/coordinator.py
@@ -315,6 +315,12 @@ _HTS_BUTTON_ACTIVITY_CANDIDATE_KEYS: tuple[int, ...] = (0x39, 0x40)
 # hub-wide and is not this device's activity.
 _HTS_BUTTON_PRESS_KEY = 0x39
 
+# How many distinct keyfob-shaped rows the coordinator will remember as
+# unrecognised (#504). A hub has a handful of keyfobs; the cap exists so a hub
+# that suddenly emits many near-miss rows cannot grow this without bound, since
+# it is held for the lifetime of the entry and dumped in diagnostics.
+_MAX_UNRECOGNISED_KEYFOB_ROWS = 16
+
 # SpaceControl settings keys on a *gRPC-modeled* keyfob's HTS row (#311) —
 # read-only probe, nothing is routed off them.
 #
@@ -624,6 +630,13 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # device + experimental "Active" sensor per entry, added at runtime via
         # the `SIGNAL_NEW_DEVICE` dispatcher as keyfobs are discovered.
         self.keyfobs: dict[str, Keyfob] = {}
+        # Rows that look like a keyfob but did not match the known shape (#504),
+        # keyed by device id: `{"missing": [...], "unexpected": [...]}` naming
+        # the sub-keys, never their values. A hub firmware that adds or drops a
+        # field stops every keyfob being recognised at once, and the entities
+        # already created go `unavailable` with no other trace — this is what
+        # makes that answerable from a diagnostics dump.
+        self.keyfob_unrecognised_rows: dict[str, dict[str, list[str]]] = {}
         # Last-seen arm flag (HTS sub-key 0x06) per hub-internal space-security
         # object (00000001/00000002…). A keypad full-arm of a group reaches us
         # only as a STATUS_UPDATE flip of this flag — no type=0x08 space event
@@ -2601,7 +2614,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         from custom_components.aegis_ajax.notification import _redact_printable  # noqa: PLC0415
 
-        if looks_like_keyfob_candidate(device_id_hex, kv):
+        is_candidate = looks_like_keyfob_candidate(device_id_hex, kv)
+        if is_candidate:
             _LOGGER.debug(
                 "Keyfob candidate %s on hub %s: %s",
                 device_id_hex,
@@ -2611,6 +2625,8 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         keyfob = parse_keyfob(device_id_hex, hub_id, kv)
         if keyfob is None:
+            if is_candidate:
+                self._record_unrecognised_keyfob_row(device_id_hex, hub_id, kv)
             return
         if self.keyfobs.get(device_id_hex) == keyfob:
             return
@@ -2619,6 +2635,51 @@ class AjaxCobrandedCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if is_new:
             async_dispatcher_send(self.hass, SIGNAL_NEW_DEVICE, device_id_hex)
         self.async_set_updated_data({"spaces": self.spaces, "devices": self.devices})
+
+    def _record_unrecognised_keyfob_row(
+        self, device_id_hex: str, hub_id: str, kv: dict[int, bytes]
+    ) -> None:
+        """Report a keyfob-shaped row the parser refused, once per shape (#504).
+
+        The classifier requires a known sub-key set, so a hub firmware that
+        changes the row stops every keyfob being recognised — and because Home
+        Assistant never removes an entity a platform stops providing, the user
+        is left with sensors reading `unavailable` and no explanation. That is
+        what happened when firmware `2.42.120` added `0x17`: the only trace was
+        the DEBUG line above, which nobody runs with.
+
+        Sub-key names only, never values: this row carries the keyfob's name as
+        text and these logs get pasted into public issues.
+        """
+        from custom_components.aegis_ajax.api.hts.keyfobs import (  # noqa: PLC0415
+            KEYFOB_SHAPE,
+        )
+
+        keys = frozenset(kv)
+        record = {
+            "missing": sorted(f"0x{k:02x}" for k in KEYFOB_SHAPE - keys),
+            "unexpected": sorted(f"0x{k:02x}" for k in keys - KEYFOB_SHAPE),
+        }
+        if self.keyfob_unrecognised_rows.get(device_id_hex) == record:
+            # Same shape as last time: a SETTINGS_BODY arrives on every
+            # reconnect, and one warning per firmware is the useful amount.
+            return
+        if (
+            device_id_hex not in self.keyfob_unrecognised_rows
+            and len(self.keyfob_unrecognised_rows) >= _MAX_UNRECOGNISED_KEYFOB_ROWS
+        ):
+            return
+        self.keyfob_unrecognised_rows[device_id_hex] = record
+        _LOGGER.warning(
+            "Row %s on hub %s looks like a SpaceControl keyfob but does not match the "
+            "known shape, so no keyfob entity is provided for it: missing sub-keys %s, "
+            "unexpected %s. This usually means the hub firmware changed the row; a "
+            "diagnostics download carries the same detail for a bug report.",
+            device_id_hex,
+            hub_id,
+            ", ".join(record["missing"]) or "none",
+            ", ".join(record["unexpected"]) or "none",
+        )
 
     def request_security_snapshot_refresh(self) -> None:
         """Nudge the authoritative security re-read, group states included.

--- a/custom_components/aegis_ajax/diagnostics.py
+++ b/custom_components/aegis_ajax/diagnostics.py
@@ -187,6 +187,13 @@ async def async_get_config_entry_diagnostics(
             }
             for kid, k in coordinator.keyfobs.items()
         },
+        # Rows that looked like a SpaceControl keyfob but did not match the
+        # known shape (#504), naming the sub-key delta and never a value. A
+        # non-empty entry here is the answer to "why is my keyfob sensor
+        # unavailable": the hub changed the row, the classifier refused it,
+        # and Home Assistant kept the entity it already had. Empty on a
+        # healthy install and on one that never had a keyfob.
+        "keyfob_unrecognised_rows": coordinator.keyfob_unrecognised_rows,
         "video_edge_onvif_rtsp": video_edge_probe,
         # What decides whether a hub gets an IMEI sensor at all (#379). A
         # `null` here is the answer to "why is my IMEI sensor unavailable":

--- a/tests/unit/hts/test_keyfobs.py
+++ b/tests/unit/hts/test_keyfobs.py
@@ -102,6 +102,59 @@ class TestParseKeyfob:
     def test_shape_matches_fixture(self) -> None:
         assert frozenset(_keyfob_row("ALICE", "02ef")) == KEYFOB_SHAPE
 
+    def test_firmware_2_42_120_row_with_extra_subkey(self) -> None:
+        """A hub firmware that ADDS a field must not drop the keyfob (#504).
+
+        Captured on hub firmware `2.42.120`: the row carries the same fifteen
+        sub-keys plus `0x17 = 0000`. An exact-set match rejected all six
+        keyfobs of that install at once, and the entities they had been
+        providing since June went `unavailable` with nothing above DEBUG to
+        say why.
+        """
+        row = dict(_KEYFOB_TEMPLATE)
+        row[0x17] = "0000"
+        kf = parse_keyfob("2A4B126E", HUB_ID, _kv(row | {0x02: _hx("T3"), 0x0A: "02f1"}))
+        assert kf is not None
+        assert kf == Keyfob(
+            id="2A4B126E",
+            hub_id=HUB_ID,
+            name="T3",
+            index=0x02F1,
+            active=True,
+            flags_hex="01:01:01:01",
+        )
+
+    def test_unknown_extra_subkeys_do_not_change_the_reading(self) -> None:
+        # Tolerating unknown fields must not let one of them be read by
+        # accident: the parsed values come from the known sub-keys only.
+        row = dict(_KEYFOB_TEMPLATE)
+        row[0x17] = "0000"
+        row[0x18] = "ff"
+        row[0x19] = _hx("NOT THE NAME")
+        kf = parse_keyfob("2ACCB91C", HUB_ID, _kv(row))
+        assert kf is not None
+        assert kf.name == "ALICE"
+        assert kf.active is True
+        assert kf.flags_hex == "01:01:01:01"
+
+    def test_row_missing_a_known_subkey_is_rejected(self) -> None:
+        # The widening is one-directional on purpose: every known sub-key is
+        # still required, so a row that merely resembles a keyfob is not
+        # absorbed. A firmware that REMOVES a field is a different change and
+        # must be seen (it surfaces through the rejected-candidate warning).
+        for missing in (0x07, 0x13, 0x16):
+            row = dict(_KEYFOB_TEMPLATE)
+            del row[missing]
+            assert parse_keyfob("2ACCB91C", HUB_ID, _kv(row)) is None, f"0x{missing:02x}"
+
+    def test_user_row_padded_to_the_keyfob_shape_is_still_rejected(self) -> None:
+        # The superset rule must not open the door to a member row that grows
+        # enough fields to cover the keyfob shape: the user markers still win.
+        row = dict(_KEYFOB_TEMPLATE)
+        row[0x01] = _hx("Home Assistant")
+        row[0x03] = _hx("+10000000000")
+        assert parse_keyfob("1B99007F", HUB_ID, _kv(row)) is None
+
     def test_deactivated_flag_value_flip(self) -> None:
         # Same keyset, 0x0b flipped to 00 → still a keyfob, but active=False.
         row = dict(_KEYFOB_TEMPLATE)

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -4726,6 +4726,65 @@ class TestOnHtsDeviceKvKeyfob:
         coordinator.async_set_updated_data.assert_called_once()
         mock_send.assert_not_called()
 
+    def test_unrecognised_keyfob_shaped_row_warns_once_and_is_recorded(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A near-miss row is reported above DEBUG and lands in diagnostics (#504).
+
+        The shape match is what a hub firmware change breaks, and when it
+        broke, the entity vanished with the only trace a DEBUG line nobody
+        has enabled. One warning per shape, and the sub-key delta recorded so
+        a diagnostics dump answers it without a capture session.
+        """
+        coordinator = _make_coordinator()
+        row = _keyfob_kv(name=b"ALICE")
+        del row[0x16]
+        row[0x17] = b"\x00\x00"
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", dict(row))
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", dict(row))
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, "the same shape must not warn on every SETTINGS_BODY"
+        assert "0x16" in warnings[0].getMessage()
+        assert "0x17" in warnings[0].getMessage()
+        # Sub-key names only: the row carries the keyfob's name as text.
+        assert "ALICE" not in warnings[0].getMessage()
+        assert coordinator.keyfobs == {}
+        assert coordinator.keyfob_unrecognised_rows == {
+            "2ACCB91C": {"missing": ["0x16"], "unexpected": ["0x17"]}
+        }
+
+    def test_recognised_keyfob_records_nothing(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.async_set_updated_data = MagicMock()
+        with patch("custom_components.aegis_ajax.coordinator.async_dispatcher_send"):
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", _keyfob_kv())
+        assert coordinator.keyfobs != {}
+        assert coordinator.keyfob_unrecognised_rows == {}
+
+    def test_a_row_whose_shape_changes_again_is_reported_again(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Two different near-misses from the same device are two different
+        # facts; the de-duplication is per shape, not per device.
+        coordinator = _make_coordinator()
+        first = _keyfob_kv()
+        del first[0x16]
+        second = _keyfob_kv()
+        del second[0x13]
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.aegis_ajax.coordinator"):
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", first)
+            coordinator._on_hts_device_kv("002B1A51", "2ACCB91C", second)
+
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 2
+        assert coordinator.keyfob_unrecognised_rows["2ACCB91C"] == {
+            "missing": ["0x13"],
+            "unexpected": [],
+        }
+
     def test_non_keyfob_unknown_row_ignored(self) -> None:
         coordinator = _make_coordinator()
         coordinator.async_set_updated_data = MagicMock()


### PR DESCRIPTION
Closes the recognition half of #504. Found while verifying the `1.20.0` deploy on a live hub: six keyfob sensors that had been reporting since June were reading `unavailable`, and had been for at least six days.

## What was wrong

The classifier required the settings row to carry **exactly** the sub-key set captured when it was written. Hub firmware `2.42.120` adds one more field to that row, so every keyfob on such a hub stopped being recognised at once. Home Assistant never removes an entity a platform stops providing, so the sensors created on the earlier firmware were left `unavailable`, with the only trace a DEBUG line that exists for this and that nobody runs with.

It was not a regression from `1.20.0`: the recorder shows a single state point over six days, the last change to this code is `aab313bd` (2026-09-04, #444), and the live state carried `restored: true` — the platform was not providing the entity at all.

## What changes

**The match is a superset, not an equality.** Every known sub-key is still required; unknown ones are ignored and never read. Checked against the same capture the bug came from: no other row in that settings body carries all fifteen — modeled device rows keep their name in a different field and have none of it, member rows lack three of them — and the user-row markers are now an explicit guard in the parser, since exact matching is no longer excluding a member row implicitly.

The widening is one-directional on purpose. A row that *drops* a known key is still rejected: that is a different shape, and worth seeing rather than absorbing.

**Backwards compatible in both directions.** A hub on the older firmware sends the exact fifteen and still parses. The `unique_id` is unchanged, so the entities are re-adopted with their history rather than arriving as duplicates — nothing to migrate.

**The next drift should not cost a capture session.** A keyfob-shaped row the parser refuses is now warned once per shape, naming which sub-keys are missing and which are unexpected, and recorded in the diagnostics dump under `keyfob_unrecognised_rows`. Sub-key names only, never values: the row carries the keyfob name as text and these logs get pasted into public issues. Capped at 16 rows, since it lives for the lifetime of the entry.

## Tests

Four new cases, all mutation-verified — reverting either half of the change fails them:

- the real 16-sub-key row from firmware `2.42.120` parses (fails with the old equality);
- unknown extra fields do not change what is read, including one shaped like a name;
- a row missing any of `0x07` / `0x13` / `0x16` is still rejected;
- a member row padded up to the keyfob shape is still rejected.

Plus three on the reporting path: one warning per shape however many times the row arrives, a second distinct shape reported again, and nothing recorded for a row that parses fine.

`make check` green in Docker: 2805 passed, coverage 91.22%.

## Not in scope

Whether the flag these entities expose really means "active" is still unconfirmed and stays on #311. This is only about the keyfobs being recognised at all.

Relates to #504, #311